### PR TITLE
fix(system-menus): create and seed menu tables during fresh install

### DIFF
--- a/htdocs/install/include/makedata.php
+++ b/htdocs/install/include/makedata.php
@@ -76,6 +76,13 @@ function system_menu_install_seed_defaults($dbm, array $groups, int $moduleId): 
             . (int) $definition['active']
             . ')'
         );
+        if (!$categoryId) {
+            trigger_error(
+                sprintf('Failed to seed menu category "%s" during install.', $definition['title']),
+                E_USER_WARNING
+            );
+            return;
+        }
         $categoryIds[$key] = (int) $categoryId;
 
         foreach (system_menu_map_group_keys($definition['group_keys'], $groupMap) as $groupId) {
@@ -102,6 +109,13 @@ function system_menu_install_seed_defaults($dbm, array $groups, int $moduleId): 
             . (int) $definition['active']
             . ')'
         );
+        if (!$itemId) {
+            trigger_error(
+                sprintf('Failed to seed menu item "%s" during install.', $definition['title']),
+                E_USER_WARNING
+            );
+            return;
+        }
 
         foreach (system_menu_map_group_keys($definition['group_keys'], $groupMap) as $groupId) {
             $dbm->insert(

--- a/htdocs/install/include/makedata.php
+++ b/htdocs/install/include/makedata.php
@@ -30,6 +30,9 @@
 // TODO: Shouldn't we insert specific field names??  That way we can use
 // the defaults specified in the database...!!!! (and don't have problem
 // of missing fields in install file, when add new fields to database)
+
+require_once XOOPS_ROOT_PATH . '/modules/system/include/menu_seed.php';
+
 function make_groups($dbm)
 {
     $groups['XOOPS_GROUP_ADMIN']     = $dbm->insert('groups', " VALUES (1, '" . addslashes(_INSTALL_WEBMASTER) . "', '" . addslashes(_INSTALL_WEBMASTERD) . "', 'Admin')");
@@ -40,6 +43,73 @@ function make_groups($dbm)
     }
 
     return $groups;
+}
+
+/**
+ * Seed protected front-end menus for a fresh install.
+ *
+ * @param Db_manager         $dbm
+ * @param array<string, int> $groups
+ * @param int                $moduleId
+ */
+function system_menu_install_seed_defaults($dbm, array $groups, int $moduleId): void
+{
+    $seed = system_menu_get_seed_definitions();
+    $groupMap = [
+        'admin'     => (int) $groups['XOOPS_GROUP_ADMIN'],
+        'users'     => (int) $groups['XOOPS_GROUP_USERS'],
+        'anonymous' => (int) $groups['XOOPS_GROUP_ANONYMOUS'],
+    ];
+    $categoryIds = [];
+
+    foreach ($seed['categories'] as $key => $definition) {
+        $categoryId = $dbm->insert(
+            'menuscategory',
+            " (`category_title`, `category_prefix`, `category_suffix`, `category_url`, `category_target`, `category_position`, `category_protected`, `category_active`) VALUES ("
+            . "'" . addslashes($definition['title']) . "', "
+            . "'" . addslashes($definition['prefix']) . "', "
+            . "'" . addslashes($definition['suffix']) . "', "
+            . "'" . addslashes($definition['url']) . "', "
+            . (int) $definition['target'] . ', '
+            . (int) $definition['position'] . ', '
+            . (int) $definition['protected'] . ', '
+            . (int) $definition['active']
+            . ')'
+        );
+        $categoryIds[$key] = (int) $categoryId;
+
+        foreach (system_menu_map_group_keys($definition['group_keys'], $groupMap) as $groupId) {
+            $dbm->insert(
+                'group_permission',
+                ' VALUES (0, ' . $groupId . ', ' . (int) $categoryId . ', ' . $moduleId . ", 'menus_category_view')"
+            );
+        }
+    }
+
+    foreach ($seed['items'] as $definition) {
+        $itemId = $dbm->insert(
+            'menusitems',
+            " (`items_pid`, `items_cid`, `items_title`, `items_prefix`, `items_suffix`, `items_url`, `items_target`, `items_position`, `items_protected`, `items_active`) VALUES ("
+            . (int) $definition['pid'] . ', '
+            . $categoryIds['account'] . ', '
+            . "'" . addslashes($definition['title']) . "', "
+            . "'" . addslashes($definition['prefix']) . "', "
+            . "'" . addslashes($definition['suffix']) . "', "
+            . "'" . addslashes($definition['url']) . "', "
+            . (int) $definition['target'] . ', '
+            . (int) $definition['position'] . ', '
+            . (int) $definition['protected'] . ', '
+            . (int) $definition['active']
+            . ')'
+        );
+
+        foreach (system_menu_map_group_keys($definition['group_keys'], $groupMap) as $groupId) {
+            $dbm->insert(
+                'group_permission',
+                ' VALUES (0, ' . $groupId . ', ' . (int) $itemId . ', ' . $moduleId . ", 'menus_items_view')"
+            );
+        }
+    }
 }
 
 /**
@@ -104,6 +174,7 @@ function make_data($dbm, $adminname, $hashedAdminPass, $adminmail, $language, $g
     $time = time();
     // RMV-NOTIFY (updated for extra column in table)
     $dbm->insert('modules', " VALUES (1, '" . _MI_SYSTEM_NAME . "', '" . $modversion['version'] . "', " . $time . ", 0, 1, 'system', 0, 1, 0, 0, 0, 0)");
+    system_menu_install_seed_defaults($dbm, $groups, 1);
 
     foreach ($modversion['templates'] as $tplfile) {
         $templateType = isset($tplfile['type']) && 'admin' === $tplfile['type'] ? 'admin' : 'module';

--- a/htdocs/install/include/makedata.php
+++ b/htdocs/install/include/makedata.php
@@ -51,8 +51,10 @@ function make_groups($dbm)
  * @param Db_manager         $dbm
  * @param array<string, int> $groups
  * @param int                $moduleId
+ *
+ * @return bool
  */
-function system_menu_install_seed_defaults($dbm, array $groups, int $moduleId): void
+function system_menu_install_seed_defaults($dbm, array $groups, int $moduleId): bool
 {
     $seed = system_menu_get_seed_definitions();
     $groupMap = [
@@ -81,15 +83,21 @@ function system_menu_install_seed_defaults($dbm, array $groups, int $moduleId): 
                 sprintf('Failed to seed menu category "%s" during install.', $definition['title']),
                 E_USER_WARNING
             );
-            return;
+            return false;
         }
         $categoryIds[$key] = (int) $categoryId;
 
         foreach (system_menu_map_group_keys($definition['group_keys'], $groupMap) as $groupId) {
-            $dbm->insert(
+            if (!$dbm->insert(
                 'group_permission',
                 ' VALUES (0, ' . $groupId . ', ' . (int) $categoryId . ', ' . $moduleId . ", 'menus_category_view')"
-            );
+            )) {
+                trigger_error(
+                    sprintf('Failed to seed menu category permissions for "%s" during install.', $definition['title']),
+                    E_USER_WARNING
+                );
+                return false;
+            }
         }
     }
 
