### PR TITLE
show section for system services always, after controlpanel

### DIFF
--- a/htdocs/modules/system/themes/modern/css/xoops.css
+++ b/htdocs/modules/system/themes/modern/css/xoops.css
@@ -501,7 +501,7 @@ body.dark-mode #help-template p.even {
 /* Hide the icon grid squares */
 .rmmenuicon,
 #xo-modadmin-index .rmmenuicon {
-    display: none !important;
+    /*display: none !important;*/
 }
 
 /* Module admin toolbar area */

--- a/htdocs/modules/system/themes/modern/css/xoops.css
+++ b/htdocs/modules/system/themes/modern/css/xoops.css
@@ -498,12 +498,6 @@ body.dark-mode #help-template p.even {
    MODULE ADMIN PAGES - HORIZONTAL TABS
    ======================================== */
 
-/* Hide the icon grid squares */
-.rmmenuicon,
-#xo-modadmin-index .rmmenuicon {
-    /*display: none !important;*/
-}
-
 /* Module admin toolbar area */
 #xo-nav-options {
     background: var(--bg-secondary);

--- a/htdocs/modules/system/themes/modern/modern.php
+++ b/htdocs/modules/system/themes/modern/modern.php
@@ -390,9 +390,13 @@ class XoopsGuiModern extends XoopsSystemGui
         }
 
         // Detect whether system panel should be opened
-        $isSystemAdmin = strpos($_SERVER['REQUEST_URI'], '/modules/system/admin.php') !== false;
-        $isControlPanelHome = strpos($_SERVER['REQUEST_URI'], '/admin.php') !== false;
-        $GLOBALS['xoopsTpl']->assign('showSystemServices', $isSystemAdmin || $isControlPanelHome);
+        $requestUri = \Xmf\Request::getString('REQUEST_URI', '', 'SERVER');
+        $path       = (string) parse_url($requestUri, PHP_URL_PATH);          // strip query string
+        $basePath   = rtrim((string) parse_url(XOOPS_URL, PHP_URL_PATH), '/'); // '' on root, '/xoops27' on WAMP
+
+        $isSystemAdmin      = ($path === $basePath . '/modules/system/admin.php');
+        $isControlPanelHome = ($path === $basePath . '/admin.php');
+        $tpl->assign('showSystemServices', $isSystemAdmin || $isControlPanelHome);
 
         // assign vars
         $tpl->assign('sys_options', $system_services);

--- a/htdocs/modules/system/themes/modern/modern.php
+++ b/htdocs/modules/system/themes/modern/modern.php
@@ -365,6 +365,7 @@ class XoopsGuiModern extends XoopsSystemGui
             $system_services[$item]['icon'] = empty($system_services[$item]['icon']) ? '' : XOOPS_ADMINTHEME_URL . '/modern/' . $system_services[$item]['icon'];
             unset($system_services[$item]['icon_small']);
         }
+        // assign links for system services list (icons) in xo_head
         $tpl->assign('system_services', $system_services);
 
         // Handle current module context
@@ -388,6 +389,13 @@ class XoopsGuiModern extends XoopsSystemGui
             }
         }
 
+        // Detect whether system panel should be opened
+        $isSystemAdmin = strpos($_SERVER['REQUEST_URI'], '/modules/system/admin.php') !== false;
+        $isControlPanelHome = strpos($_SERVER['REQUEST_URI'], '/admin.php') !== false;
+        $GLOBALS['xoopsTpl']->assign('showSystemServices', $isSystemAdmin || $isControlPanelHome);
+
+        // assign vars
+        $tpl->assign('sys_options', $system_services);
         $tpl->assign('mod_options', $mod_options);
         $tpl->assign('modpath', $modpath);
         $tpl->assign('modname', $modname);
