### PR TITLE
fix(upgrade): skip stale patch directories and fix System module update URL

### DIFF
--- a/upgrade/class/Xoops/Upgrade/UpgradeControl.php
+++ b/upgrade/class/Xoops/Upgrade/UpgradeControl.php
@@ -235,12 +235,14 @@ class UpgradeControl
                 try {
                     $className = include $patchFile;
                 } catch (\Throwable $e) {
-                    // Skip patches that fail to load (e.g. stale directories
-                    // from a previous version with incompatible class references).
-                    $this->logs[] = sprintf(
-                        'Skipped patch %s: %s',
-                        $dir,
-                        $e->getMessage()
+                    // Stale directories from a previous version (e.g.
+                    // upd_2.5.11-to-2.5.12 from the pre-rename beta cycle) can
+                    // fail to load because they reference classes that no longer
+                    // exist. Emit a visible warning and skip — crashing the
+                    // entire upgrade is worse than skipping one broken patch.
+                    trigger_error(
+                        sprintf('Upgrade patch %s could not be loaded: %s', $dir, $e->getMessage()),
+                        E_USER_WARNING
                     );
                     continue;
                 }

--- a/upgrade/class/Xoops/Upgrade/UpgradeControl.php
+++ b/upgrade/class/Xoops/Upgrade/UpgradeControl.php
@@ -228,7 +228,22 @@ class UpgradeControl
 
         foreach ($dirs as $dir) {
             if (str_contains($dir, '-to-')) {
-                $className = include $upgradeRoot . DIRECTORY_SEPARATOR . $dir . DIRECTORY_SEPARATOR . 'index.php';
+                $patchFile = $upgradeRoot . DIRECTORY_SEPARATOR . $dir . DIRECTORY_SEPARATOR . 'index.php';
+                if (!file_exists($patchFile)) {
+                    continue;
+                }
+                try {
+                    $className = include $patchFile;
+                } catch (\Throwable $e) {
+                    // Skip patches that fail to load (e.g. stale directories
+                    // from a previous version with incompatible class references).
+                    $this->logs[] = sprintf(
+                        'Skipped patch %s: %s',
+                        $dir,
+                        $e->getMessage()
+                    );
+                    continue;
+                }
                 if (is_string($className) && class_exists($className)) {
                     $upg           = $this->createPatch($className);
                     $results[$dir] = $upg->isApplied();

--- a/upgrade/index.php
+++ b/upgrade/index.php
@@ -124,7 +124,7 @@ if (!$xoopsUser || !$xoopsUser->isAdmin()) {
     }
     if (0 === $upgradeControl->countUpgradeQueue()) {
         echo $upgradeControl->oneButtonContinueForm(
-            XOOPS_URL . '/modules/system/admin.php?fct=modulesadmin&amp;op=update&amp;module=system',
+            XOOPS_URL . '/modules/system/admin.php?fct=modulesadmin&op=update&module=system',
             [],
         );
     } else {

--- a/upgrade/upd-2.4.x-to-2.5.0/index.php
+++ b/upgrade/upd-2.4.x-to-2.5.0/index.php
@@ -81,11 +81,13 @@ class Upgrade_250 extends XoopsUpgrade
      */
     public function apply_config(): bool
     {
-        if (!file_exists($this->dbmanagerFile)) {
-            $this->logs[] = 'Database manager file not found: ' . $this->dbmanagerFile;
-            return false;
+        if (!class_exists('Db_manager', false)) {
+            if (!file_exists($this->dbmanagerFile)) {
+                $this->logs[] = 'Database manager file not found: ' . $this->dbmanagerFile;
+                return false;
+            }
+            require_once $this->dbmanagerFile;
         }
-        require_once $this->dbmanagerFile;
         $dbm = new Db_manager();
 
         $sql    = 'SELECT conf_id FROM `' . $this->db->prefix('config') . "` WHERE `conf_name` IN ('cpanel')";
@@ -199,11 +201,13 @@ class Upgrade_250 extends XoopsUpgrade
             return false;
         }
 
-        if (!file_exists($this->dbmanagerFile)) {
-            $this->logs[] = 'Database manager file not found: ' . $this->dbmanagerFile;
-            return false;
+        if (!class_exists('Db_manager', false)) {
+            if (!file_exists($this->dbmanagerFile)) {
+                $this->logs[] = 'Database manager file not found: ' . $this->dbmanagerFile;
+                return false;
+            }
+            require_once $this->dbmanagerFile;
         }
-        require_once $this->dbmanagerFile;
         $dbm  = new Db_manager();
         $time = time();
         foreach ($modversion['templates'] as $tplfile) {

--- a/upgrade/upd-2.4.x-to-2.5.0/index.php
+++ b/upgrade/upd-2.4.x-to-2.5.0/index.php
@@ -12,7 +12,9 @@
 use Xoops\Upgrade\XoopsUpgrade;
 use Xoops\Upgrade\UpgradeControl;
 
-require_once __DIR__ . '/dbmanager.php';
+if (!class_exists('Db_manager', false)) {
+    require_once __DIR__ . '/dbmanager.php';
+}
 
 /**
  * Upgrade from 2.4.x to 2.5.0

--- a/upgrade/upd_2.5.10-to-2.5.11/index.php
+++ b/upgrade/upd_2.5.10-to-2.5.11/index.php
@@ -9,7 +9,9 @@
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
-require_once XOOPS_ROOT_PATH . '/install/class/dbmanager.php';
+if (!class_exists('Db_manager', false)) {
+    require_once XOOPS_ROOT_PATH . '/install/class/dbmanager.php';
+}
 
 use Xmf\Database\Tables;
 use Xoops\Upgrade\XoopsUpgrade;


### PR DESCRIPTION
  Wrap patch file includes in buildUpgradeQueue() with try/catch so that
  stale directories from previous beta versions (e.g. upd_2.5.11-to-2.5.12
  from the pre-rename cycle) are logged and skipped instead of crashing the
  upgrade with a fatal "Class not found" error.

  Also fix double-encoding of the System module update URL at the end of
  the upgrade wizard — &amp; in the PHP string was re-encoded by
  htmlspecialchars() in oneButtonContinueForm(), producing &amp;amp; which
  broke the query parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced upgrade stability by adding error handling for patch loading; upgrades now gracefully skip problematic patches and log details instead of failing.
  * Fixed upgrade continuation form URL encoding.

* **Refactor**
  * Optimized class initialization to prevent unnecessary reloading during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->