@@ -114,16 +122,24 @@ function system_menu_install_seed_defaults($dbm, array $groups, int $moduleId): 
                 sprintf('Failed to seed menu item "%s" during install.', $definition['title']),
                 E_USER_WARNING
             );
-            return;
+            return false;
         }
 
         foreach (system_menu_map_group_keys($definition['group_keys'], $groupMap) as $groupId) {
-            $dbm->insert(
+            if (!$dbm->insert(
                 'group_permission',
                 ' VALUES (0, ' . $groupId . ', ' . (int) $itemId . ', ' . $moduleId . ", 'menus_items_view')"
-            );
+            )) {
+                trigger_error(
+                    sprintf('Failed to seed menu item permissions for "%s" during install.', $definition['title']),
+                    E_USER_WARNING
+                );
+                return false;
+            }
         }
     }
+
+    return true;
 }
 
 /**
@@ -188,7 +204,9 @@ function make_data($dbm, $adminname, $hashedAdminPass, $adminmail, $language, $g
     $time = time();
     // RMV-NOTIFY (updated for extra column in table)
     $dbm->insert('modules', " VALUES (1, '" . _MI_SYSTEM_NAME . "', '" . $modversion['version'] . "', " . $time . ", 0, 1, 'system', 0, 1, 0, 0, 0, 0)");
-    system_menu_install_seed_defaults($dbm, $groups, 1);
+    if (!system_menu_install_seed_defaults($dbm, $groups, 1)) {
+        return false;
+    }
 
     foreach ($modversion['templates'] as $tplfile) {
         $templateType = isset($tplfile['type']) && 'admin' === $tplfile['type'] ? 'admin' : 'module';

--- a/htdocs/install/sql/mysql.structure.sql
+++ b/htdocs/install/sql/mysql.structure.sql
@@ -231,6 +231,49 @@ CREATE TABLE group_permission (
 ) ENGINE=MyISAM;
 # --------------------------------------------------------
 
+#
+# Table structure for table `menuscategory`
+#
+
+CREATE TABLE menuscategory (
+  category_id int unsigned NOT NULL auto_increment,
+  category_title varchar(100) NOT NULL default '',
+  category_prefix text NOT NULL,
+  category_suffix text NOT NULL,
+  category_url varchar(255) NOT NULL default '',
+  category_target tinyint(1) unsigned NOT NULL default '0',
+  category_position int NOT NULL default '0',
+  category_protected int NOT NULL default '0',
+  category_active tinyint(1) unsigned NOT NULL default '1',
+  PRIMARY KEY  (category_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+# --------------------------------------------------------
+
+#
+# Table structure for table `menusitems`
+#
+
+CREATE TABLE menusitems (
+  items_id int unsigned NOT NULL auto_increment,
+  items_pid int NOT NULL default '0',
+  items_cid int unsigned NOT NULL default '0',
+  items_title varchar(100) NOT NULL default '',
+  items_prefix text NOT NULL,
+  items_suffix text NOT NULL,
+  items_url varchar(255) NOT NULL default '',
+  items_target tinyint(1) unsigned NOT NULL default '0',
+  items_position int NOT NULL default '0',
+  items_protected int NOT NULL default '0',
+  items_active tinyint(1) unsigned NOT NULL default '1',
+  PRIMARY KEY  (items_id),
+  KEY idx_items_cid (items_cid),
+  KEY idx_items_pid (items_pid),
+  FOREIGN KEY (items_cid)
+    REFERENCES menuscategory (category_id)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+# --------------------------------------------------------
+
 
 #
 # Table structure for table `groups_users_link`

--- a/htdocs/install/sql/mysql.structure.sql
+++ b/htdocs/install/sql/mysql.structure.sql
@@ -267,10 +267,7 @@ CREATE TABLE menusitems (
   items_active tinyint(1) unsigned NOT NULL default '1',
   PRIMARY KEY  (items_id),
   KEY idx_items_cid (items_cid),
-  KEY idx_items_pid (items_pid),
-  FOREIGN KEY (items_cid)
-    REFERENCES menuscategory (category_id)
-    ON DELETE CASCADE
+  KEY idx_items_pid (items_pid)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 # --------------------------------------------------------
 

--- a/htdocs/modules/system/include/menu_seed.php
+++ b/htdocs/modules/system/include/menu_seed.php
@@ -1,0 +1,164 @@
+<?php
+/*
+ * You may not change or alter any portion of this comment or credits
+ * of supporting developers from this source code or any supporting source code
+ * which is considered copyrighted (c) material of the original comment or credit authors.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+/**
+ * Shared protected menu seed data for install and upgrade flows.
+ *
+ * Titles are stored as language constant identifiers and resolved at render time.
+ *
+ * @return array{categories: array<string, array<string, mixed>>, items: array<int, array<string, mixed>>}
+ */
+function system_menu_get_seed_definitions(): array
+{
+    return [
+        'categories' => [
+            'home' => [
+                'title'      => 'MENUS_HOME',
+                'prefix'     => '<span class="fa fa-home"></span>',
+                'suffix'     => '',
+                'url'        => 'index.php',
+                'target'     => 0,
+                'position'   => 1,
+                'protected'  => 1,
+                'active'     => 1,
+                'group_keys' => ['admin', 'users', 'anonymous'],
+            ],
+            'account' => [
+                'title'      => 'MENUS_ACCOUNT',
+                'prefix'     => '<span class="fa fa-user fa-fw"></span>',
+                'suffix'     => '',
+                'url'        => '',
+                'target'     => 0,
+                'position'   => 2,
+                'protected'  => 1,
+                'active'     => 1,
+                'group_keys' => ['admin', 'users', 'anonymous'],
+            ],
+            'admin' => [
+                'title'      => 'MENUS_ADMIN',
+                'prefix'     => '<span class="fa fa-wrench fa-fw"></span>',
+                'suffix'     => '',
+                'url'        => 'admin.php',
+                'target'     => 0,
+                'position'   => 3,
+                'protected'  => 1,
+                'active'     => 1,
+                'group_keys' => ['admin'],
+            ],
+        ],
+        'items' => [
+            [
+                'title'      => 'MENUS_ACCOUNT_EDIT',
+                'prefix'     => '<span class="fa fa-edit fa-fw"></span>',
+                'suffix'     => '',
+                'url'        => 'user.php',
+                'target'     => 0,
+                'position'   => 1,
+                'pid'        => 0,
+                'protected'  => 1,
+                'active'     => 1,
+                'group_keys' => ['admin', 'users'],
+            ],
+            [
+                'title'      => 'MENUS_ACCOUNT_LOGIN',
+                'prefix'     => '<span class="fa fa-sign-in fa-fw"></span>',
+                'suffix'     => '',
+                'url'        => 'user.php',
+                'target'     => 0,
+                'position'   => 2,
+                'pid'        => 0,
+                'protected'  => 1,
+                'active'     => 1,
+                'group_keys' => ['anonymous'],
+            ],
+            [
+                'title'      => 'MENUS_ACCOUNT_REGISTER',
+                'prefix'     => '<span class="fa fa-sign-in fa-fw"></span>',
+                'suffix'     => '',
+                'url'        => 'register.php',
+                'target'     => 0,
+                'position'   => 3,
+                'pid'        => 0,
+                'protected'  => 1,
+                'active'     => 1,
+                'group_keys' => ['anonymous'],
+            ],
+            [
+                'title'      => 'MENUS_ACCOUNT_MESSAGES',
+                'prefix'     => '<span class="fa fa-envelope fa-fw"></span>',
+                'suffix'     => '<span class="badge bg-primary rounded-pill"><{xoInboxCount}></span>',
+                'url'        => 'viewpmsg.php',
+                'target'     => 0,
+                'position'   => 4,
+                'pid'        => 0,
+                'protected'  => 1,
+                'active'     => 1,
+                'group_keys' => ['admin', 'users'],
+            ],
+            [
+                'title'      => 'MENUS_ACCOUNT_NOTIFICATIONS',
+                'prefix'     => '<span class="fa fa-info-circle fa-fw"></span>',
+                'suffix'     => '',
+                'url'        => 'notifications.php',
+                'target'     => 0,
+                'position'   => 5,
+                'pid'        => 0,
+                'protected'  => 1,
+                'active'     => 1,
+                'group_keys' => ['admin', 'users'],
+            ],
+            [
+                'title'      => 'MENUS_ACCOUNT_TOOLBAR',
+                'prefix'     => '<span class="fa fa-wrench fa-fw"></span>',
+                'suffix'     => '<span id="xswatch-toolbar-ind"></span>',
+                'url'        => '#xswatch-toolbar-toggle',
+                'target'     => 0,
+                'position'   => 6,
+                'pid'        => 0,
+                'protected'  => 1,
+                'active'     => 1,
+                'group_keys' => ['admin', 'users'],
+            ],
+            [
+                'title'      => 'MENUS_ACCOUNT_LOGOUT',
+                'prefix'     => '<span class="fa fa-sign-out fa-fw"></span>',
+                'suffix'     => '',
+                'url'        => 'user.php?op=logout',
+                'target'     => 0,
+                'position'   => 7,
+                'pid'        => 0,
+                'protected'  => 1,
+                'active'     => 1,
+                'group_keys' => ['admin', 'users'],
+            ],
+        ],
+    ];
+}
+
+/**
+ * Resolve symbolic group keys to concrete group ids.
+ *
+ * @param string[]           $groupKeys
+ * @param array<string, int> $groupMap
+ *
+ * @return int[]
+ */
+function system_menu_map_group_keys(array $groupKeys, array $groupMap): array
+{
+    $groupIds = [];
+    foreach ($groupKeys as $groupKey) {
+        if (isset($groupMap[$groupKey])) {
+            $groupIds[] = $groupMap[$groupKey];
+        }
+    }
+
+    return $groupIds;
+}

