### PR TITLE
fix(installer): remove XMF dependency from all pre-autoloader install…

### DIFF
--- a/htdocs/include/xoopssetcookie.php
+++ b/htdocs/include/xoopssetcookie.php
@@ -55,21 +55,19 @@ function xoops_setcookie(
     }
 
     // Validate the domain BEFORE using it.
-    if (class_exists('\Xoops\RegDom\RegisteredDomain')) {
-        if (!\Xoops\RegDom\RegisteredDomain::domainMatches($host, $domain)) {
-            $originalDomain = $domain;
-            $domain = ''; // Auto-correct to a safe, host-only cookie
+    if (!xoops_cookieDomainMatches($host, $domain)) {
+        $originalDomain = $domain;
+        $domain = ''; // Auto-correct to a safe, host-only cookie
 
-            if (defined('XOOPS_DEBUG_MODE') && XOOPS_DEBUG_MODE) {
-                error_log(
-                    sprintf(
-                        '[XOOPS Cookie] Invalid domain "%s" for host "%s" (cookie: %s) - using host-only.',
-                        $originalDomain,
-                        $host,
-                        $name
-                    )
-                );
-            }
+        if (defined('XOOPS_DEBUG_MODE') && XOOPS_DEBUG_MODE) {
+            error_log(
+                sprintf(
+                    '[XOOPS Cookie] Invalid domain "%s" for host "%s" (cookie: %s) - using host-only.',
+                    $originalDomain,
+                    $host,
+                    $name
+                )
+            );
         }
     }
 
@@ -91,6 +89,33 @@ function xoops_setcookie(
         $options['domain'] = $domain;
     }
     return setcookie($name, $value, $options);
+}
+
+/**
+ * Validate a cookie domain against the current host while remaining
+ * compatible with older RegDom releases that do not provide domainMatches().
+ */
+function xoops_cookieDomainMatches(string $host, string $domain): bool
+{
+    $host = strtolower(trim($host));
+    $domain = strtolower(ltrim(trim($domain), '.'));
+    if ($domain === '') {
+        return true;
+    }
+    if ($domain === 'localhost') {
+        return false;
+    }
+    if (filter_var($host, FILTER_VALIDATE_IP) || filter_var($domain, FILTER_VALIDATE_IP)) {
+        return false;
+    }
+    if (class_exists('\Xoops\RegDom\RegisteredDomain') && is_callable(['\Xoops\RegDom\RegisteredDomain', 'domainMatches'])) {
+        return \Xoops\RegDom\RegisteredDomain::domainMatches($host, $domain);
+    }
+    if ($host === $domain) {
+        return true;
+    }
+
+    return (strlen($host) > strlen($domain)) && (substr_compare($host, '.' . $domain, -1 - strlen($domain)) === 0);
 }
 
 /**

--- a/htdocs/include/xoopssetcookie.php
+++ b/htdocs/include/xoopssetcookie.php
@@ -60,13 +60,14 @@ function xoops_setcookie(
         $domain = ''; // Auto-correct to a safe, host-only cookie
 
         if (defined('XOOPS_DEBUG_MODE') && XOOPS_DEBUG_MODE) {
-            error_log(
+            trigger_error(
                 sprintf(
                     '[XOOPS Cookie] Invalid domain "%s" for host "%s" (cookie: %s) - using host-only.',
                     $originalDomain,
                     $host,
                     $name
-                )
+                ),
+                E_USER_WARNING
             );
         }
     }

--- a/htdocs/install/class/dbmanager.php
+++ b/htdocs/install/class/dbmanager.php
@@ -93,12 +93,16 @@ class Db_manager
      */
     public function queryFromFile($sql_file_path)
     {
-        $tables = [];
+        $allSucceeded = true;
 
         if (!file_exists($sql_file_path)) {
             return false;
         }
-        $sql_query = trim(fread(fopen($sql_file_path, 'r'), filesize($sql_file_path)));
+        $sql_query = file_get_contents($sql_file_path);
+        if (false === $sql_query) {
+            return false;
+        }
+        $sql_query = trim($sql_query);
         SqlUtility::splitMySqlFile($pieces, $sql_query);
         $this->db->connect();
         foreach ($pieces as $piece) {
@@ -114,6 +118,7 @@ class Db_manager
                             $this->s_tables['create'][$table] = 1;
                         }
                     } else {
+                        $allSucceeded = false;
                         if (!isset($this->f_tables['create'][$table])) {
                             $this->f_tables['create'][$table] = 1;
                         }
@@ -126,6 +131,7 @@ class Db_manager
                             $this->s_tables['insert'][$table]++;
                         }
                     } else {
+                        $allSucceeded = false;
                         if (!isset($this->f_tables['insert'][$table])) {
                             $this->f_tables['insert'][$table] = 1;
                         } else {
@@ -138,7 +144,8 @@ class Db_manager
                             $this->s_tables['alter'][$table] = 1;
                         }
                     } else {
-                        if (!isset($this->s_tables['alter'][$table])) {
+                        $allSucceeded = false;
+                        if (!isset($this->f_tables['alter'][$table])) {
                             $this->f_tables['alter'][$table] = 1;
                         }
                     }
@@ -148,6 +155,7 @@ class Db_manager
                             $this->s_tables['drop'][$table] = 1;
                         }
                     } else {
+                        $allSucceeded = false;
                         if (!isset($this->s_tables['drop'][$table])) {
                             $this->f_tables['drop'][$table] = 1;
                         }
@@ -156,7 +164,7 @@ class Db_manager
             }
         }
 