@@ -409,7 +417,7 @@ class XoopsGuiModern extends XoopsSystemGui
         // Build modules array for dashboard display
         $modules_list = [];
         foreach ($modules as $mod) {
-            if ($moduleperm_handler->checkRight('module_admin', $mod->getVar('mid'), $xoopsUser->getGroups())) {
+            if ($moduleperm_handler->checkRight('module_admin', $mod->getVar('mid'), $xoopsUser->getGroups()) && 'system' !== $mod->getVar('dirname')) {
                 $info = $mod->getInfo();
 
                 $item = [];

--- a/htdocs/modules/system/themes/modern/modern.php
+++ b/htdocs/modules/system/themes/modern/modern.php
@@ -432,7 +432,7 @@ class XoopsGuiModern extends XoopsSystemGui
                 if (!empty($info['adminindex'])) {
                     $item['link'] = XOOPS_URL . '/modules/' . $mod->getVar('dirname', 'n') . '/' . $info['adminindex'];
                 } else {
-                    $item['link'] = XOOPS_URL . '/modules/system/admin.php?fct=preferences&amp;op=showmod&amp;mod=' . $mod->getVar('mid');
+                    $item['link'] = XOOPS_URL . '/modules/system/admin.php?fct=preferences&op=showmod&mod=' . $mod->getVar('mid');
                 }
 
                 $module_menu[] = $item;
@@ -442,7 +442,7 @@ class XoopsGuiModern extends XoopsSystemGui
                 if (!empty($info['adminindex'])) {
                     $rtn['link'] = XOOPS_URL . '/modules/' . $mod->getVar('dirname', 'n') . '/' . $info['adminindex'];
                 } else {
-                    $rtn['link'] = XOOPS_URL . '/modules/system/admin.php?fct=preferences&amp;op=showmod&amp;mod=' . $mod->getVar('mid');
+                    $rtn['link'] = XOOPS_URL . '/modules/system/admin.php?fct=preferences&op=showmod&mod=' . $mod->getVar('mid');
                 }
                 $rtn['title'] = htmlspecialchars((string) $mod->getVar('name'), ENT_QUOTES | ENT_HTML5);
                 $rtn['description'] = $mod->getInfo('description');

--- a/htdocs/modules/system/themes/modern/xotpl/xo_head.tpl
+++ b/htdocs/modules/system/themes/modern/xotpl/xo_head.tpl
@@ -13,7 +13,7 @@
     <{* Quick-access icon strip - always shows System Services *}>
     <{if $system_services}>
     <div class="header-toolbar-icons">
-        <{foreach item=op from=$system_services}>
+        <{foreach item='op' from=$system_services}>
             <a class="header-toolbar-icon" href="<{$op.link}>" title="<{$op.title}>">
                 <{if $op.icon}>
                     <img src="<{$op.icon}>" alt="<{$op.title}>">

--- a/htdocs/modules/system/themes/modern/xotpl/xo_head.tpl
+++ b/htdocs/modules/system/themes/modern/xotpl/xo_head.tpl
@@ -14,9 +14,9 @@
     <{if $system_services}>
     <div class="header-toolbar-icons">
         <{foreach item='op' from=$system_services}>
-            <a class="header-toolbar-icon" href="<{$op.link}>" title="<{$op.title}>">
+            <a class="header-toolbar-icon" href="<{$op.link|escape:'html'}>" title="<{$op.title|escape:'html'}>">
                 <{if $op.icon}>
-                    <img src="<{$op.icon}>" alt="<{$op.title}>">
+                    <img src="<{$op.icon|escape:'html'}>" alt="<{$op.title|escape:'html'}>">
                 <{else}>
                     <span>⚙️</span>
                 <{/if}>

--- a/htdocs/modules/system/themes/modern/xotpl/xo_page.tpl
+++ b/htdocs/modules/system/themes/modern/xotpl/xo_page.tpl
@@ -11,7 +11,7 @@
                 <{* Horizontal Icon Toolbar - inline with module name *}>
                 <{if $mod_options}>
                     <div id="xo-toolbar">
-                        <{foreach item=option from=$mod_options}>
+                        <{foreach item='option' from=$mod_options}>
                             <a class="tooltip" href="<{$option.link}>" title="<{$option.title}>">
                                 <{if $option.icon}>
                                     <img src='<{$option.icon}>' alt="<{$option.title}>"/>

--- a/htdocs/modules/system/themes/modern/xotpl/xo_page.tpl
+++ b/htdocs/modules/system/themes/modern/xotpl/xo_page.tpl
@@ -46,7 +46,7 @@
                     <{if $module.description}>
                         <p class="module-description"><{$module.description|escape:'html'}></p>
                     <{/if}>
-                    <a href="<{$module.link}>" class="module-link"><{$smarty.const._MODERN_OPEN}></a>
+                    <a href="<{$module.link|escape:'html'}>" class="module-link"><{$smarty.const._MODERN_OPEN}></a>
                 </div>
             <{/foreach}>
         </div>

--- a/htdocs/modules/system/themes/modern/xotpl/xo_sidebar.tpl
+++ b/htdocs/modules/system/themes/modern/xotpl/xo_sidebar.tpl
@@ -20,7 +20,7 @@
                 <span class="nav-section-arrow">&#9654;</span>
             </summary>
             <div class="nav-section-items">
-                <{foreach item=item from=$sys_options}>
+                <{foreach item='item' from=$sys_options}>
                 <a href="<{$item.link|escape:'html'}>" class="nav-item">
                     <{if $item.icon|default:''|escape:'html'}>
                         <img src="<{$item.icon|escape:'html'}>" class="nav-icon-img" alt="">
@@ -41,7 +41,7 @@
                     <span class="nav-section-arrow">&#9654;</span>
                 </summary>
                 <div class="nav-section-items">
-                <{foreach item=module from=$module_menu}>
+                <{foreach item='module' from=$module_menu}>
                     <{if $module.link}>
                         <a href="<{$module.link|escape:'html'}>" class="nav-item">
                             <{if $module.icon|default:''|escape:'html'}>

--- a/htdocs/modules/system/themes/modern/xotpl/xo_sidebar.tpl
+++ b/htdocs/modules/system/themes/modern/xotpl/xo_sidebar.tpl
@@ -1,5 +1,6 @@
 <aside class="modern-sidebar" id="sidebar">
     <nav class="sidebar-nav">
+        <!-- Nav section control panel -->
         <div class="nav-section">
             <div class="nav-section-title"><{$smarty.const._MODERN_CONTROL_PANEL}></div>
             <{foreach item=item from=$control_menu}>
@@ -12,6 +13,27 @@
             <{/foreach}>
         </div>
 
+        <!-- Nav section with sytem module -->
+        <details class="nav-section nav-section-collapsible" <{if $showSystemServices}>open<{/if}>>
+            <summary class="nav-section-title">
+                <span><{$smarty.const._MODERN_SYSTEM}></span>
+                <span class="nav-section-arrow">&#9654;</span>
+            </summary>
+            <div class="nav-section-items">
+                <{foreach item=item from=$sys_options}>
+                <a href="<{$item.link}>" class="nav-item">
+                    <{if $item.icon}>
+                <img src="<{$item.icon}>" class="nav-icon-img" alt="">
+                    <{else}>
+                    <span class="nav-icon">⚙️</span>
+                    <{/if}>
+                    <span class="nav-text"><{$item.title}></span>
+                </a>
+                <{/foreach}>
+            </div>
+        </details>
+
+        <!-- Nav section all other modules -->
         <{if $module_menu}>
             <details class="nav-section nav-section-collapsible" open>
                 <summary class="nav-section-title">
@@ -20,36 +42,16 @@
                 </summary>
                 <div class="nav-section-items">
                 <{foreach item=module from=$module_menu}>
-                    <a href="<{$module.link}>" class="nav-item">
-                        <{if $module.icon}>
-                            <img src="<{$module.icon}>" class="nav-icon-img" alt="">
-                        <{else}>
-                            <span class="nav-icon">&#x1F4E6;</span>
-                        <{/if}>
-                        <span class="nav-text"><{$module.name}></span>
-                    </a>
-                <{/foreach}>
-                </div>
-            </details>
-        <{/if}>
-
-        <{* Only show System section on system admin pages, not module pages *}>
-        <{if $mod_options && $xoops_dirname == 'system'}>
-            <details class="nav-section nav-section-collapsible" open>
-                <summary class="nav-section-title">
-                    <span><{$smarty.const._MODERN_SYSTEM}></span>
-                    <span class="nav-section-arrow">&#9654;</span>
-                </summary>
-                <div class="nav-section-items">
-                <{foreach item=item from=$mod_options}>
-                    <a href="<{$item.link}>" class="nav-item">
-                        <{if $item.icon}>
-                            <img src="<{$item.icon}>" class="nav-icon-img" alt="">
-                        <{else}>
-                            <span class="nav-icon">⚙️</span>
-                        <{/if}>
-                        <span class="nav-text"><{$item.title}></span>
-                    </a>
+                    <{if $module.link}>
+                        <a href="<{$module.link}>" class="nav-item">
+                            <{if $module.icon}>
+                                <img src="<{$module.icon}>" class="nav-icon-img" alt="">
+                            <{else}>
+                                <span class="nav-icon">&#x1F4E6;</span>
+                            <{/if}>
+                            <span class="nav-text"><{$module.name}></span>
+                        </a>
+                    <{/if}>
                 <{/foreach}>
                 </div>
             </details>

--- a/htdocs/modules/system/themes/modern/xotpl/xo_sidebar.tpl
+++ b/htdocs/modules/system/themes/modern/xotpl/xo_sidebar.tpl
@@ -22,7 +22,7 @@
             <div class="nav-section-items">
                 <{foreach item='item' from=$sys_options}>
                 <a href="<{$item.link|escape:'html'}>" class="nav-item">
-                    <{if $item.icon|default:''|escape:'html'}>
+                    <{if !empty($item.icon)}>
                         <img src="<{$item.icon|escape:'html'}>" class="nav-icon-img" alt="">
                     <{else}>
                         <span class="nav-icon">⚙️</span>
@@ -43,8 +43,8 @@
                 <div class="nav-section-items">
                 <{foreach item='module' from=$module_menu}>
                     <{if $module.link}>
-                        <a href="<{$module.link}>" class="nav-item">
-                            <{if $module.icon|default:''|escape:'html'}>
+                        <a href="<{$module.link|escape:'html'}>" class="nav-item">
+                            <{if !empty($module.icon)}>
                                 <img src="<{$module.icon|escape:'html'}>" class="nav-icon-img" alt="">
                             <{else}>
                                 <span class="nav-icon">&#x1F4E6;</span>

--- a/htdocs/modules/system/themes/modern/xotpl/xo_sidebar.tpl
+++ b/htdocs/modules/system/themes/modern/xotpl/xo_sidebar.tpl
@@ -13,7 +13,7 @@
             <{/foreach}>
         </div>
 
-        <!-- Nav section with sytem module -->
+        <!-- Nav section with system module -->
         <details class="nav-section nav-section-collapsible" <{if $showSystemServices}>open<{/if}>>
             <summary class="nav-section-title">
                 <span><{$smarty.const._MODERN_SYSTEM}></span>
@@ -43,7 +43,7 @@
                 <div class="nav-section-items">
                 <{foreach item='module' from=$module_menu}>
                     <{if $module.link}>
-                        <a href="<{$module.link|escape:'html'}>" class="nav-item">
+                        <a href="<{$module.link}>" class="nav-item">
                             <{if $module.icon|default:''|escape:'html'}>
                                 <img src="<{$module.icon|escape:'html'}>" class="nav-icon-img" alt="">
                             <{else}>

--- a/htdocs/modules/system/themes/modern/xotpl/xo_sidebar.tpl
+++ b/htdocs/modules/system/themes/modern/xotpl/xo_sidebar.tpl
@@ -4,7 +4,7 @@
         <div class="nav-section">
             <div class="nav-section-title"><{$smarty.const._MODERN_CONTROL_PANEL}></div>
             <{foreach item=item from=$control_menu}>
-                <a href="<{$item.link}>" class="nav-item" <{if $item.absolute}>target="_parent"<{/if}>>
+                <a href="<{$item.link|escape:'html'}>" class="nav-item" <{if $item.absolute}>target="_parent"<{/if}>>
                     <span class="nav-icon">
                         <{if $item.icon == 'home' || $item.icon == 'dashboard'}>&#x1F3E0;<{elseif $item.icon == 'logout'}>&#x1F6AA;<{else}>&#x1F4CA;<{/if}>
                     </span>
@@ -21,13 +21,13 @@
             </summary>
             <div class="nav-section-items">
                 <{foreach item=item from=$sys_options}>
-                <a href="<{$item.link}>" class="nav-item">
-                    <{if $item.icon}>
-                <img src="<{$item.icon}>" class="nav-icon-img" alt="">
+                <a href="<{$item.link|escape:'html'}>" class="nav-item">
+                    <{if $item.icon|default:''|escape:'html'}>
+                        <img src="<{$item.icon|escape:'html'}>" class="nav-icon-img" alt="">
                     <{else}>
-                    <span class="nav-icon">⚙️</span>
+                        <span class="nav-icon">⚙️</span>
                     <{/if}>
-                    <span class="nav-text"><{$item.title}></span>
+                    <span class="nav-text"><{$item.title|escape:'html'}></span>
                 </a>
                 <{/foreach}>
             </div>
@@ -43,13 +43,13 @@
                 <div class="nav-section-items">
                 <{foreach item=module from=$module_menu}>
                     <{if $module.link}>
-                        <a href="<{$module.link}>" class="nav-item">
-                            <{if $module.icon}>
-                                <img src="<{$module.icon}>" class="nav-icon-img" alt="">
+                        <a href="<{$module.link|escape:'html'}>" class="nav-item">
+                            <{if $module.icon|default:''|escape:'html'}>
+                                <img src="<{$module.icon|escape:'html'}>" class="nav-icon-img" alt="">
                             <{else}>
                                 <span class="nav-icon">&#x1F4E6;</span>
                             <{/if}>
-                            <span class="nav-text"><{$module.name}></span>
+                            <span class="nav-text"><{$module.name|escape:'html'}></span>
                         </a>
                     <{/if}>
                 <{/foreach}>

--- a/htdocs/modules/system/themes/modern/xotpl/xo_sidebar.tpl
+++ b/htdocs/modules/system/themes/modern/xotpl/xo_sidebar.tpl
@@ -3,7 +3,7 @@
         <!-- Nav section control panel -->
         <div class="nav-section">
             <div class="nav-section-title"><{$smarty.const._MODERN_CONTROL_PANEL}></div>
-            <{foreach item=item from=$control_menu}>
+            <{foreach item='item' from=$control_menu}>
                 <a href="<{$item.link|escape:'html'}>" class="nav-item" <{if $item.absolute}>target="_parent"<{/if}>>
                     <span class="nav-icon">
                         <{if $item.icon == 'home' || $item.icon == 'dashboard'}>&#x1F3E0;<{elseif $item.icon == 'logout'}>&#x1F6AA;<{else}>&#x1F4CA;<{/if}>

--- a/htdocs/modules/system/themes/modern/xotpl/xo_widgets.tpl
+++ b/htdocs/modules/system/themes/modern/xotpl/xo_widgets.tpl
@@ -2,7 +2,7 @@
 <{* Dynamically renders widgets from any module that implements ModernThemeWidgetInterface *}>
 
 <{if !empty($module_widgets)}>
-    <{foreach key=mod_name item=widget from=$module_widgets}>
+    <{foreach key=mod_name item='widget' from=$module_widgets}>
         <{if is_array($widget)}>
         <div class="widget-card">
             <div class="widget-header">
@@ -14,7 +14,7 @@
             <div class="widget-body">
                 <{if !empty($widget.stats)}>
                 <div class="widget-stats">
-                    <{foreach key=stat_key item=stat_val from=$widget.stats}>
+                    <{foreach key=stat_key item='stat_val' from=$widget.stats}>
                     <div class="widget-stat">
                         <div class="widget-stat-value"><{$stat_val|escape:'html'}></div>
                         <div class="widget-stat-label"><{$stat_key|replace:'_':' '|capitalize}></div>
@@ -25,7 +25,7 @@
 
                 <{if !empty($widget.recent)}>
                 <div class="widget-recent">
-                    <{foreach item=item from=$widget.recent}>
+                    <{foreach item='item' from=$widget.recent}>
                     <div class="widget-recent-item">
                         <span class="widget-recent-title"><{$item.title|escape:'html'|truncate:50}></span>
                         <{if !empty($item.author)}>

--- a/htdocs/modules/system/themes/modern/xotpl/xo_widgets.tpl
+++ b/htdocs/modules/system/themes/modern/xotpl/xo_widgets.tpl
@@ -17,7 +17,7 @@
                     <{foreach key=stat_key item='stat_val' from=$widget.stats}>
                     <div class="widget-stat">
                         <div class="widget-stat-value"><{$stat_val|escape:'html'}></div>
-                        <div class="widget-stat-label"><{$stat_key|replace:'_':' '|capitalize}></div>
+                        <div class="widget-stat-label"><{$stat_key|replace:'_':' '|capitalize|escape:'html'}></div>
                     </div>
                     <{/foreach}>
                 </div>


### PR DESCRIPTION
IMO it make sense that the system services are in a separate section, which is always available and should be the first section after control panel section
the section "Modules" should only contain all other modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsible "System" section in navigation that can auto-open based on the current admin path.

* **Refactor**
  * System modules are excluded from the modules dashboard list even for module-admins.
  * Module links are only shown when available.

* **UI / Style**
  * Icon grid visibility restored so module icons can appear.

* **Bug Fixes**
  * Fixes to module link URLs so query parameters render correctly.

* **Security**
  * Navigation links, icons and labels are now HTML-escaped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->