--- a/htdocs/modules/system/include/update.php
+++ b/htdocs/modules/system/include/update.php
@@ -15,6 +15,25 @@
  * @author       XOOPS Development Team, Kazumi Ono (AKA onokazu)
  */
 
+require_once __DIR__ . '/menu_seed.php';
+
+/**
+ * System module install hook.
+ *
+ * On a fresh XOOPS install this does not fire, because the installer inserts
+ * the System module row directly and seeds menus from htdocs/install/include/makedata.php.
+ * This hook exists for module-admin reinstall flows, where reusing the idempotent
+ * update logic is the safest behavior.
+ *
+ * @param XoopsModule $module
+ *
+ * @return bool
+ */
+function xoops_module_install_system(XoopsModule $module)
+{
+    return system_menu_update($module);
+}
+
 /**
  * @param XoopsModule $module
  * @param string|null $prev_version
@@ -283,15 +302,15 @@ function system_menu_create_tables(XoopsMySQLDatabase $db): void
 {
     $prefix = $db->prefix('menuscategory');
     $sql = "CREATE TABLE IF NOT EXISTS `{$prefix}` (
-        `category_id`        INT          NOT NULL AUTO_INCREMENT,
+        `category_id`        INT UNSIGNED NOT NULL AUTO_INCREMENT,
         `category_title`     VARCHAR(100) NOT NULL DEFAULT '',
         `category_prefix`    TEXT         NOT NULL,
         `category_suffix`    TEXT         NOT NULL,
         `category_url`       VARCHAR(255) NOT NULL DEFAULT '',
-        `category_target`    TINYINT(1)   NOT NULL DEFAULT 0,
+        `category_target`    TINYINT(1) UNSIGNED NOT NULL DEFAULT 0,
         `category_position`  INT          NOT NULL DEFAULT 0,
         `category_protected` INT          NOT NULL DEFAULT 0,
-        `category_active`    TINYINT(1)   NOT NULL DEFAULT 1,
+        `category_active`    TINYINT(1) UNSIGNED NOT NULL DEFAULT 1,
         PRIMARY KEY (`category_id`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
     system_menu_exec_or_throw($db, $sql);
@@ -304,17 +323,17 @@ function system_menu_create_tables(XoopsMySQLDatabase $db): void
     $prefix = $db->prefix('menusitems');
     $fkName = $db->prefix('fk_items_category');
     $sql = "CREATE TABLE IF NOT EXISTS `{$prefix}` (
-        `items_id`        INT          NOT NULL AUTO_INCREMENT,
+        `items_id`        INT UNSIGNED NOT NULL AUTO_INCREMENT,
         `items_pid`       INT          NOT NULL DEFAULT 0,
-        `items_cid`       INT          NOT NULL DEFAULT 0,
+        `items_cid`       INT UNSIGNED NOT NULL DEFAULT 0,
         `items_title`     VARCHAR(100) NOT NULL DEFAULT '',
         `items_prefix`    TEXT         NOT NULL,
         `items_suffix`    TEXT         NOT NULL,
         `items_url`       VARCHAR(255) NOT NULL DEFAULT '',
-        `items_target`    TINYINT(1)   NOT NULL DEFAULT 0,
+        `items_target`    TINYINT(1) UNSIGNED NOT NULL DEFAULT 0,
         `items_position`  INT          NOT NULL DEFAULT 0,
         `items_protected` INT          NOT NULL DEFAULT 0,
-        `items_active`    TINYINT(1)   NOT NULL DEFAULT 1,
+        `items_active`    TINYINT(1) UNSIGNED NOT NULL DEFAULT 1,
         PRIMARY KEY (`items_id`),
         KEY `idx_items_cid` (`items_cid`),
         KEY `idx_items_pid` (`items_pid`),
@@ -536,138 +555,14 @@ function system_menu_seed_permissions(
  */
 function system_menu_seed_defaults(XoopsMySQLDatabase $db, int $moduleId): void
 {
-    $adminGroup = defined('XOOPS_GROUP_ADMIN') ? (int) XOOPS_GROUP_ADMIN : 1;
-    $usersGroup = defined('XOOPS_GROUP_USERS') ? (int) XOOPS_GROUP_USERS : 2;
-    $anonGroup  = defined('XOOPS_GROUP_ANONYMOUS') ? (int) XOOPS_GROUP_ANONYMOUS : 3;
-
-    $allGroups   = [$adminGroup, $usersGroup, $anonGroup];
-    $authGroups  = [$adminGroup, $usersGroup];
-    $adminGroups = [$adminGroup];
-
-    // --- Category definitions ---
-    $categories = [
-        'home' => [
-            'title'     => 'MENUS_HOME',
-            'prefix'    => '<span class="fa fa-home"></span>',
-            'suffix'    => '',
-            'url'       => 'index.php',
-            'target'    => 0,
-            'position'  => 1,
-            'protected' => 1,
-            'active'    => 1,
-            'groups'    => $allGroups,
-        ],
-        'account' => [
-            'title'     => 'MENUS_ACCOUNT',
-            'prefix'    => '<span class="fa fa-user fa-fw"></span>',
-            'suffix'    => '',
-            'url'       => '',
-            'target'    => 0,
-            'position'  => 2,
-            'protected' => 1,
-            'active'    => 1,
-            'groups'    => $allGroups,
-        ],
-        'admin' => [
-            'title'     => 'MENUS_ADMIN',
-            'prefix'    => '<span class="fa fa-wrench fa-fw"></span>',
-            'suffix'    => '',
-            'url'       => 'admin.php',
-            'target'    => 0,
-            'position'  => 3,
-            'protected' => 1,
-            'active'    => 1,
-            'groups'    => $adminGroups,
-        ],
+    $groupMap = [
+        'admin'     => defined('XOOPS_GROUP_ADMIN') ? (int) XOOPS_GROUP_ADMIN : 1,
+        'users'     => defined('XOOPS_GROUP_USERS') ? (int) XOOPS_GROUP_USERS : 2,
+        'anonymous' => defined('XOOPS_GROUP_ANONYMOUS') ? (int) XOOPS_GROUP_ANONYMOUS : 3,
     ];
-
-    // --- Item definitions (under Account) ---
-    $items = [
-        [
-            'title'     => 'MENUS_ACCOUNT_EDIT',
-            'prefix'    => '<span class="fa fa-edit fa-fw"></span>',
-            'suffix'    => '',
-            'url'       => 'user.php',
-            'target'    => 0,
-            'position'  => 1,
-            'pid'       => 0,
-            'protected' => 1,
-            'active'    => 1,
-            'groups'    => $authGroups,
-        ],
-        [
-            'title'     => 'MENUS_ACCOUNT_LOGIN',
-            'prefix'    => '<span class="fa fa-sign-in fa-fw"></span>',
-            'suffix'    => '',
-            'url'       => 'user.php',
-            'target'    => 0,
-            'position'  => 2,
-            'pid'       => 0,
-            'protected' => 1,
-            'active'    => 1,
-            'groups'    => [$anonGroup],
-        ],
-        [
-            'title'     => 'MENUS_ACCOUNT_REGISTER',
-            'prefix'    => '<span class="fa fa-sign-in fa-fw"></span>',
-            'suffix'    => '',
-            'url'       => 'register.php',
-            'target'    => 0,
-            'position'  => 3,
-            'pid'       => 0,
-            'protected' => 1,
-            'active'    => 1,
-            'groups'    => [$anonGroup],
-        ],
-        [
-            'title'     => 'MENUS_ACCOUNT_MESSAGES',
-            'prefix'    => '<span class="fa fa-envelope fa-fw"></span>',
-            'suffix'    => '<span class="badge bg-primary rounded-pill"><{xoInboxCount}></span>',
-            'url'       => 'viewpmsg.php',
-            'target'    => 0,
-            'position'  => 4,
-            'pid'       => 0,
-            'protected' => 1,
-            'active'    => 1,
-            'groups'    => $authGroups,
-        ],
-        [
-            'title'     => 'MENUS_ACCOUNT_NOTIFICATIONS',
-            'prefix'    => '<span class="fa fa-info-circle fa-fw"></span>',
-            'suffix'    => '',
-            'url'       => 'notifications.php',
-            'target'    => 0,
-            'position'  => 5,
-            'pid'       => 0,
-            'protected' => 1,
-            'active'    => 1,
-            'groups'    => $authGroups,
-        ],
-        [
-            'title'     => 'MENUS_ACCOUNT_TOOLBAR',
-            'prefix'    => '<span class="fa fa-wrench fa-fw"></span>',
-            'suffix'    => '<span id="xswatch-toolbar-ind"></span>',
-            'url'       => '#xswatch-toolbar-toggle',
-            'target'    => 0,
-            'position'  => 6,
-            'pid'       => 0,
-            'protected' => 1,
-            'active'    => 1,
-            'groups'    => $authGroups,
-        ],
-        [
-            'title'     => 'MENUS_ACCOUNT_LOGOUT',
-            'prefix'    => '<span class="fa fa-sign-out fa-fw"></span>',
-            'suffix'    => '',
-            'url'       => 'user.php?op=logout',
-            'target'    => 0,
-            'position'  => 7,
-            'pid'       => 0,
-            'protected' => 1,
-            'active'    => 1,
-            'groups'    => $authGroups,
-        ],
-    ];
+    $seed = system_menu_get_seed_definitions();
+    $categories = $seed['categories'];
+    $items = $seed['items'];
 
     // --- Persist categories ---
     $categoryIds = [];
@@ -683,12 +578,22 @@ function system_menu_seed_defaults(XoopsMySQLDatabase $db, int $moduleId): void
 
     // --- Seed category permissions (idempotent — skips existing) ---
     foreach ($categories as $key => $catDef) {
-        system_menu_seed_permissions($moduleId, 'menus_category_view', $categoryIds[$key], $catDef['groups']);
+        system_menu_seed_permissions(
+            $moduleId,
+            'menus_category_view',
+            $categoryIds[$key],
+            system_menu_map_group_keys($catDef['group_keys'], $groupMap)
+        );
     }
 
     // --- Seed item permissions ---
     foreach ($items as $idx => $itemDef) {
-        system_menu_seed_permissions($moduleId, 'menus_items_view', $itemIds[$idx], $itemDef['groups']);
+        system_menu_seed_permissions(
+            $moduleId,
+            'menus_items_view',
+            $itemIds[$idx],
+            system_menu_map_group_keys($itemDef['group_keys'], $groupMap)
+        );
     }
 }
 

--- a/htdocs/modules/system/include/update.php
+++ b/htdocs/modules/system/include/update.php
@@ -373,6 +373,10 @@ function system_menu_normalize_schema(XoopsMySQLDatabase $db): void
 {
     $catTable = $db->prefix('menuscategory');
     $itemTable = $db->prefix('menusitems');
+    $fkName = $db->prefix('fk_items_category');
+
+    // Drop category FKs before changing signedness on the parent/child key columns.
+    system_menu_drop_parent_foreign_keys($db, 'menuscategory');
 
     // Drop self-referencing FK on items_pid (incompatible with 0-as-root convention)
     $result = $db->query(
@@ -392,6 +396,15 @@ function system_menu_normalize_schema(XoopsMySQLDatabase $db): void
     system_menu_exec_or_throw($db, "UPDATE `{$itemTable}` SET `items_pid` = 0 WHERE `items_pid` IS NULL");
     system_menu_exec_or_throw($db, "ALTER TABLE `{$itemTable}` MODIFY `items_pid` INT NOT NULL DEFAULT 0");
 
+    // Keep fresh-install and upgraded schemas aligned.
+    system_menu_exec_or_throw($db, "ALTER TABLE `{$catTable}` MODIFY `category_id` INT UNSIGNED NOT NULL AUTO_INCREMENT");
+    system_menu_exec_or_throw($db, "ALTER TABLE `{$catTable}` MODIFY `category_target` TINYINT(1) UNSIGNED NOT NULL DEFAULT 0");
+    system_menu_exec_or_throw($db, "ALTER TABLE `{$catTable}` MODIFY `category_active` TINYINT(1) UNSIGNED NOT NULL DEFAULT 1");
+    system_menu_exec_or_throw($db, "ALTER TABLE `{$itemTable}` MODIFY `items_id` INT UNSIGNED NOT NULL AUTO_INCREMENT");
+    system_menu_exec_or_throw($db, "ALTER TABLE `{$itemTable}` MODIFY `items_cid` INT UNSIGNED NOT NULL DEFAULT 0");
+    system_menu_exec_or_throw($db, "ALTER TABLE `{$itemTable}` MODIFY `items_target` TINYINT(1) UNSIGNED NOT NULL DEFAULT 0");
+    system_menu_exec_or_throw($db, "ALTER TABLE `{$itemTable}` MODIFY `items_active` TINYINT(1) UNSIGNED NOT NULL DEFAULT 1");
+
     // Enforce NOT NULL on affix columns
     system_menu_exec_or_throw($db, "ALTER TABLE `{$catTable}` MODIFY `category_prefix` TEXT NOT NULL");
     system_menu_exec_or_throw($db, "ALTER TABLE `{$catTable}` MODIFY `category_suffix` TEXT NOT NULL");
@@ -404,6 +417,22 @@ function system_menu_normalize_schema(XoopsMySQLDatabase $db): void
         "UPDATE `{$catTable}` SET `category_url` = " . $db->quote('index.php')
         . " WHERE `category_protected` = 1 AND `category_url` = " . $db->quote('/')
     );
+
+    // Restore the category FK after type normalization if it is absent.
+    $fkCheck = $db->query(
+        "SELECT 1 FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS"
+        . " WHERE CONSTRAINT_NAME = " . $db->quote($fkName)
+        . " AND TABLE_NAME = " . $db->quote($itemTable)
+        . " AND TABLE_SCHEMA = DATABASE()"
+    );
+    if ($db->isResultSet($fkCheck) && ($fkCheck instanceof \mysqli_result) && 0 === $db->getRowsNum($fkCheck)) {
+        system_menu_exec_or_throw(
+            $db,
+            "ALTER TABLE `{$itemTable}` ADD CONSTRAINT `{$fkName}`"
+            . " FOREIGN KEY (`items_cid`) REFERENCES `{$catTable}` (`category_id`)"
+            . " ON DELETE CASCADE"
+        );
+    }
 }
 
 /**

--- a/htdocs/modules/system/xoops_version.php
+++ b/htdocs/modules/system/xoops_version.php
@@ -32,6 +32,7 @@ $modversion['hasAdmin']   = 1;
 $modversion['adminindex'] = 'admin.php';
 $modversion['adminmenu']  = 'menu.php';
 
+$modversion['onInstall'] = 'include/update.php';
 $modversion['onUpdate'] = 'include/update.php';
 
 // Templates

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -17,6 +17,7 @@
             <directory suffix=".php">../htdocs/modules/pm</directory>
             <directory suffix=".php">../htdocs/modules/profile</directory>
             <directory suffix=".php">../htdocs/modules/protector</directory>
+            <directory suffix=".php">../htdocs/install</directory>
         </include>
         <exclude>
             <directory>../htdocs/class/libraries/vendor</directory>

--- a/tests/unit/htdocs/modules/system/SystemMenuInstallationTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMenuInstallationTest.php
@@ -98,6 +98,7 @@ final class SystemMenuInstallationTest extends TestCase
     public function installerSchemaDeclaresMenuTablesUsingUnsignedIds(): void
     {
         $source = $this->readSourceFile('install/sql/mysql.structure.sql');
+        preg_match('/CREATE TABLE menusitems \(.*?\) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;/s', $source, $menusItemsBlock);
 
         $this->assertMatchesRegularExpression(
             '/CREATE TABLE menuscategory \\(.*?category_id int unsigned NOT NULL auto_increment/s',
@@ -107,7 +108,8 @@ final class SystemMenuInstallationTest extends TestCase
             '/CREATE TABLE menusitems \\(.*?items_id int unsigned NOT NULL auto_increment.*?items_cid int unsigned NOT NULL default \\\'0\\\'/s',
             $source
         );
-        $this->assertStringNotContainsString('FOREIGN KEY', $source);
+        $this->assertNotEmpty($menusItemsBlock, 'menusitems DDL block not found');
+        $this->assertStringNotContainsString('FOREIGN KEY', $menusItemsBlock[0]);
     }
 
     #[Test]

--- a/tests/unit/htdocs/modules/system/SystemMenuInstallationTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMenuInstallationTest.php
@@ -17,6 +17,7 @@ final class SystemMenuInstallationTest extends TestCase
     {
         if (!self::$seedLoaded) {
             require_once XOOPS_ROOT_PATH . '/modules/system/include/menu_seed.php';
+            require_once XOOPS_ROOT_PATH . '/install/include/makedata.php';
             self::$seedLoaded = true;
         }
     }
@@ -113,6 +114,33 @@ final class SystemMenuInstallationTest extends TestCase
     }
 
     #[Test]
+    public function updateScriptNormalizesExistingMenuTableTypesForUpgrades(): void
+    {
+        $source = $this->readSourceFile('modules/system/include/update.php');
+
+        $this->assertStringContainsString(
+            "ALTER TABLE `{\$catTable}` MODIFY `category_id` INT UNSIGNED NOT NULL AUTO_INCREMENT",
+            $source
+        );
+        $this->assertStringContainsString(
+            "ALTER TABLE `{\$itemTable}` MODIFY `items_id` INT UNSIGNED NOT NULL AUTO_INCREMENT",
+            $source
+        );
+        $this->assertStringContainsString(
+            "ALTER TABLE `{\$itemTable}` MODIFY `items_cid` INT UNSIGNED NOT NULL DEFAULT 0",
+            $source
+        );
+        $this->assertStringContainsString(
+            "ALTER TABLE `{\$catTable}` MODIFY `category_target` TINYINT(1) UNSIGNED NOT NULL DEFAULT 0",
+            $source
+        );
+        $this->assertStringContainsString(
+            "ALTER TABLE `{\$itemTable}` MODIFY `items_active` TINYINT(1) UNSIGNED NOT NULL DEFAULT 1",
+            $source
+        );
+    }
+
+    #[Test]
     public function installerUsesSharedSeedDefinitionsAndSeedsMenusAfterSystemModuleInsert(): void
     {
         $source = $this->readSourceFile('install/include/makedata.php');
@@ -142,5 +170,117 @@ final class SystemMenuInstallationTest extends TestCase
         $this->assertTrue(function_exists('xoops_module_install_system'));
         $this->assertTrue(function_exists('xoops_module_update_system'));
         $this->assertTrue(function_exists('system_menu_seed_defaults'));
+    }
+
+    #[Test]
+    public function installerSeedingStopsWhenCategoryInsertFails(): void
+    {
+        $dbm = new class {
+            public array $calls = [];
+
+            public function insert($table, $values)
+            {
+                $this->calls[] = $table;
+                if ($table === 'menuscategory') {
+                    return false;
+                }
+
+                return count($this->calls);
+            }
+        };
+
+        $warnings = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$warnings): bool {
+            $warnings[] = [$errno, $errstr];
+            return true;
+        });
+
+        try {
+            system_menu_install_seed_defaults(
+                $dbm,
+                [
+                    'XOOPS_GROUP_ADMIN' => 1,
+                    'XOOPS_GROUP_USERS' => 2,
+                    'XOOPS_GROUP_ANONYMOUS' => 3,
+                ],
+                1
+            );
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame(['menuscategory'], $dbm->calls);
+        $this->assertCount(1, $warnings);
+        $this->assertSame(E_USER_WARNING, $warnings[0][0]);
+        $this->assertStringContainsString('Failed to seed menu category', $warnings[0][1]);
+    }
+
+    #[Test]
+    public function installerSeedsExpectedRowsAndRespectsCategoryBeforeItemOrdering(): void
+    {
+        $dbm = new class {
+            public array $inserts = [];
+            /** @var array<string, int> */
+            private array $ids = [];
+
+            public function insert($table, $values)
+            {
+                $nextId = ($this->ids[$table] ?? 0) + 1;
+                $this->ids[$table] = $nextId;
+                $this->inserts[] = [
+                    'table' => $table,
+                    'values' => $values,
+                    'id' => $nextId,
+                ];
+
+                return $nextId;
+            }
+        };
+
+        system_menu_install_seed_defaults(
+            $dbm,
+            [
+                'XOOPS_GROUP_ADMIN' => 1,
+                'XOOPS_GROUP_USERS' => 2,
+                'XOOPS_GROUP_ANONYMOUS' => 3,
+            ],
+            1
+        );
+
+        $byTable = array_count_values(array_column($dbm->inserts, 'table'));
+        $this->assertSame(3, $byTable['menuscategory'] ?? 0);
+        $this->assertSame(7, $byTable['menusitems'] ?? 0);
+        $this->assertGreaterThan(0, $byTable['group_permission'] ?? 0);
+
+        $categoryInsertIndexes = [];
+        $itemInsertIndexes = [];
+        foreach ($dbm->inserts as $index => $insert) {
+            if ($insert['table'] === 'menuscategory') {
+                $categoryInsertIndexes[] = $index;
+            }
+            if ($insert['table'] === 'menusitems') {
+                $itemInsertIndexes[] = $index;
+            }
+        }
+
+        $this->assertNotEmpty($categoryInsertIndexes);
+        $this->assertNotEmpty($itemInsertIndexes);
+        $this->assertLessThan(
+            min($itemInsertIndexes),
+            max($categoryInsertIndexes),
+            'All menu categories should be inserted before the first menu item'
+        );
+
+        $itemInserts = array_values(array_filter(
+            $dbm->inserts,
+            static fn(array $insert): bool => $insert['table'] === 'menusitems'
+        ));
+        foreach ($itemInserts as $insert) {
+            $this->assertMatchesRegularExpression(
+                "/VALUES \\(0, 2, 'MENUS_ACCOUNT_[A-Z_]+'/",
+                $insert['values'],
+                'Each seeded menu item should reference the inserted Account category id'
+            );
+        }
     }
 }

