### PR TITLE
Update README for XOOPS Core version change to 2.7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![alt XOOPS CMS](https://xoops.org/images/logoXoops4GithubRepository.png)
-# XOOPS Core 2.5.x
+# XOOPS Core 2.7.x
 
 [![Build Status](https://img.shields.io/travis/XOOPS/XoopsCore/master.svg?style=flat)](https://travis-ci.org/XOOPS/XoopsCore25)
 [![Software License](https://img.shields.io/badge/license-GPL-brightgreen.svg?style=flat)](docs/license.txt)
@@ -7,9 +7,9 @@
 [![Quality Score](https://img.shields.io/scrutinizer/g/XOOPS/XoopsCore25.svg?style=flat)](https://scrutinizer-ci.com/g/XOOPS/XoopsCore25)
 [![Latest Version](https://img.shields.io/github/release/XOOPS/XoopsCore25.svg?style=flat)](https://github.com/XOOPS/XoopsCore25/releases)
 
-> **Note:** This repository contains the core code of the XOOPS Core 2.5.x. Our next generation is currently under development on [GitHub](https://github.com/XOOPS/XoopsCore).
+> **Note:** This repository contains the core code of the XOOPS Core 2.7.x. Our next generation is currently under development on [GitHub](https://github.com/XOOPS/XoopsCore).
 
-To install this version of XOOPS 2.5.x follow the instructions in [The XOOPS Install & Upgrade Guide](https://xoops.gitbook.io/xoops-install-upgrade/)
+To install this version of XOOPS 2.7.x follow the instructions in [The XOOPS Install & Upgrade Guide](https://xoops.gitbook.io/xoops-install-upgrade/)
 
 For more information on building a web site using XOOPS, visit the main [XOOPS Web Site](https://xoops.org).
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated README to reference XOOPS Core 2.7.x as the current version
* Updated installation and upgrade guide instructions to point to the 2.7.x process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->