-        return true;
+        return $allSucceeded;
     }
 
     public array $successStrings = [
@@ -273,7 +281,7 @@ class Db_manager
      */
     public function isError()
     {
-        return isset($this->f_tables) ? true : false;
+        return !empty($this->f_tables);
     }
 
     /**

--- a/htdocs/install/class/dbmanager.php
+++ b/htdocs/install/class/dbmanager.php
@@ -156,7 +156,7 @@ class Db_manager
                         }
                     } else {
                         $allSucceeded = false;
-                        if (!isset($this->s_tables['drop'][$table])) {
+                        if (!isset($this->f_tables['drop'][$table])) {
                             $this->f_tables['drop'][$table] = 1;
                         }
                     }

--- a/htdocs/install/class/installwizard.php
+++ b/htdocs/install/class/installwizard.php
@@ -189,6 +189,7 @@ class XoopsInstallWizard
 
         if ($this->pageIndex > 0 && empty($_COOKIE['xo_install_lang'])) {
             header('Location: index.php');
+            exit;
         }
 
         return $this->pageIndex;

--- a/htdocs/install/class/installwizard.php
+++ b/htdocs/install/class/installwizard.php
@@ -128,7 +128,8 @@ class XoopsInstallWizard
             return true;
         }
 
-        if (empty($GLOBALS['xoopsUser']) && !empty($_COOKIE['xo_install_user'])) {
+        $installUserCookie = $_COOKIE['xo_install_user'] ?? '';
+        if (empty($GLOBALS['xoopsUser']) && is_string($installUserCookie) && $installUserCookie !== '') {
             return install_acceptUser();
         }
         if (empty($GLOBALS['xoopsUser'])) {

--- a/htdocs/install/class/installwizard.php
+++ b/htdocs/install/class/installwizard.php
@@ -128,7 +128,9 @@ class XoopsInstallWizard
             return true;
         }
 
-        $installUser = \Xmf\Request::getString('xo_install_user', '', 'COOKIE');
+        // Raw $_COOKIE — XMF autoloader may not be available on early
+        // install pages when xoops_lib has been relocated.
+        $installUser = isset($_COOKIE['xo_install_user']) ? trim((string) $_COOKIE['xo_install_user']) : '';
         if (empty($GLOBALS['xoopsUser']) && !empty($installUser)) {
             return install_acceptUser($installUser);
         }
@@ -185,7 +187,7 @@ class XoopsInstallWizard
             return false;
         }
 
-        if ($this->pageIndex > 0 && !\Xmf\Request::hasVar('xo_install_lang', 'COOKIE')) {
+        if ($this->pageIndex > 0 && empty($_COOKIE['xo_install_lang'])) {
             header('Location: index.php');
         }
 

--- a/htdocs/install/class/installwizard.php
+++ b/htdocs/install/class/installwizard.php
@@ -128,11 +128,8 @@ class XoopsInstallWizard
             return true;
         }
 
-        // Raw $_COOKIE — XMF autoloader may not be available on early
-        // install pages when xoops_lib has been relocated.
-        $installUser = isset($_COOKIE['xo_install_user']) ? trim((string) $_COOKIE['xo_install_user']) : '';
-        if (empty($GLOBALS['xoopsUser']) && !empty($installUser)) {
-            return install_acceptUser($installUser);
+        if (empty($GLOBALS['xoopsUser']) && !empty($_COOKIE['xo_install_user'])) {
+            return install_acceptUser();
         }
         if (empty($GLOBALS['xoopsUser'])) {
             redirect_header('../user.php');

--- a/htdocs/install/class/installwizard.php
+++ b/htdocs/install/class/installwizard.php
@@ -185,7 +185,8 @@ class XoopsInstallWizard
             return false;
         }
 
-        if ($this->pageIndex > 0 && empty($_COOKIE['xo_install_lang'])) {
+        $installLanguageCookie = $_COOKIE['xo_install_lang'] ?? null;
+        if ($this->pageIndex > 0 && (!is_string($installLanguageCookie) || '' === $installLanguageCookie)) {
             header('Location: index.php');
             exit;
         }

--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -233,6 +233,62 @@ class PathController
         return false; // Return false for invalid paths
     }
 
+    /**
+     * Determine whether the given PHP source contains an executable
+     * XOOPS_VERSION definition.
+     *
+     * @param string $source
+     *
+     * @return bool
+     */
+    private function hasXoopsVersionDefinition($source)
+    {
+        $tokens = token_get_all($source);
+        $count  = count($tokens);
+
+        for ($i = 0; $i < $count; ++$i) {
+            if (!is_array($tokens[$i]) || $tokens[$i][0] !== T_STRING || strtolower($tokens[$i][1]) !== 'define') {
+                continue;
+            }
+            $openParenIndex = $this->nextSignificantTokenIndex($tokens, $i + 1);
+            if (null === $openParenIndex || '(' !== $tokens[$openParenIndex]) {
+                continue;
+            }
+            $nameIndex = $this->nextSignificantTokenIndex($tokens, $openParenIndex + 1);
+            if (null === $nameIndex || !is_array($tokens[$nameIndex]) || $tokens[$nameIndex][0] !== T_CONSTANT_ENCAPSED_STRING) {
+                continue;
+            }
+            if ('XOOPS_VERSION' === trim($tokens[$nameIndex][1], "\"'")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Find the next non-whitespace/comment token.
+     *
+     * @param array<int, mixed> $tokens
+     * @param int               $startIndex
+     *
+     * @return int|null
+     */
+    private function nextSignificantTokenIndex(array $tokens, $startIndex)
+    {
+        $count = count($tokens);
+        for ($i = $startIndex; $i < $count; ++$i) {
+            if (!is_array($tokens[$i])) {
+                return $i;
+            }
+            if (!in_array($tokens[$i][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                return $i;
+            }
+        }
+
+        return null;
+    }
+
     //========================================
     public function execute()
     {
@@ -339,13 +395,10 @@ class PathController
             if (is_dir($this->xoopsPath[$path]) && is_readable($this->xoopsPath[$path])) {
                 $versionFile = "{$this->xoopsPath[$path]}/include/version.php";
                 $distFile    = "{$this->xoopsPath[$path]}/mainfile.dist.php";
-                if (file_exists($versionFile) && is_readable($versionFile)) {
+                if (is_file($versionFile) && is_readable($versionFile)) {
                     $versionContents = file_get_contents($versionFile);
-                    if (false !== $versionContents) {
-                        $versionPattern = "/define\\s*\\(\\s*['\"]XOOPS_VERSION['\"]\\s*,\\s*['\"][^'\"]+['\"]\\s*\\)/";
-                        if (preg_match($versionPattern, $versionContents) && file_exists($distFile) && is_readable($distFile)) {
-                            $this->validPath[$path] = 1;
-                        }
+                    if (false !== $versionContents && $this->hasXoopsVersionDefinition($versionContents) && is_file($distFile) && is_readable($distFile)) {
+                        $this->validPath[$path] = 1;
                     }
                 }
             }
@@ -360,6 +413,7 @@ class PathController
                 && is_file($autoloader)
                 && is_readable($autoloader)
                 && is_file($xmfMarker)
+                && is_readable($xmfMarker)
             ) {
                 $this->validPath[$path] = 1;
             } else {

--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -245,10 +245,17 @@ class PathController
             $_SESSION['settings']['URL']           = $this->xoopsUrl;
             $_SESSION['settings']['COOKIE_DOMAIN'] = $this->xoopsCookieDomain;
             if ($valid) {
+                // Sync TRUST_PATH from lib — common.inc.php loads the Composer
+                // autoloader from TRUST_PATH, not PATH. Only set on valid POST
+                // so a bad submission doesn't poison the session.
+                if (!empty($this->xoopsPath['lib'])) {
+                    $_SESSION['settings']['TRUST_PATH'] = $this->xoopsPath['lib'];
+                }
                 $GLOBALS['wizard']->redirectToPage('+1');
             } else {
                 $GLOBALS['wizard']->redirectToPage('+0');
             }
+            exit;
         }
     }
 

--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -249,9 +249,13 @@ class PathController
             if ($valid) {
                 // Sync TRUST_PATH only on valid POST — common.inc.php loads
                 // the Composer autoloader from TRUST_PATH, not PATH. A bad
-                // lib path must not poison TRUST_PATH.
-                if (!empty($this->xoopsPath['lib'])) {
-                    $_SESSION['settings']['TRUST_PATH'] = $this->xoopsPath['lib'];
+                // lib path must not poison TRUST_PATH. Canonicalize it before
+                // storing it so later bootstrap code gets an absolute path.
+                $trustPath = $this->sanitizePath($this->xoopsPath['lib']);
+                if (false !== $trustPath) {
+                    $this->xoopsPath['lib']             = $trustPath;
+                    $_SESSION['settings']['PATH']       = $trustPath;
+                    $_SESSION['settings']['TRUST_PATH'] = $trustPath;
                 }
                 $GLOBALS['wizard']->redirectToPage('+1');
             } else {

--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -239,15 +239,14 @@ class PathController
         $this->readRequest();
         $valid = $this->validate();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            foreach ($this->path_lookup as $req => $sess) {
-                $_SESSION['settings'][$sess] = $this->xoopsPath[$req];
-            }
-            $_SESSION['settings']['URL']           = $this->xoopsUrl;
-            $_SESSION['settings']['COOKIE_DOMAIN'] = $this->xoopsCookieDomain;
             if ($valid) {
+                foreach ($this->path_lookup as $req => $sess) {
+                    $_SESSION['settings'][$sess] = $this->xoopsPath[$req];
+                }
+                $_SESSION['settings']['URL']           = $this->xoopsUrl;
+                $_SESSION['settings']['COOKIE_DOMAIN'] = $this->xoopsCookieDomain;
                 // Sync TRUST_PATH from lib — common.inc.php loads the Composer
-                // autoloader from TRUST_PATH, not PATH. Only set on valid POST
-                // so a bad submission doesn't poison the session.
+                // autoloader from TRUST_PATH, not PATH.
                 if (!empty($this->xoopsPath['lib'])) {
                     $_SESSION['settings']['TRUST_PATH'] = $this->xoopsPath['lib'];
                 }

--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -331,13 +331,15 @@ class PathController
         $ret = 1;
         if ($PATH === 'root' || empty($PATH)) {
             $path = 'root';
+            $this->validPath[$path] = 0;
             if (is_dir($this->xoopsPath[$path]) && is_readable($this->xoopsPath[$path])) {
                 $versionFile = "{$this->xoopsPath[$path]}/include/version.php";
-                if (file_exists($versionFile)) {
+                $distFile    = "{$this->xoopsPath[$path]}/mainfile.dist.php";
+                if (file_exists($versionFile) && is_readable($versionFile)) {
                     $versionContents = file_get_contents($versionFile);
                     if (false !== $versionContents) {
                         $versionPattern = "/define\\s*\\(\\s*['\"]XOOPS_VERSION['\"]\\s*,\\s*['\"][^'\"]+['\"]\\s*\\)/";
-                        if (preg_match($versionPattern, $versionContents) && file_exists("{$this->xoopsPath[$path]}/mainfile.dist.php")) {
+                        if (preg_match($versionPattern, $versionContents) && file_exists($distFile) && is_readable($distFile)) {
                             $this->validPath[$path] = 1;
                         }
                     }
@@ -348,10 +350,12 @@ class PathController
         if ($PATH === 'lib' || empty($PATH)) {
             $path = 'lib';
             $autoloader = $this->xoopsPath[$path] . '/vendor/autoload.php';
+            $xmfMarker = $this->xoopsPath[$path] . '/vendor/xoops/xmf/src/Request.php';
             if (is_dir($this->xoopsPath[$path])
                 && is_readable($this->xoopsPath[$path])
                 && is_file($autoloader)
                 && is_readable($autoloader)
+                && is_file($xmfMarker)
             ) {
                 $this->validPath[$path] = 1;
             } else {
@@ -363,6 +367,8 @@ class PathController
             $path = 'data';
             if (is_dir($this->xoopsPath[$path]) && is_readable($this->xoopsPath[$path])) {
                 $this->validPath[$path] = 1;
+            } else {
+                $this->validPath[$path] = 0;
             }
             $ret *= $this->validPath[$path];
         }

--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -303,6 +303,13 @@ class PathController
             $_SESSION['settings']['URL']           = $this->xoopsUrl;
             $_SESSION['settings']['COOKIE_DOMAIN'] = $this->xoopsCookieDomain;
             if ($valid) {
+                foreach ($this->path_lookup as $req => $sess) {
+                    $canonicalPath = $this->sanitizePath($this->xoopsPath[$req]);
+                    if (false !== $canonicalPath) {
+                        $this->xoopsPath[$req] = $canonicalPath;
+                        $_SESSION['settings'][$sess] = $canonicalPath;
+                    }
+                }
                 // Sync TRUST_PATH only on valid POST — common.inc.php loads
                 // the Composer autoloader from TRUST_PATH, not PATH. A bad
                 // lib path must not poison TRUST_PATH. Canonicalize it before

--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -245,9 +245,25 @@ class PathController
     {
         $tokens = token_get_all($source);
         $count  = count($tokens);
+        $depth  = 0;
 
         for ($i = 0; $i < $count; ++$i) {
+            if (is_string($tokens[$i])) {
+                if ('{' === $tokens[$i]) {
+                    ++$depth;
+                } elseif ('}' === $tokens[$i] && $depth > 0) {
+                    --$depth;
+                }
+                continue;
+            }
             if (!is_array($tokens[$i]) || $tokens[$i][0] !== T_STRING || strtolower($tokens[$i][1]) !== 'define') {
+                continue;
+            }
+            if ($depth > 0) {
+                continue;
+            }
+            $previousIndex = $this->nextSignificantTokenIndexReverse($tokens, $i - 1);
+            if (null !== $previousIndex && is_array($tokens[$previousIndex]) && in_array($tokens[$previousIndex][0], [T_OBJECT_OPERATOR, T_DOUBLE_COLON], true)) {
                 continue;
             }
             $openParenIndex = $this->nextSignificantTokenIndex($tokens, $i + 1);
@@ -278,6 +294,28 @@ class PathController
     {
         $count = count($tokens);
         for ($i = $startIndex; $i < $count; ++$i) {
+            if (!is_array($tokens[$i])) {
+                return $i;
+            }
+            if (!in_array($tokens[$i][0], [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true)) {
+                return $i;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find the previous non-whitespace/comment token.
+     *
+     * @param array<int, mixed> $tokens
+     * @param int               $startIndex
+     *
+     * @return int|null
+     */
+    private function nextSignificantTokenIndexReverse(array $tokens, $startIndex)
+    {
+        for ($i = $startIndex; $i >= 0; --$i) {
             if (!is_array($tokens[$i])) {
                 return $i;
             }
@@ -333,7 +371,7 @@ class PathController
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $request = $_POST;
             foreach ($this->path_lookup as $req => $sess) {
-                if (isset($request[$req])) {
+                if (isset($request[$req]) && is_string($request[$req])) {
                     $request[$req] = str_replace("\\", '/', trim($request[$req]));
                     if (substr($request[$req], -1) === '/') {
                         $request[$req] = substr($request[$req], 0, -1);
@@ -341,14 +379,14 @@ class PathController
                     $this->xoopsPath[$req] = $request[$req];
                 }
             }
-            if (isset($request['URL'])) {
+            if (isset($request['URL']) && is_string($request['URL'])) {
                 $request['URL'] = trim($request['URL']);
                 if (substr($request['URL'], -1) === '/') {
                     $request['URL'] = substr($request['URL'], 0, -1);
                 }
                 $this->xoopsUrl = $request['URL'];
             }
-            if (isset($request['COOKIE_DOMAIN'])) {
+            if (isset($request['COOKIE_DOMAIN']) && is_string($request['COOKIE_DOMAIN'])) {
                 $tempCookieDomain = trim($request['COOKIE_DOMAIN']);
                 $tempParts        = parse_url($tempCookieDomain);
                 if (!empty($tempParts['host'])) {

--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -334,10 +334,13 @@ class PathController
             if (is_dir($this->xoopsPath[$path]) && is_readable($this->xoopsPath[$path])) {
                 $versionFile = "{$this->xoopsPath[$path]}/include/version.php";
                 if (file_exists($versionFile)) {
-                    include_once $versionFile;
-                }
-                if (defined('XOOPS_VERSION') && file_exists("{$this->xoopsPath[$path]}/mainfile.dist.php")) {
-                    $this->validPath[$path] = 1;
+                    $versionContents = file_get_contents($versionFile);
+                    if (false !== $versionContents) {
+                        $versionPattern = "/define\\s*\\(\\s*['\"]XOOPS_VERSION['\"]\\s*,\\s*['\"][^'\"]+['\"]\\s*\\)/";
+                        if (preg_match($versionPattern, $versionContents) && file_exists("{$this->xoopsPath[$path]}/mainfile.dist.php")) {
+                            $this->validPath[$path] = 1;
+                        }
+                    }
                 }
             }
             $ret *= $this->validPath[$path];

--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -239,14 +239,17 @@ class PathController
         $this->readRequest();
         $valid = $this->validate();
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            // Always persist submitted paths so the form repopulates on
+            // validation failure (redirect back to this page).
+            foreach ($this->path_lookup as $req => $sess) {
+                $_SESSION['settings'][$sess] = $this->xoopsPath[$req];
+            }
+            $_SESSION['settings']['URL']           = $this->xoopsUrl;
+            $_SESSION['settings']['COOKIE_DOMAIN'] = $this->xoopsCookieDomain;
             if ($valid) {
-                foreach ($this->path_lookup as $req => $sess) {
-                    $_SESSION['settings'][$sess] = $this->xoopsPath[$req];
-                }
-                $_SESSION['settings']['URL']           = $this->xoopsUrl;
-                $_SESSION['settings']['COOKIE_DOMAIN'] = $this->xoopsCookieDomain;
-                // Sync TRUST_PATH from lib — common.inc.php loads the Composer
-                // autoloader from TRUST_PATH, not PATH.
+                // Sync TRUST_PATH only on valid POST — common.inc.php loads
+                // the Composer autoloader from TRUST_PATH, not PATH. A bad
+                // lib path must not poison TRUST_PATH.
                 if (!empty($this->xoopsPath['lib'])) {
                     $_SESSION['settings']['TRUST_PATH'] = $this->xoopsPath['lib'];
                 }

--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -335,9 +335,11 @@ class PathController
         }
         if ($PATH === 'lib' || empty($PATH)) {
             $path = 'lib';
+            $autoloader = $this->xoopsPath[$path] . '/vendor/autoload.php';
             if (is_dir($this->xoopsPath[$path])
                 && is_readable($this->xoopsPath[$path])
-                && is_file($this->xoopsPath[$path] . '/vendor/autoload.php')
+                && is_file($autoloader)
+                && is_readable($autoloader)
             ) {
                 $this->validPath[$path] = 1;
             } else {

--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -335,8 +335,13 @@ class PathController
         }
         if ($PATH === 'lib' || empty($PATH)) {
             $path = 'lib';
-            if (is_dir($this->xoopsPath[$path]) && is_readable($this->xoopsPath[$path])) {
+            if (is_dir($this->xoopsPath[$path])
+                && is_readable($this->xoopsPath[$path])
+                && is_file($this->xoopsPath[$path] . '/vendor/autoload.php')
+            ) {
                 $this->validPath[$path] = 1;
+            } else {
+                $this->validPath[$path] = 0;
             }
             $ret *= $this->validPath[$path];
         }

--- a/htdocs/install/include/functions.php
+++ b/htdocs/install/include/functions.php
@@ -26,7 +26,7 @@ function installerHtmlSpecialChars($value = '')
     return htmlspecialchars($value, ENT_QUOTES, _INSTALL_CHARSET, true);
 }
 
-function install_acceptUser($hash = '')
+function install_acceptUser()
 {
     $GLOBALS['xoopsUser'] = null;
     $assertClaims = [

--- a/htdocs/install/include/functions.php
+++ b/htdocs/install/include/functions.php
@@ -12,8 +12,6 @@
  * @author           Skalpa Keo <skalpa@xoops.org>
  * @author           Taiwen Jiang <phppp@users.sourceforge.net>
  * @author           DuGris (aka L. JEN) <dugris@frxoops.org>
- * @param string $hash
- * @return bool
  */
 
 /**

--- a/htdocs/install/include/makedata.php
+++ b/htdocs/install/include/makedata.php
@@ -79,7 +79,7 @@ function system_menu_install_seed_defaults($dbm, array $groups, int $moduleId): 
             . (int) $definition['active']
             . ')'
         );
-        if (!$categoryId) {
+        if (false === $categoryId) {
             trigger_error(
                 sprintf('Failed to seed menu category "%s" during install.', $definition['title']),
                 E_USER_WARNING
@@ -89,7 +89,7 @@ function system_menu_install_seed_defaults($dbm, array $groups, int $moduleId): 
         $categoryIds[$key] = (int) $categoryId;
 
         foreach (system_menu_map_group_keys($definition['group_keys'], $groupMap) as $groupId) {
-            if (!$dbm->insert(
+            if (false === $dbm->insert(
                 'group_permission',
                 ' (gperm_id, gperm_groupid, gperm_itemid, gperm_modid, gperm_name) VALUES (0, ' . $groupId . ', ' . (int) $categoryId . ', ' . $moduleId . ", 'menus_category_view')"
             )) {
@@ -118,7 +118,7 @@ function system_menu_install_seed_defaults($dbm, array $groups, int $moduleId): 
             . (int) $definition['active']
             . ')'
         );
-        if (!$itemId) {
+        if (false === $itemId) {
             trigger_error(
                 sprintf('Failed to seed menu item "%s" during install.', $definition['title']),
                 E_USER_WARNING
@@ -127,7 +127,7 @@ function system_menu_install_seed_defaults($dbm, array $groups, int $moduleId): 
         }
 
         foreach (system_menu_map_group_keys($definition['group_keys'], $groupMap) as $groupId) {
-            if (!$dbm->insert(
+            if (false === $dbm->insert(
                 'group_permission',
                 ' (gperm_id, gperm_groupid, gperm_itemid, gperm_modid, gperm_name) VALUES (0, ' . $groupId . ', ' . (int) $itemId . ', ' . $moduleId . ", 'menus_items_view')"
             )) {
@@ -416,7 +416,7 @@ function make_data($dbm, $adminname, $hashedAdminPass, $adminmail, $language, $g
     $dbm->insert('config', $cfgCols . " VALUES (128, 1, 0, 'general_editor', '_MI_SYSTEM_PREFERENCE_GENERAL_EDITOR', 'dhtmltextarea', '_MI_SYSTEM_PREFERENCE_GENERAL_EDITOR_DSC', 'select', 'text', 320)");
     $dbm->insert('config', $cfgCols . " VALUES (129, 1, 0, 'redirect', '_MI_SYSTEM_PREFERENCE_REDIRECT', 'admin.php?fct=preferences', '', 'hidden', 'text', 330)");
     $dbm->insert('config', $cfgCols . " VALUES (130, 1, 0, 'com_anonpost', '_MI_SYSTEM_PREFERENCE_ANONPOST', '', '', 'hidden', 'text', 340)");
-    $dbm->insert('config', $cfgCols . " VALUES (133, 1, 0, 'jquery_theme', '_MI_SYSTEM_PREFERENCE_JQUERY_THEME', 'base', '', 'select', 'text', 35)");
+    $dbm->insert('config', $cfgCols . " VALUES (131, 1, 0, 'jquery_theme', '_MI_SYSTEM_PREFERENCE_JQUERY_THEME', 'base', '', 'select', 'text', 35)");
 
     $dbm->insert('config', $cfgCols . " VALUES (134, 0, 1, 'redirect_message_ajax', '_MD_AM_CUSTOM_REDIRECT', '1', '_MD_AM_CUSTOM_REDIRECT_DESC', 'yesno', 'int', 12)");
     //notification method
@@ -424,6 +424,7 @@ function make_data($dbm, $adminname, $hashedAdminPass, $adminmail, $language, $g
     // Session cookie preferences (2.7.0)
     $dbm->insert('config', $cfgCols . " VALUES (136, 0, 1, 'session_cookie_samesite', '_MD_AM_SESSSAMESITE', 'Lax', '_MD_AM_SESSSAMESITE_DSC', 'select', 'text', 43)");
     $dbm->insert('config', $cfgCols . " VALUES (137, 0, 1, 'session_cookie_secure', '_MD_AM_SESSSECURE', '0', '_MD_AM_SESSSECURE_DSC', 'yesno', 'int', 44)");
+    $dbm->insert('config', $cfgCols . " VALUES (138, 1, 0, 'active_menus', '_MI_SYSTEM_MENUS_ACTIVE', '1', '_MI_SYSTEM_MENUS_ACTIVE_DESC', 'yesno', 'int', 145)");
 
     require_once XOOPS_ROOT_PATH . '/class/xoopslists.php';
     $editors = XoopsLists::getDirListAsArray(XOOPS_ROOT_PATH . '/class/xoopseditor');

--- a/htdocs/install/include/makedata.php
+++ b/htdocs/install/include/makedata.php
@@ -453,7 +453,7 @@ function make_data($dbm, $adminname, $hashedAdminPass, $adminmail, $language, $g
     }
     $jqueryui = XoopsLists::getDirListAsArray(XOOPS_ROOT_PATH . '/modules/system/css/ui');
     foreach ($jqueryui as $dir) {
-        $dbm->insert('configoption', ' (confop_id, confop_name, confop_value, conf_id) VALUES (' . $conf . ", '" . $dir . "', '" . $dir . "', 133)");
+        $dbm->insert('configoption', ' (confop_id, confop_name, confop_value, conf_id) VALUES (' . $conf . ", '" . $dir . "', '" . $dir . "', 131)");
         ++$conf;
     }
     //notification method

--- a/htdocs/install/page_langselect.php
+++ b/htdocs/install/page_langselect.php
@@ -68,7 +68,8 @@ EOT;
 $languages = getDirList(XOOPS_INSTALL_PATH . '/language/');
 foreach ($languages as $lang) {
     $sel = ($lang == $wizard->language) ? ' selected' : '';
-    $content .= "<option value=\"{$lang}\"{$sel}>{$lang}</option>\n";
+    $escapedLang = installerHtmlSpecialChars($lang);
+    $content .= "<option value=\"{$escapedLang}\"{$sel}>{$escapedLang}</option>\n";
 }
 $content .=<<<EOB
     </select>

--- a/htdocs/install/page_langselect.php
+++ b/htdocs/install/page_langselect.php
@@ -30,8 +30,10 @@ require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
 xoops_setcookie('xo_install_lang', 'english', 0, '', '');
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && \Xmf\Request::hasVar('lang', 'POST')) {
-    $lang = \Xmf\Request::getString('lang', '', 'POST');
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['lang'])) {
+    // Raw $_POST here — XMF autoloader is not available until the user
+    // configures the xoops_lib path on the pathsettings page (page 4).
+    $lang = trim((string) $_POST['lang']);
     xoops_setcookie('xo_install_lang', $lang, 0, '', '');
 
     $wizard->redirectToPage('+1');

--- a/htdocs/install/page_langselect.php
+++ b/htdocs/install/page_langselect.php
@@ -30,12 +30,19 @@ require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
 xoops_setcookie('xo_install_lang', 'english', 0, '', '');
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['lang'])) {
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // Raw $_POST here — XMF autoloader is not available until the user
     // configures the xoops_lib path on the pathsettings page (page 4).
     // Validate using the same pattern as initLanguage() — strip invalid
     // characters and verify the language directory exists.
-    $lang = preg_replace('/[^a-z0-9_\-]/i', '', trim((string) $_POST['lang']));
+    $rawLang = $_POST['lang'] ?? '';
+    $lang    = 'english';
+    if (is_string($rawLang) && $rawLang !== '') {
+        $lang = preg_replace('/[^a-z0-9_\-]/i', '', trim($rawLang));
+        if (!is_string($lang) || $lang === '' || !file_exists(XOOPS_INSTALL_PATH . "/language/{$lang}/install.php")) {
+            $lang = 'english';
+        }
+    }
     if (!file_exists(XOOPS_INSTALL_PATH . "/language/{$lang}/install.php")) {
         $lang = 'english';
     }

--- a/htdocs/install/page_langselect.php
+++ b/htdocs/install/page_langselect.php
@@ -57,7 +57,8 @@ $content =<<<EOT
     <select name="lang" id="lang" class="form-control">
 EOT;
 
-$languages = getDirList(__DIR__ . '/../language/');
+// List installer languages (not site languages) to match initLanguage() validation
+$languages = getDirList(XOOPS_INSTALL_PATH . '/language/');
 foreach ($languages as $lang) {
     $sel = ($lang == $wizard->language) ? ' selected' : '';
     $content .= "<option value=\"{$lang}\"{$sel}>{$lang}</option>\n";

--- a/htdocs/install/page_langselect.php
+++ b/htdocs/install/page_langselect.php
@@ -33,7 +33,12 @@ xoops_setcookie('xo_install_lang', 'english', 0, '', '');
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['lang'])) {
     // Raw $_POST here — XMF autoloader is not available until the user
     // configures the xoops_lib path on the pathsettings page (page 4).
-    $lang = trim((string) $_POST['lang']);
+    // Validate using the same pattern as initLanguage() — strip invalid
+    // characters and verify the language directory exists.
+    $lang = preg_replace('/[^a-z0-9_\-]/i', '', trim((string) $_POST['lang']));
+    if (!file_exists(XOOPS_INSTALL_PATH . "/language/{$lang}/install.php")) {
+        $lang = 'english';
+    }
     xoops_setcookie('xo_install_lang', $lang, 0, '', '');
 
     $wizard->redirectToPage('+1');

--- a/htdocs/install/page_pathsettings.php
+++ b/htdocs/install/page_pathsettings.php
@@ -36,10 +36,11 @@ $pageHasHelp = true;
 
 $pathController = new PathController($wizard->configs['xoopsPathDefault'], $wizard->configs['dataPath']);
 
-// Handle GET request for AJAX path checking (read-only validation).
+// Handle GET request for AJAX path checking (validation only).
 // Raw $_GET — XMF autoloader is not available until the user enters the
-// xoops_lib path on THIS page. This handler only validates; it does NOT
-// write session state or include PHP files from the submitted path.
+// xoops_lib path on THIS page. This handler validates and returns HTML
+// status. It does not write session state. Note: checkPath('root') does
+// include version.php from the validated root path to verify XOOPS_VERSION.
 $allowedPathKeys = ['root', 'data', 'lib'];
 if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['var'], $_GET['action']) && $_GET['action'] === 'checkpath') {
     $pathKey = trim((string) ($_GET['var'] ?? ''));
@@ -58,9 +59,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['var'], $_GET['action'])
         exit();
     }
 
-    // For the library path, verify the Composer autoloader is present
-    if ($pathKey === 'lib' && !is_file($newPath . '/vendor/autoload.php')) {
-        echo 'Error: Could not find vendor/autoload.php in the specified library path.';
+    // For the library path, verify the Composer autoloader is present and readable
+    $autoloader = $newPath . '/vendor/autoload.php';
+    if ($pathKey === 'lib' && (!is_file($autoloader) || !is_readable($autoloader))) {
+        echo 'Error: Could not find or read vendor/autoload.php in the specified library path.';
         exit();
     }
 
@@ -74,6 +76,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['var'], $_GET['action'])
 // exist inside the lib directory. If it's missing, execute() will redirect
 // back to this page instead of advancing to page 5.
 $pathController->execute();
+
+// execute() stores the lib path in $_SESSION['settings']['PATH'] (via
+// path_lookup), but common.inc.php loads the autoloader from TRUST_PATH.
+// Sync them so pages 5+ can find the autoloader.
+if (!empty($pathController->xoopsPath['lib'])) {
+    if (!isset($_SESSION['settings']['TRUST_PATH']) || $_SESSION['settings']['TRUST_PATH'] !== $pathController->xoopsPath['lib']) {
+        $_SESSION['settings']['TRUST_PATH'] = $pathController->xoopsPath['lib'];
+    }
+}
 
 ob_start();
 ?>

--- a/htdocs/install/page_pathsettings.php
+++ b/htdocs/install/page_pathsettings.php
@@ -119,7 +119,7 @@ ob_start();
             <div class="form-group">
                 <label class="xolabel" for="root"><?php echo XOOPS_ROOT_PATH_LABEL; ?></label>
                 <div class="xoform-help alert alert-info"><?php echo XOOPS_ROOT_PATH_HELP; ?></div>
-                <input type="text" class="form-control" name="root" id="root" value="<?php echo $pathController->xoopsPath['root']; ?>" onchange="updPath('root', this.value)"/>
+                <input type="text" class="form-control" name="root" id="root" value="<?php echo htmlspecialchars($pathController->xoopsPath['root'], ENT_QUOTES, 'UTF-8'); ?>" onchange="updPath('root', this.value)"/>
                 <span id="rootpathimg"><?php echo genPathCheckHtml('root', $pathController->validPath['root']); ?></span>
             </div>
 
@@ -144,7 +144,7 @@ ob_start();
             <div class="form-group">
                 <label for="data"><?php echo XOOPS_DATA_PATH_LABEL; ?></label>
                 <div class="xoform-help alert alert-info"><?php echo XOOPS_DATA_PATH_HELP; ?></div>
-                <input type="text" class="form-control" name="data" id="data" value="<?php echo $pathController->xoopsPath['data']; ?>" onchange="updPath('data', this.value)"/>
+                <input type="text" class="form-control" name="data" id="data" value="<?php echo htmlspecialchars($pathController->xoopsPath['data'], ENT_QUOTES, 'UTF-8'); ?>" onchange="updPath('data', this.value)"/>
                 <span id="datapathimg"><?php echo genPathCheckHtml('data', $pathController->validPath['data']); ?></span>
             </div>
             <?php
@@ -168,7 +168,7 @@ ob_start();
             <div class="form-group">
                 <label class="xolabel" for="lib"><?php echo XOOPS_LIB_PATH_LABEL; ?></label>
                 <div class="xoform-help alert alert-info"><?php echo XOOPS_LIB_PATH_HELP; ?></div>
-                <input type="text" class="form-control" name="lib" id="lib" value="<?php echo $pathController->xoopsPath['lib']; ?>" onchange="updPath('lib', this.value)"/>
+                <input type="text" class="form-control" name="lib" id="lib" value="<?php echo htmlspecialchars($pathController->xoopsPath['lib'], ENT_QUOTES, 'UTF-8'); ?>" onchange="updPath('lib', this.value)"/>
                 <span id="libpathimg"><?php echo genPathCheckHtml('lib', $pathController->validPath['lib']); ?></span>
             </div>
 

--- a/htdocs/install/page_pathsettings.php
+++ b/htdocs/install/page_pathsettings.php
@@ -36,158 +36,51 @@ $pageHasHelp = true;
 
 $pathController = new PathController($wizard->configs['xoopsPathDefault'], $wizard->configs['dataPath']);
 
-//if ($_SERVER['REQUEST_METHOD'] === 'GET' && @$_GET['var'] && Xmf\Request::getString('action', '', 'GET') === 'checkpath') {
-//    $path                   = $_GET['var'];
-//    $pathController->xoopsPath[$path] = htmlspecialchars(trim($_GET['path']), ENT_QUOTES | ENT_HTML5);
-//    echo genPathCheckHtml($path, $pathController->checkPath($path));
-//    exit();
-//}
-
-// install/page_pathsettings.php
-
-/*
-
-if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['var']) && isset($_GET['action']) && $_GET['action'] === 'checkpath') {
-    // Sanitize the input
-    $pathKey = htmlspecialchars(trim($_GET['var']), ENT_QUOTES | ENT_HTML5);
-    $newPath = htmlspecialchars(trim($_GET['path']), ENT_QUOTES | ENT_HTML5);
-
-    // Perform basic validation for the new path
-    if (!is_dir($newPath)) {
-        echo "Error: The specified path does not exist. Please verify the folder and try again.";
-        exit();
-    }
-
-    // Update the XOOPS_TRUST_PATH dynamically if it's the library path
-    if ($pathKey === 'lib') {
-        // Update session and constant
-        $_SESSION['settings']['TRUST_PATH'] = $newPath;
-
-        if (!defined('XOOPS_TRUST_PATH')) {
-            define('XOOPS_TRUST_PATH', $newPath);
-        }
-
-        if (defined('XOOPS_TRUST_PATH') && XOOPS_TRUST_PATH !== $newPath ){
-//redefine XOOPS_TRUST_PATH if it is different from $newPath, because obviously the XOOPS_TRUST_PATH has been changed
-        }
-
-        $pathController->updateXoopsTrustPath($newPath);
-
-//        if ($newPath) {
-//            try {
-//                $pathController->updateXoopsTrustPath($newPath);
-//            } catch (RuntimeException $e) {
-//                $pathController->validPath['lib'] = false;
-//                $pathController->errorMessage = $e->getMessage();
-//            }
-//        } else {
-//            $pathController->validPath['lib'] = false;
-//            $pathController->errorMessage = "Invalid XOOPS library directory. Please check the path.";
-//        }
-//
-
-
-
-
-
-        // Check for the autoloader in the new path
-        $composerAutoloader = XOOPS_TRUST_PATH . '/vendor/autoload.php';
-        echo "$composerAutoloader";
-        if (!file_exists($composerAutoloader)) {
-            echo "Error: Could not find the Composer autoloader in the specified path.";
-            exit();
-        }
-
-        // Include the autoloader
-        require_once $composerAutoloader;
-    }
-
-    // Perform the path check
-    $pathController->xoopsPath[$pathKey] = $newPath;
-    echo genPathCheckHtml($pathKey, $pathController->checkPath($pathKey));
-    exit();
-}
-
-*/
-
-
-// Handle GET request for path checking
-// Raw $_GET here — XMF autoloader is not available until the user
-// enters the xoops_lib path on THIS page (chicken-and-egg).
+// Handle GET request for AJAX path checking (read-only validation).
+// Raw $_GET — XMF autoloader is not available until the user enters the
+// xoops_lib path on THIS page. This handler only validates; it does NOT
+// write session state or include PHP files from the submitted path.
+$allowedPathKeys = ['root', 'data', 'lib'];
 if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['var'], $_GET['action']) && $_GET['action'] === 'checkpath') {
-    // Sanitize input
-    $pathKey = htmlspecialchars(trim((string) ($_GET['var'] ?? '')), ENT_QUOTES | ENT_HTML5);
-    $newPath = htmlspecialchars(trim((string) ($_GET['path'] ?? '')), ENT_QUOTES | ENT_HTML5);
+    $pathKey = trim((string) ($_GET['var'] ?? ''));
+    $newPath = trim((string) ($_GET['path'] ?? ''));
 
-    // Validate directory
-    if (!is_dir($newPath)) {
-        echo "Error: The specified path does not exist. Please verify the folder and try again.";
+    // Whitelist the path key — reject unknown values
+    if (!in_array($pathKey, $allowedPathKeys, true)) {
+        echo 'Error: Unknown path key.';
         exit();
     }
 
-    if ($pathKey === 'lib') {
-        // Update session and variable
-        $_SESSION['settings']['TRUST_PATH'] = $newPath;
-        $xoopsTrustPath = $newPath;
-
-        $pathController->updateXoopsTrustPath($newPath);
-
-        // Check for Composer autoloader
-        $composerAutoloader = $xoopsTrustPath . '/vendor/autoload.php';
-        echo "$composerAutoloader";
-        if (!file_exists($composerAutoloader)) {
-            echo "Error: Could not find the Composer autoloader in the specified path.";
-            exit();
-        }
-
-        // Include the autoloader only once
-//        if (!class_exists('ComposerAutoloaderInit401aa2fe6008ca63602daf4ec1d196f2')) {
-        include_once $composerAutoloader;
-//        }
+    // Normalize the path via the controller (strips traversal, trailing slashes)
+    $newPath = $pathController->sanitizePath($newPath);
+    if (false === $newPath || !is_dir($newPath)) {
+        echo 'Error: The specified path does not exist. Please verify the folder and try again.';
+        exit();
     }
 
-    // Perform the path check
+    // For the library path, verify the Composer autoloader is present
+    if ($pathKey === 'lib' && !is_file($newPath . '/vendor/autoload.php')) {
+        echo 'Error: Could not find vendor/autoload.php in the specified library path.';
+        exit();
+    }
+
+    // Perform the path check (read-only — does not write session)
     $pathController->xoopsPath[$pathKey] = $newPath;
     echo genPathCheckHtml($pathKey, $pathController->checkPath($pathKey));
     exit();
 }
-
 
 $pathController->execute();
-//if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-//    return null;
-//}
 
-/*
-
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (isset($_POST['lib']) && $_POST['lib'] !== $pathController->xoopsPath['lib']) {
-        $newTrustPath = $pathController->sanitizePath(trim($_POST['lib']));
-
-        if ($newTrustPath) {
-            try {
-                $pathController->updateXoopsTrustPath($newTrustPath);
-            } catch (RuntimeException $e) {
-                $pathController->validPath['lib'] = false;
-                $pathController->errorMessage = $e->getMessage();
-            }
-        } else {
-            $pathController->validPath['lib'] = false;
-            $pathController->errorMessage = "Invalid XOOPS library directory. Please check the path.";
-        }
-    }
-}
-
-*/
-
-// Handle POST request for updating paths
+// Handle POST request for updating paths.
+// Only accept the lib path if it contains vendor/autoload.php — otherwise
+// pages 5+ will fail with the same missing-autoloader problem.
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $libPost = isset($_POST['lib']) ? trim((string) $_POST['lib']) : '';
     if ('' !== $libPost && $libPost !== $pathController->xoopsPath['lib']) {
         $newTrustPath = $pathController->sanitizePath($libPost);
 
-        if ($newTrustPath && is_dir($newTrustPath)) {
-            $xoopsTrustPath = $newTrustPath;
+        if ($newTrustPath && is_dir($newTrustPath) && is_file($newTrustPath . '/vendor/autoload.php')) {
             $_SESSION['settings']['TRUST_PATH'] = $newTrustPath;
 
             try {
@@ -198,19 +91,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             }
         } else {
             $pathController->validPath['lib'] = false;
-            $pathController->errorMessage = "Invalid XOOPS library directory. Please check the path.";
+            $pathController->errorMessage = !$newTrustPath || !is_dir($newTrustPath)
+                ? 'Invalid XOOPS library directory. Please check the path.'
+                : 'The specified library directory does not contain vendor/autoload.php. Please verify the path points to the relocated xoops_lib folder.';
         }
     }
 }
-
-// Include Composer autoloader if not already included
-//if (!class_exists('ComposerAutoloaderInit401aa2fe6008ca63602daf4ec1d196f2')) {
-//   include_once $xoopsTrustPath . '/vendor/autoload.php';
-//}
-
-
-
-
 
 ob_start();
 ?>
@@ -223,15 +109,6 @@ ob_start();
 
             return val;
         }
-
-        //function updPath(key, val) {
-        //    val = removeTrailing(key, val);
-        //    $.get( "<?php //echo $_SERVER['PHP_SELF']; ?>//", { action: "checkpath", var: key, path: val } )
-        //        .done(function( data ) {
-        //            $("#" + key + 'pathimg').html(data);
-        //        });
-        //    $("#" + key + 'perms').style.display = 'none';
-        //}
 
         function updPath(key, val) {
             // Remove trailing slashes

--- a/htdocs/install/page_pathsettings.php
+++ b/htdocs/install/page_pathsettings.php
@@ -72,19 +72,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['var'], $_GET['action'])
     exit();
 }
 
-// PathController::checkPath('lib') now requires vendor/autoload.php to
-// exist inside the lib directory. If it's missing, execute() will redirect
-// back to this page instead of advancing to page 5.
+// PathController::checkPath('lib') requires vendor/autoload.php to exist.
+// execute() syncs TRUST_PATH into the session and exits after redirect.
 $pathController->execute();
-
-// execute() stores the lib path in $_SESSION['settings']['PATH'] (via
-// path_lookup), but common.inc.php loads the autoloader from TRUST_PATH.
-// Sync them so pages 5+ can find the autoloader.
-if (!empty($pathController->xoopsPath['lib'])) {
-    if (!isset($_SESSION['settings']['TRUST_PATH']) || $_SESSION['settings']['TRUST_PATH'] !== $pathController->xoopsPath['lib']) {
-        $_SESSION['settings']['TRUST_PATH'] = $pathController->xoopsPath['lib'];
-    }
-}
 
 ob_start();
 ?>

--- a/htdocs/install/page_pathsettings.php
+++ b/htdocs/install/page_pathsettings.php
@@ -70,33 +70,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['var'], $_GET['action'])
     exit();
 }
 
+// PathController::checkPath('lib') now requires vendor/autoload.php to
+// exist inside the lib directory. If it's missing, execute() will redirect
+// back to this page instead of advancing to page 5.
 $pathController->execute();
-
-// Handle POST request for updating paths.
-// Only accept the lib path if it contains vendor/autoload.php — otherwise
-// pages 5+ will fail with the same missing-autoloader problem.
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $libPost = isset($_POST['lib']) ? trim((string) $_POST['lib']) : '';
-    if ('' !== $libPost && $libPost !== $pathController->xoopsPath['lib']) {
-        $newTrustPath = $pathController->sanitizePath($libPost);
-
-        if ($newTrustPath && is_dir($newTrustPath) && is_file($newTrustPath . '/vendor/autoload.php')) {
-            $_SESSION['settings']['TRUST_PATH'] = $newTrustPath;
-
-            try {
-                $pathController->updateXoopsTrustPath($newTrustPath);
-            } catch (RuntimeException $e) {
-                $pathController->validPath['lib'] = false;
-                $pathController->errorMessage = $e->getMessage();
-            }
-        } else {
-            $pathController->validPath['lib'] = false;
-            $pathController->errorMessage = !$newTrustPath || !is_dir($newTrustPath)
-                ? 'Invalid XOOPS library directory. Please check the path.'
-                : 'The specified library directory does not contain vendor/autoload.php. Please verify the path points to the relocated xoops_lib folder.';
-        }
-    }
-}
 
 ob_start();
 ?>

--- a/htdocs/install/page_pathsettings.php
+++ b/htdocs/install/page_pathsettings.php
@@ -39,8 +39,8 @@ $pathController = new PathController($wizard->configs['xoopsPathDefault'], $wiza
 // Handle GET request for AJAX path checking (validation only).
 // Raw $_GET — XMF autoloader is not available until the user enters the
 // xoops_lib path on THIS page. This handler validates and returns HTML
-// status. It does not write session state. Note: checkPath('root') does
-// include version.php from the validated root path to verify XOOPS_VERSION.
+// status. It does not write session state. Note: checkPath('root') reads
+// version.php from the validated root path to verify XOOPS_VERSION.
 $allowedPathKeys = ['root', 'data', 'lib'];
 if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['var'], $_GET['action']) && $_GET['action'] === 'checkpath') {
     $pathKey = trim((string) ($_GET['var'] ?? ''));
@@ -119,7 +119,7 @@ ob_start();
             <div class="form-group">
                 <label class="xolabel" for="root"><?php echo XOOPS_ROOT_PATH_LABEL; ?></label>
                 <div class="xoform-help alert alert-info"><?php echo XOOPS_ROOT_PATH_HELP; ?></div>
-                <input type="text" class="form-control" name="root" id="root" value="<?php echo htmlspecialchars($pathController->xoopsPath['root'], ENT_QUOTES, 'UTF-8'); ?>" onchange="updPath('root', this.value)"/>
+                <input type="text" class="form-control" name="root" id="root" value="<?php echo installerHtmlSpecialChars($pathController->xoopsPath['root']); ?>" onchange="updPath('root', this.value)"/>
                 <span id="rootpathimg"><?php echo genPathCheckHtml('root', $pathController->validPath['root']); ?></span>
             </div>
 
@@ -144,7 +144,7 @@ ob_start();
             <div class="form-group">
                 <label for="data"><?php echo XOOPS_DATA_PATH_LABEL; ?></label>
                 <div class="xoform-help alert alert-info"><?php echo XOOPS_DATA_PATH_HELP; ?></div>
-                <input type="text" class="form-control" name="data" id="data" value="<?php echo htmlspecialchars($pathController->xoopsPath['data'], ENT_QUOTES, 'UTF-8'); ?>" onchange="updPath('data', this.value)"/>
+                <input type="text" class="form-control" name="data" id="data" value="<?php echo installerHtmlSpecialChars($pathController->xoopsPath['data']); ?>" onchange="updPath('data', this.value)"/>
                 <span id="datapathimg"><?php echo genPathCheckHtml('data', $pathController->validPath['data']); ?></span>
             </div>
             <?php
@@ -168,7 +168,7 @@ ob_start();
             <div class="form-group">
                 <label class="xolabel" for="lib"><?php echo XOOPS_LIB_PATH_LABEL; ?></label>
                 <div class="xoform-help alert alert-info"><?php echo XOOPS_LIB_PATH_HELP; ?></div>
-                <input type="text" class="form-control" name="lib" id="lib" value="<?php echo htmlspecialchars($pathController->xoopsPath['lib'], ENT_QUOTES, 'UTF-8'); ?>" onchange="updPath('lib', this.value)"/>
+                <input type="text" class="form-control" name="lib" id="lib" value="<?php echo installerHtmlSpecialChars($pathController->xoopsPath['lib']); ?>" onchange="updPath('lib', this.value)"/>
                 <span id="libpathimg"><?php echo genPathCheckHtml('lib', $pathController->validPath['lib']); ?></span>
             </div>
 

--- a/htdocs/install/page_pathsettings.php
+++ b/htdocs/install/page_pathsettings.php
@@ -112,10 +112,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['var']) && isset($_GET['
 
 
 // Handle GET request for path checking
-if ($_SERVER['REQUEST_METHOD'] === 'GET' && \Xmf\Request::hasVar('var', 'GET') && \Xmf\Request::hasVar('action', 'GET') && \Xmf\Request::getCmd('action', '', 'GET') === 'checkpath') {
+// Raw $_GET here — XMF autoloader is not available until the user
+// enters the xoops_lib path on THIS page (chicken-and-egg).
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['var'], $_GET['action']) && $_GET['action'] === 'checkpath') {
     // Sanitize input
-    $pathKey = htmlspecialchars(trim(\Xmf\Request::getString('var', '', 'GET')), ENT_QUOTES | ENT_HTML5);
-    $newPath = htmlspecialchars(trim(\Xmf\Request::getString('path', '', 'GET')), ENT_QUOTES | ENT_HTML5);
+    $pathKey = htmlspecialchars(trim((string) ($_GET['var'] ?? '')), ENT_QUOTES | ENT_HTML5);
+    $newPath = htmlspecialchars(trim((string) ($_GET['path'] ?? '')), ENT_QUOTES | ENT_HTML5);
 
     // Validate directory
     if (!is_dir($newPath)) {
@@ -180,8 +182,9 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 // Handle POST request for updating paths
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    if (\Xmf\Request::hasVar('lib', 'POST') && \Xmf\Request::getString('lib', '', 'POST') !== $pathController->xoopsPath['lib']) {
-        $newTrustPath = $pathController->sanitizePath(trim(\Xmf\Request::getString('lib', '', 'POST')));
+    $libPost = isset($_POST['lib']) ? trim((string) $_POST['lib']) : '';
+    if ('' !== $libPost && $libPost !== $pathController->xoopsPath['lib']) {
+        $newTrustPath = $pathController->sanitizePath($libPost);
 
         if ($newTrustPath && is_dir($newTrustPath)) {
             $xoopsTrustPath = $newTrustPath;

--- a/htdocs/install/page_pathsettings.php
+++ b/htdocs/install/page_pathsettings.php
@@ -194,13 +194,13 @@ ob_start();
             <div class="form-group">
                 <label class="xolabel" for="url"><?php echo XOOPS_URL_LABEL; ?></label>
                 <div class="xoform-help alert alert-info"><?php echo XOOPS_URL_HELP; ?></div>
-                <input type="text" class="form-control" name="URL" id="url" value="<?php echo $pathController->xoopsUrl; ?>" onchange="removeTrailing('url', this.value)"/>
+                <input type="text" class="form-control" name="URL" id="url" value="<?php echo installerHtmlSpecialChars($pathController->xoopsUrl); ?>" onchange="removeTrailing('url', this.value)"/>
             </div>
 
             <div class="form-group">
                 <label class="xolabel" for="cookie_domain"><?php echo XOOPS_COOKIE_DOMAIN_LABEL; ?></label>
                 <div class="xoform-help alert alert-info"><?php echo XOOPS_COOKIE_DOMAIN_HELP; ?></div>
-                <input type="text" class="form-control" name="COOKIE_DOMAIN" id="cookie_domain" value="<?php echo $pathController->xoopsCookieDomain; ?>" onchange="removeTrailing('url', this.value)"/>
+                <input type="text" class="form-control" name="COOKIE_DOMAIN" id="cookie_domain" value="<?php echo installerHtmlSpecialChars($pathController->xoopsCookieDomain); ?>" onchange="removeTrailing('url', this.value)"/>
             </div>
         </div>
     </div>

--- a/htdocs/install/page_pathsettings.php
+++ b/htdocs/install/page_pathsettings.php
@@ -42,9 +42,12 @@ $pathController = new PathController($wizard->configs['xoopsPathDefault'], $wiza
 // status. It does not write session state. Note: checkPath('root') reads
 // version.php from the validated root path to verify XOOPS_VERSION.
 $allowedPathKeys = ['root', 'data', 'lib'];
-if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['var'], $_GET['action']) && $_GET['action'] === 'checkpath') {
-    $pathKey = trim((string) ($_GET['var'] ?? ''));
-    $newPath = trim((string) ($_GET['path'] ?? ''));
+$rawAction      = $_GET['action'] ?? '';
+$rawPathKey     = $_GET['var'] ?? '';
+$rawNewPath     = $_GET['path'] ?? '';
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && is_string($rawAction) && $rawAction === 'checkpath') {
+    $pathKey = is_string($rawPathKey) ? trim($rawPathKey) : '';
+    $newPath = is_string($rawNewPath) ? trim($rawNewPath) : '';
 
     // Whitelist the path key — reject unknown values
     if (!in_array($pathKey, $allowedPathKeys, true)) {

--- a/htdocs/install/page_tablesfill.php
+++ b/htdocs/install/page_tablesfill.php
@@ -98,10 +98,11 @@ $error = false;
 $hashedAdminPass = password_hash($adminpass, PASSWORD_DEFAULT);
 
 if ($process) {
-    $dbm->queryFromFile('./sql/' . XOOPS_DB_TYPE . '.data.sql');
-    $dbm->queryFromFile('./language/' . $wizard->language . '/' . XOOPS_DB_TYPE . '.lang.data.sql');
+    $schemaSqlOk     = $dbm->queryFromFile('./sql/' . XOOPS_DB_TYPE . '.data.sql');
+    $schemaLangSqlOk = $dbm->queryFromFile('./language/' . $wizard->language . '/' . XOOPS_DB_TYPE . '.lang.data.sql');
     $group = make_groups($dbm);
-    if (false === $group || false === make_data($dbm, $adminname, $hashedAdminPass, $adminmail, $wizard->language, $group)) {
+    $data = false !== $group ? make_data($dbm, $adminname, $hashedAdminPass, $adminmail, $wizard->language, $group) : false;
+    if (false === $schemaSqlOk || false === $schemaLangSqlOk || false === $group || false === $data) {
         $error = true;
         $content = '<div class="alert alert-danger"><span class="fa-solid fa-ban text-danger"></span> '
             . FAILED . '</div><div class="alert alert-warning">'

--- a/htdocs/install/page_tablesfill.php
+++ b/htdocs/install/page_tablesfill.php
@@ -98,12 +98,18 @@ $error = false;
 $hashedAdminPass = password_hash($adminpass, PASSWORD_DEFAULT);
 
 if ($process) {
-    $result  = $dbm->queryFromFile('./sql/' . XOOPS_DB_TYPE . '.data.sql');
-    $result  = $dbm->queryFromFile('./language/' . $wizard->language . '/' . XOOPS_DB_TYPE . '.lang.data.sql');
-    $group   = make_groups($dbm);
-    $result  = make_data($dbm, $adminname, $hashedAdminPass, $adminmail, $wizard->language, $group);
-    $content = '<div class="alert alert-success"><span class="fa-solid fa-check text-success"></span> '
-        . DATA_INSERTED . '</div><div class="well">' . $dbm->report() . '</div>';
+    $dbm->queryFromFile('./sql/' . XOOPS_DB_TYPE . '.data.sql');
+    $dbm->queryFromFile('./language/' . $wizard->language . '/' . XOOPS_DB_TYPE . '.lang.data.sql');
+    $group = make_groups($dbm);
+    if (false === $group || false === make_data($dbm, $adminname, $hashedAdminPass, $adminmail, $wizard->language, $group)) {
+        $error = true;
+        $content = '<div class="alert alert-danger"><span class="fa-solid fa-ban text-danger"></span> '
+            . FAILED . '</div><div class="alert alert-warning">'
+            . XOOPS_ERROR_SEE_BELOW . '</div><div class="well">' . $dbm->report() . '</div>';
+    } else {
+        $content = '<div class="alert alert-success"><span class="fa-solid fa-check text-success"></span> '
+            . DATA_INSERTED . '</div><div class="well">' . $dbm->report() . '</div>';
+    }
 } else {
     $content = '<div class="alert alert-info"><span class="fa-solid fa-circle-info text-info"></span> '
         . DATA_ALREADY_INSERTED . '</div>';

--- a/htdocs/kernel/session.php
+++ b/htdocs/kernel/session.php
@@ -60,10 +60,8 @@ class XoopsSessionHandler implements
             $host = '';
         }
         $cookieDomain = XOOPS_COOKIE_DOMAIN;
-        if (class_exists('\Xoops\RegDom\RegisteredDomain')) {
-            if (!\Xoops\RegDom\RegisteredDomain::domainMatches($host, $cookieDomain)) {
-                $cookieDomain = '';
-            }
+        if (!xoops_cookieDomainMatches($host, $cookieDomain)) {
+            $cookieDomain = '';
         }
 
         // Resolve SameSite and Secure from XOOPS config preferences


### PR DESCRIPTION
… pages

  Replace \Xmf\Request calls with raw $_POST/$_GET/$_COOKIE access on
  installer pages 1 through 4. The XMF autoloader lives in xoops_lib/vendor/
  which is not discoverable until the user enters the relocated xoops_lib
  path on page 4 (pathsettings). Page 4 itself also used \Xmf\Request to
  process the path form — a chicken-and-egg problem where the page that
  configures the autoloader path needed the autoloader to load.

  Pages 5+ (dbconnection, dbsettings, configsave, etc.) continue to use
  \Xmf\Request normally because $_SESSION['settings']['TRUST_PATH'] is
  set by page 4's form submission.

  Fixes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer redirects now terminate immediately; acceptance/flow reliability improved.
  * Table and data creation now surface failures instead of silently continuing.

* **New Features**
  * Language selection sanitizes, validates and persists choices, escapes UI output, and falls back to English when needed.
  * Cookie/domain matching improved to better validate and normalize domains.

* **Refactor**
  * Path validation tightened (stricter checks, autoloader requirement); path POST updates removed; path settings persisted after validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->