--- a/tests/unit/htdocs/modules/system/SystemMenuInstallationTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMenuInstallationTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace modulessystem;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversNothing]
+final class SystemMenuInstallationTest extends TestCase
+{
+    private static bool $seedLoaded = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!self::$seedLoaded) {
+            require_once XOOPS_ROOT_PATH . '/modules/system/include/menu_seed.php';
+            self::$seedLoaded = true;
+        }
+    }
+
+    private function readSourceFile(string $relativePath): string
+    {
+        $fullPath = XOOPS_ROOT_PATH . '/' . $relativePath;
+        $this->assertFileExists($fullPath, "Source file not found: {$relativePath}");
+
+        $contents = file_get_contents($fullPath);
+        $this->assertNotFalse($contents, "Unable to read source file: {$relativePath}");
+
+        return $contents;
+    }
+
+    #[Test]
+    public function sharedSeedDefinitionsExposeExpectedProtectedMenus(): void
+    {
+        $seed = system_menu_get_seed_definitions();
+
+        $this->assertArrayHasKey('categories', $seed);
+        $this->assertArrayHasKey('items', $seed);
+        $this->assertArrayHasKey('home', $seed['categories']);
+        $this->assertArrayHasKey('account', $seed['categories']);
+        $this->assertArrayHasKey('admin', $seed['categories']);
+        $this->assertNotEmpty($seed['items']);
+        $this->assertSame('MENUS_HOME', $seed['categories']['home']['title']);
+        $this->assertSame('MENUS_ACCOUNT', $seed['categories']['account']['title']);
+        $this->assertSame('MENUS_ADMIN', $seed['categories']['admin']['title']);
+        $this->assertCount(7, $seed['items']);
+        $titles = array_column($seed['items'], 'title');
+        $this->assertContains('MENUS_ACCOUNT_EDIT', $titles);
+        $this->assertContains('MENUS_ACCOUNT_LOGIN', $titles);
+        $this->assertContains('MENUS_ACCOUNT_REGISTER', $titles);
+        $this->assertContains('MENUS_ACCOUNT_MESSAGES', $titles);
+        $this->assertContains('MENUS_ACCOUNT_NOTIFICATIONS', $titles);
+        $this->assertContains('MENUS_ACCOUNT_TOOLBAR', $titles);
+        $this->assertContains('MENUS_ACCOUNT_LOGOUT', $titles);
+        $this->assertContains('anonymous', $seed['categories']['account']['group_keys']);
+        $this->assertContains('admin', $seed['categories']['admin']['group_keys']);
+    }
+
+    #[Test]
+    public function sharedGroupKeyMapperResolvesKnownGroupsOnly(): void
+    {
+        $groupIds = system_menu_map_group_keys(
+            ['admin', 'users', 'anonymous', 'missing'],
+            [
+                'admin' => 1,
+                'users' => 2,
+                'anonymous' => 3,
+            ]
+        );
+
+        $this->assertSame([1, 2, 3], $groupIds);
+    }
+
+    #[Test]
+    public function installerSchemaDeclaresMenuTablesUsingUnsignedIds(): void
+    {
+        $source = $this->readSourceFile('install/sql/mysql.structure.sql');
+
+        $this->assertMatchesRegularExpression(
+            '/CREATE TABLE menuscategory \\(.*?category_id int unsigned NOT NULL auto_increment/s',
+            $source
+        );
+        $this->assertMatchesRegularExpression(
+            '/CREATE TABLE menusitems \\(.*?items_id int unsigned NOT NULL auto_increment.*?items_cid int unsigned NOT NULL default \\\'0\\\'/s',
+            $source
+        );
+        $this->assertMatchesRegularExpression(
+            '/FOREIGN KEY \(items_cid\)\s+REFERENCES menuscategory \(category_id\)\s+ON DELETE CASCADE/s',
+            $source
+        );
+    }
+
+    #[Test]
+    public function updateScriptCreateTablesMatchInstallerSignedness(): void
+    {
+        $source = $this->readSourceFile('modules/system/include/update.php');
+
+        $this->assertMatchesRegularExpression(
+            '/`category_id`\\s+INT UNSIGNED\\s+NOT NULL\\s+AUTO_INCREMENT/i',
+            $source
+        );
+        $this->assertMatchesRegularExpression(
+            '/`items_id`\\s+INT UNSIGNED\\s+NOT NULL\\s+AUTO_INCREMENT/i',
+            $source
+        );
+        $this->assertMatchesRegularExpression(
+            '/`items_cid`\\s+INT UNSIGNED\\s+NOT NULL\\s+DEFAULT 0/i',
+            $source
+        );
+    }
+
+    #[Test]
+    public function installerUsesSharedSeedDefinitionsAndSeedsMenusAfterSystemModuleInsert(): void
+    {
+        $source = $this->readSourceFile('install/include/makedata.php');
+
+        $this->assertStringContainsString(
+            'system_menu_install_seed_defaults($dbm, $groups, 1);',
+            $source
+        );
+    }
+
+    #[Test]
+    public function systemModuleRegistersInstallAndUpdateHooksToSameScript(): void
+    {
+        $modversion = [];
+        require_once XOOPS_ROOT_PATH . '/modules/system/language/english/modinfo.php';
+        include XOOPS_ROOT_PATH . '/modules/system/xoops_version.php';
+
+        $this->assertSame('include/update.php', $modversion['onInstall'] ?? null);
+        $this->assertSame('include/update.php', $modversion['onUpdate'] ?? null);
+    }
+
+    #[Test]
+    public function updateScriptExposesMenuLifecycleFunctions(): void
+    {
+        require_once XOOPS_ROOT_PATH . '/modules/system/include/update.php';
+
+        $this->assertTrue(function_exists('xoops_module_install_system'));
+        $this->assertTrue(function_exists('xoops_module_update_system'));
+        $this->assertTrue(function_exists('system_menu_seed_defaults'));
+    }
+}

--- a/tests/unit/htdocs/modules/system/SystemMenuInstallationTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMenuInstallationTest.php
@@ -1,4 +1,13 @@
 <?php
+/*
+ * You may not change or alter any portion of this comment or credits
+ * of supporting developers from this source code or any supporting source code
+ * which is considered copyrighted (c) material of the original comment or credit authors.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
 
 declare(strict_types=1);
 
@@ -8,6 +17,16 @@ use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * Verifies system menu install wiring and schema expectations.
+ *
+ * @category  Xoops
+ * @package   System
+ * @author    XOOPS Development Team
+ * @copyright (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2.0 or later (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @link      https://xoops.org
+ */
 #[CoversNothing]
 final class SystemMenuInstallationTest extends TestCase
 {
@@ -88,10 +107,7 @@ final class SystemMenuInstallationTest extends TestCase
             '/CREATE TABLE menusitems \\(.*?items_id int unsigned NOT NULL auto_increment.*?items_cid int unsigned NOT NULL default \\\'0\\\'/s',
             $source
         );
-        $this->assertMatchesRegularExpression(
-            '/FOREIGN KEY \(items_cid\)\s+REFERENCES menuscategory \(category_id\)\s+ON DELETE CASCADE/s',
-            $source
-        );
+        $this->assertStringNotContainsString('FOREIGN KEY', $source);
     }
 
     #[Test]
@@ -138,6 +154,10 @@ final class SystemMenuInstallationTest extends TestCase
             "ALTER TABLE `{\$itemTable}` MODIFY `items_active` TINYINT(1) UNSIGNED NOT NULL DEFAULT 1",
             $source
         );
+        $this->assertStringContainsString(
+            'FOREIGN KEY (`items_cid`) REFERENCES `{$catTable}` (`category_id`)',
+            $source
+        );
     }
 
     #[Test]
@@ -146,7 +166,7 @@ final class SystemMenuInstallationTest extends TestCase
         $source = $this->readSourceFile('install/include/makedata.php');
 
         $this->assertStringContainsString(
-            'system_menu_install_seed_defaults($dbm, $groups, 1);',
+            'if (!system_menu_install_seed_defaults($dbm, $groups, 1)) {',
             $source
         );
     }
@@ -196,7 +216,7 @@ final class SystemMenuInstallationTest extends TestCase
         });
 
         try {
-            system_menu_install_seed_defaults(
+            $result = system_menu_install_seed_defaults(
                 $dbm,
                 [
                     'XOOPS_GROUP_ADMIN' => 1,
@@ -209,6 +229,7 @@ final class SystemMenuInstallationTest extends TestCase
             restore_error_handler();
         }
 
+        $this->assertFalse($result);
         $this->assertSame(['menuscategory'], $dbm->calls);
         $this->assertCount(1, $warnings);
         $this->assertSame(E_USER_WARNING, $warnings[0][0]);
@@ -237,7 +258,7 @@ final class SystemMenuInstallationTest extends TestCase
             }
         };
 
-        system_menu_install_seed_defaults(
+        $result = system_menu_install_seed_defaults(
             $dbm,
             [
                 'XOOPS_GROUP_ADMIN' => 1,
@@ -247,6 +268,7 @@ final class SystemMenuInstallationTest extends TestCase
             1
         );
 
+        $this->assertTrue($result);
         $byTable = array_count_values(array_column($dbm->inserts, 'table'));
         $this->assertSame(3, $byTable['menuscategory'] ?? 0);
         $this->assertSame(7, $byTable['menusitems'] ?? 0);
@@ -271,13 +293,27 @@ final class SystemMenuInstallationTest extends TestCase
             'All menu categories should be inserted before the first menu item'
         );
 
+        $categoryInserts = array_values(array_filter(
+            $dbm->inserts,
+            static fn(array $insert): bool => $insert['table'] === 'menuscategory'
+        ));
+        $accountCategoryId = null;
+        foreach ($categoryInserts as $insert) {
+            if (str_contains($insert['values'], "'MENUS_ACCOUNT'")) {
+                $accountCategoryId = $insert['id'];
+                break;
+            }
+        }
+
+        $this->assertNotNull($accountCategoryId, 'Expected to find the Account category insert');
+
         $itemInserts = array_values(array_filter(
             $dbm->inserts,
             static fn(array $insert): bool => $insert['table'] === 'menusitems'
         ));
         foreach ($itemInserts as $insert) {
             $this->assertMatchesRegularExpression(
-                "/VALUES \\(0, 2, 'MENUS_ACCOUNT_[A-Z_]+'/",
+                "/VALUES \\(0, {$accountCategoryId}, 'MENUS_ACCOUNT_[A-Z_]+'/",
                 $insert['values'],
                 'Each seeded menu item should reference the inserted Account category id'
             );

--- a/tests/unit/htdocs/modules/system/SystemMenusRegressionTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMenusRegressionTest.php
@@ -138,12 +138,12 @@ class SystemMenusRegressionTest extends TestCase
     #[Test]
     public function updateScriptSeedsToolbarWithSafeFragmentUrl(): void
     {
-        $source = $this->readSourceFile('modules/system/include/update.php');
+        $source = $this->readSourceFile('modules/system/include/menu_seed.php');
 
         $this->assertStringContainsString(
             '#xswatch-toolbar-toggle',
             $source,
-            'Toolbar seed must use fragment URL, not javascript:'
+            'Toolbar seed must use fragment URL in the shared seed definitions, not javascript:'
         );
     }
 


### PR DESCRIPTION
Fresh XOOPS installs did not create or populate `menuscategory` and `menusitems` because menu setup only ran from `modules/system/include/update.php`. As a result, menus were missing until the System module was manually updated.

Move menu setup into the real install path by:
- adding the menu tables to `htdocs/install/sql/mysql.structure.sql`
- seeding default menu rows and permissions from `htdocs/install/include/makedata.php`
- extracting shared seed definitions to `modules/system/include/menu_seed.php`

Keep the existing System module update flow as the idempotent upgrade path.
Align `system_menu_create_tables()` column types with install SQL (INT UNSIGNED for auto-increment IDs and `items_cid`, TINYINT(1) UNSIGNED for boolean flags) to avoid signedness drift between fresh installs and upgraded sites.

Add `onInstall` for the System module so reinstall flows reuse the same update logic. This hook does not fire on fresh install because the installer inserts the System module row directly via `makedata.php`, but it protects the module-admin reinstall path.

Fresh installs intentionally omit the `menusitems.items_cid -> menuscategory.category_id` foreign key from installer SQL because `SqlUtility::prefixQuery()` does not rewrite `REFERENCES ...` targets inside `CREATE TABLE` bodies. Install-time integrity is maintained by seeding categories before items, and the runtime System module update path adds/restores the foreign key with properly prefixed table names. Install-time FK parity is tracked separately in #9.

Add test coverage in `tests/unit/htdocs/modules/system/SystemMenuInstallationTest.php` covering shared seed definitions and group-key mapping, installer schema for both menu tables, update-script schema parity and runtime FK restoration, installer wiring, and behavioral verification of the `$modversion` hooks and lifecycle functions in `update.php`. Update `SystemMenusRegressionTest.php` so its toolbar fragment-URL assertion reads from the new shared seed source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System menu automatically initializes during installation with predefined categories and menu items.
  * Menu access now controlled through group-based permissions for different user types.

* **Database**
  * New tables added to support hierarchical menu structures and category organization.

* **Tests**
  * Comprehensive test coverage added for menu seeding functionality and schema migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->