### PR TITLE
normalize profile and session indexes for 2.7.0

### DIFF
--- a/htdocs/install/sql/mysql.structure.sql
+++ b/htdocs/install/sql/mysql.structure.sql
@@ -508,7 +508,7 @@ CREATE TABLE session (
   sess_updated int(10) unsigned NOT NULL default '0',
   sess_ip varchar(45) NOT NULL default '',
   sess_data text,
-  PRIMARY KEY  (sess_id(200)) USING BTREE,
+  PRIMARY KEY  (sess_id),
   KEY updated (sess_updated)
 ) ENGINE=MyISAM;
 # --------------------------------------------------------

--- a/htdocs/install/sql/mysql.structure.sql
+++ b/htdocs/install/sql/mysql.structure.sql
@@ -508,7 +508,7 @@ CREATE TABLE session (
   sess_updated int(10) unsigned NOT NULL default '0',
   sess_ip varchar(45) NOT NULL default '',
   sess_data text,
-  PRIMARY KEY  (sess_id),
+  PRIMARY KEY  (sess_id(200)) USING BTREE,
   KEY updated (sess_updated)
 ) ENGINE=MyISAM;
 # --------------------------------------------------------

--- a/htdocs/modules/profile/sql/mysql.sql
+++ b/htdocs/modules/profile/sql/mysql.sql
@@ -27,7 +27,7 @@ CREATE TABLE `profile_field` (
   `step_id`             smallint(3) unsigned    NOT NULL default '0',
   
   PRIMARY KEY  (`field_id`),
-  UNIQUE KEY `field_name` (`field_name`),
+  UNIQUE KEY `field_name` (`field_name`(64)) USING BTREE,
   KEY `step` (`step_id`, `field_weight`)
 ) ENGINE=MyISAM;
 
@@ -48,7 +48,7 @@ CREATE TABLE `profile_regstep` (
   `step_save`       tinyint(1) unsigned     NOT NULL default '0',
   
   PRIMARY KEY (`step_id`),
-  KEY `sort` (`step_order`, `step_name`(100))
+  KEY `sort` (`step_order`, `step_name`(100)) USING BTREE
 ) ENGINE=MyISAM;
 
 CREATE TABLE `profile_profile` (

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -29,8 +29,7 @@ use Xoops\Upgrade\UpgradeControl;
  * 10. deleteflashsanitizer   — Delete obsolete Flash text sanitizer plugin
  * 11. normalizeprofilefieldname   — Normalize profile_field.field_name column + unique index (prefix 64)
  * 12. normalizeprofileregstepsort — Normalize profile_regstep.sort index (step_name prefix 100)
- * 13. normalizesessionpk          — Normalize session PRIMARY KEY (sess_id prefix 200)
- * 14. cleancache             — Clear compiled templates and cache files
+ * 13. cleancache             — Clear compiled templates and cache files
  *
  * @category     Upgrade
  * @copyright    (c) 2000-2026 XOOPS Project (https://xoops.org)
@@ -70,7 +69,6 @@ class Upgrade_270 extends XoopsUpgrade
             'deleteflashsanitizer',
             'normalizeprofilefieldname',
             'normalizeprofileregstepsort',
-            'normalizesessionpk',
             'cleancache',
         ];
         $this->usedFiles = [];
@@ -900,88 +898,7 @@ class Upgrade_270 extends XoopsUpgrade
     }
 
     // =========================================================================
-    // Task 13: normalizesessionpk — Normalize session PRIMARY KEY
-    //
-    // Older installations used PRIMARY KEY (sess_id) indexing the full
-    // varchar(256) column. Target:
-    //   PRIMARY KEY (`sess_id`(200)) USING BTREE
-    // A 200-byte prefix keeps the PK inside InnoDB's 767-byte default limit
-    // if the table is ever migrated from MyISAM.
-    // =========================================================================
-
-    /**
-     * Check if the session PRIMARY KEY matches the canonical layout:
-     *   PRIMARY KEY (`sess_id`(200)).
-     *
-     * Verifies the full PK shape — not just the prefix length on sess_id —
-     * so a composite PRIMARY KEY that happens to include `sess_id` with
-     * SUB_PART=200 does not incorrectly pass the normalise check.
-     *
-     * @return bool true if already normalised (no action needed)
-     */
-    public function check_normalizesessionpk(): bool
-    {
-        $table = $this->db->prefix('session');
-
-        $sql    = "SELECT `COLUMN_NAME`, `SEQ_IN_INDEX`, `SUB_PART`"
-                . " FROM `information_schema`.`STATISTICS`"
-                . " WHERE `TABLE_SCHEMA` = DATABASE()"
-                . " AND `TABLE_NAME` = " . $this->db->quote($table)
-                . " AND `INDEX_NAME` = 'PRIMARY'"
-                . " ORDER BY `SEQ_IN_INDEX`";
-        $result = $this->db->query($sql);
-        if (!$this->db->isResultSet($result) || !($result instanceof \mysqli_result)) {
-            return false;
-        }
-
-        $rows = [];
-        while ($row = $this->db->fetchRow($result)) {
-            $rows[] = $row;
-        }
-
-        // Expect exactly: [('sess_id', 1, 200)]
-        if (1 !== count($rows)) {
-            return false;
-        }
-
-        return 'sess_id' === $rows[0][0]
-            && 1 === (int) $rows[0][1]
-            && 200 === (int) $rows[0][2];
-    }
-
-    /**
-     * Recreate the session PRIMARY KEY with an explicit (200) prefix.
-     *
-     * DROP and ADD are issued as separate statements so a session table
-     * that somehow lost its PRIMARY KEY (manual intervention, earlier
-     * failed migration) can still be normalised — a combined
-     * "DROP PRIMARY KEY, ADD PRIMARY KEY ..." would abort on the DROP.
-     *
-     * @return bool true on success
-     */
-    public function apply_normalizesessionpk(): bool
-    {
-        $table = $this->db->prefix('session');
-
-        $hasPrimary = $this->indexExists($table, 'PRIMARY');
-        if (null === $hasPrimary) {
-            $this->logs[] = sprintf(
-                'Cannot verify existence of PRIMARY KEY on `%s`; information_schema query failed.',
-                $table
-            );
-            return false;
-        }
-        if ($hasPrimary && !$this->execOrFail("ALTER TABLE `{$table}` DROP PRIMARY KEY")) {
-            return false;
-        }
-
-        return $this->execOrFail(
-            "ALTER TABLE `{$table}` ADD PRIMARY KEY (`sess_id`(200)) USING BTREE"
-        );
-    }
-
-    // =========================================================================
-    // Task 14: cleancache — Clear compiled templates and cache files
+    // Task 13: cleancache — Clear compiled templates and cache files
     // =========================================================================
 
     /**

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -665,14 +665,6 @@ class Upgrade_270 extends XoopsUpgrade
             return true;
         }
 
-        // Skip-with-warning path was already taken this session for a widened
-        // column. apply_ logged the advisory and deferred to manual action —
-        // treat the task as settled so the overall patch can complete rather
-        // than looping forever on check_ returning false.
-        if (!empty($_SESSION[$this->widenedFieldNameSkipKey])) {
-            return true;
-        }
-
         // Column must be varchar(64) NOT NULL DEFAULT ''
         $sql    = "SELECT `DATA_TYPE`, `CHARACTER_MAXIMUM_LENGTH`, `IS_NULLABLE`, `COLUMN_DEFAULT`"
                 . " FROM `information_schema`.`COLUMNS`"
@@ -684,6 +676,20 @@ class Upgrade_270 extends XoopsUpgrade
             return false;
         }
         $row = $this->db->fetchRow($result);
+
+        // Skip-with-warning flag is honoured only while the column is STILL
+        // widened (the condition that originally triggered the skip).
+        // If the admin followed the logged advice and narrowed the column
+        // in the same session, the flag is stale — clear it and fall
+        // through to the normal canonical-shape check so the index can
+        // still be normalised without waiting for a new session.
+        if (!empty($_SESSION[$this->widenedFieldNameSkipKey])) {
+            if ($row && (int) $row[1] > 64) {
+                return true;  // still widened — defer to manual action
+            }
+            unset($_SESSION[$this->widenedFieldNameSkipKey]);
+        }
+
         if (!$row
             || 'varchar' !== strtolower((string) $row[0])
             || 64 !== (int) $row[1]

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -747,10 +747,16 @@ class Upgrade_270 extends XoopsUpgrade
         }
 
         // Step 2: Recreate the unique index with an explicit prefix of 64.
-        if ($this->indexExists($table, 'field_name')) {
-            if (!$this->execOrFail("ALTER TABLE `{$table}` DROP INDEX `field_name`")) {
-                return false;
-            }
+        $hasIndex = $this->indexExists($table, 'field_name');
+        if (null === $hasIndex) {
+            $this->logs[] = sprintf(
+                'Cannot verify existence of index `field_name` on `%s`; information_schema query failed.',
+                $table
+            );
+            return false;
+        }
+        if ($hasIndex && !$this->execOrFail("ALTER TABLE `{$table}` DROP INDEX `field_name`")) {
+            return false;
         }
         $addIndex = "ALTER TABLE `{$table}` ADD UNIQUE `field_name` (`field_name`(64)) USING BTREE";
 
@@ -843,10 +849,16 @@ class Upgrade_270 extends XoopsUpgrade
             return true;
         }
 
-        if ($this->indexExists($table, 'sort')) {
-            if (!$this->execOrFail("ALTER TABLE `{$table}` DROP INDEX `sort`")) {
-                return false;
-            }
+        $hasIndex = $this->indexExists($table, 'sort');
+        if (null === $hasIndex) {
+            $this->logs[] = sprintf(
+                'Cannot verify existence of index `sort` on `%s`; information_schema query failed.',
+                $table
+            );
+            return false;
+        }
+        if ($hasIndex && !$this->execOrFail("ALTER TABLE `{$table}` DROP INDEX `sort`")) {
+            return false;
         }
         $sql = "ALTER TABLE `{$table}` ADD KEY `sort` (`step_order`, `step_name`(100)) USING BTREE";
 
@@ -889,10 +901,16 @@ class Upgrade_270 extends XoopsUpgrade
     {
         $table = $this->db->prefix('session');
 
-        if ($this->indexExists($table, 'PRIMARY')) {
-            if (!$this->execOrFail("ALTER TABLE `{$table}` DROP PRIMARY KEY")) {
-                return false;
-            }
+        $hasPrimary = $this->indexExists($table, 'PRIMARY');
+        if (null === $hasPrimary) {
+            $this->logs[] = sprintf(
+                'Cannot verify existence of PRIMARY KEY on `%s`; information_schema query failed.',
+                $table
+            );
+            return false;
+        }
+        if ($hasPrimary && !$this->execOrFail("ALTER TABLE `{$table}` DROP PRIMARY KEY")) {
+            return false;
         }
 
         return $this->execOrFail(
@@ -1078,10 +1096,17 @@ class Upgrade_270 extends XoopsUpgrade
     /**
      * Check whether an index exists on a table.
      *
+     * Tri-state so callers can distinguish "index genuinely absent" from
+     * "we don't know" — mirrors tableExists():
+     *   true  → index exists
+     *   false → index is absent (caller can safely skip a DROP)
+     *   null  → information_schema query failed (caller should log + fail
+     *           rather than risk an ADD against an index that actually exists)
+     *
      * @param string $table     fully prefixed table name
      * @param string $indexName index name (use 'PRIMARY' for the primary key)
      */
-    private function indexExists(string $table, string $indexName): bool
+    private function indexExists(string $table, string $indexName): ?bool
     {
         $sql    = "SELECT 1 FROM `information_schema`.`STATISTICS`"
                 . " WHERE `TABLE_SCHEMA` = DATABASE()"
@@ -1090,7 +1115,7 @@ class Upgrade_270 extends XoopsUpgrade
                 . " LIMIT 1";
         $result = $this->db->query($sql);
         if (!$this->db->isResultSet($result) || !($result instanceof \mysqli_result)) {
-            return false;
+            return null;
         }
 
         return (bool) $this->db->fetchArray($result);

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -705,10 +705,11 @@ class Upgrade_270 extends XoopsUpgrade
      * uses an explicit (64) prefix.
      *
      * Skipped silently when the table is absent (Profile module not
-     * installed). Refuses to silently narrow a column that has been widened
-     * beyond 64 chars locally — the admin must resolve that manually.
+     * installed). Skipped with a warning in the log when the column has
+     * been widened beyond 64 chars locally — the admin must resolve that
+     * manually, but the rest of the 2.7.0 upgrade is not blocked.
      *
-     * @return bool true on success (or table absent)
+     * @return bool true on success, table absent, or skipped with warning
      */
     public function apply_normalizeprofilefieldname(): bool
     {
@@ -756,16 +757,20 @@ class Upgrade_270 extends XoopsUpgrade
             return false;
         }
 
-        // Guard 2: refuse to narrow a legitimate wide varchar/char column —
-        // values could be truncated if the server's sql_mode does not
-        // include STRICT_ALL_TABLES.
+        // Guard 2: skip-with-warning when the column has been widened.
+        // Narrowing could silently truncate data (if sql_mode lacks
+        // STRICT_ALL_TABLES); recreating the UNIQUE index with prefix(64)
+        // on a wider column would weaken uniqueness from "full width" to
+        // "first 64 chars". Either outcome is worse than leaving the
+        // customised column alone, so the task logs a warning and returns
+        // true so the rest of the 2.7.0 upgrade is not blocked.
         if ($currentLen > 64) {
             $this->logs[] = sprintf(
-                'profile_field.field_name is %s(%d); refusing to narrow to varchar(64) automatically. Reduce the column manually after verifying no values exceed 64 chars.',
+                'profile_field.field_name is %s(%d); skipping index normalisation — column is wider than 64 chars. Reduce the column manually after verifying no values exceed 64 chars, then re-run the upgrade.',
                 $dataType,
                 $currentLen
             );
-            return false;
+            return true;
         }
 
         if ('varchar' !== $dataType || $currentLen !== 64) {
@@ -1176,37 +1181,6 @@ class Upgrade_270 extends XoopsUpgrade
         }
 
         return (bool) $this->db->fetchArray($result);
-    }
-
-    /**
-     * Return the explicit prefix length for an index column, or null if the
-     * index/column pair does not exist or indexes the full column width.
-     *
-     * SUB_PART is NULL in information_schema.STATISTICS when no prefix was
-     * supplied at index-creation time — callers treat NULL as "not normalised".
-     *
-     * @param string $table      fully prefixed table name
-     * @param string $indexName  index name (use 'PRIMARY' for the primary key)
-     * @param string $columnName column name within the index
-     */
-    private function indexPrefixLength(string $table, string $indexName, string $columnName): ?int
-    {
-        $sql    = "SELECT `SUB_PART` FROM `information_schema`.`STATISTICS`"
-                . " WHERE `TABLE_SCHEMA` = DATABASE()"
-                . " AND `TABLE_NAME` = " . $this->db->quote($table)
-                . " AND `INDEX_NAME` = " . $this->db->quote($indexName)
-                . " AND `COLUMN_NAME` = " . $this->db->quote($columnName)
-                . " LIMIT 1";
-        $result = $this->db->query($sql);
-        if (!$this->db->isResultSet($result) || !($result instanceof \mysqli_result)) {
-            return null;
-        }
-        $row = $this->db->fetchRow($result);
-        if (!$row || null === $row[0]) {
-            return null;
-        }
-
-        return (int) $row[0];
     }
 }
 

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -840,12 +840,13 @@ class Upgrade_270 extends XoopsUpgrade
 
     /**
      * Check if the `sort` index already uses the canonical layout:
-     *   (step_order, step_name(100)).
+     *   KEY `sort` (`step_order`, `step_name`(100)) — non-UNIQUE.
      *
-     * Verifies the full layout (column order and prefixes), not just the
-     * prefix length on step_name — a partial hand-patch that left step_order
-     * out of the index must still be rebuilt. Skipped silently when the
-     * table is absent (Profile module not installed).
+     * Verifies the full layout (column order, prefix lengths, AND that the
+     * index is non-UNIQUE), not just the prefix length on step_name — a
+     * partial hand-patch that left step_order out, or upgraded the index
+     * to UNIQUE, must still be rebuilt. Skipped silently when the table is
+     * absent (Profile module not installed).
      *
      * @return bool true if already normalised (no action needed)
      */
@@ -861,7 +862,7 @@ class Upgrade_270 extends XoopsUpgrade
             return true;
         }
 
-        $sql    = "SELECT `COLUMN_NAME`, `SEQ_IN_INDEX`, `SUB_PART`"
+        $sql    = "SELECT `COLUMN_NAME`, `SEQ_IN_INDEX`, `SUB_PART`, `NON_UNIQUE`"
                 . " FROM `information_schema`.`STATISTICS`"
                 . " WHERE `TABLE_SCHEMA` = DATABASE()"
                 . " AND `TABLE_NAME` = " . $this->db->quote($table)
@@ -877,14 +878,23 @@ class Upgrade_270 extends XoopsUpgrade
             $rows[] = $row;
         }
 
-        // Expect exactly: [('step_order', 1, NULL), ('step_name', 2, 100)]
+        // Expect exactly two non-UNIQUE rows:
+        //   [('step_order', 1, NULL, 1), ('step_name', 2, 100, 1)]
         if (2 !== count($rows)) {
             return false;
         }
-        if ('step_order' !== $rows[0][0] || 1 !== (int) $rows[0][1] || null !== $rows[0][2]) {
+        if ('step_order' !== $rows[0][0]
+            || 1 !== (int) $rows[0][1]
+            || null !== $rows[0][2]
+            || 1 !== (int) $rows[0][3]
+        ) {
             return false;
         }
-        if ('step_name' !== $rows[1][0] || 2 !== (int) $rows[1][1] || 100 !== (int) $rows[1][2]) {
+        if ('step_name' !== $rows[1][0]
+            || 2 !== (int) $rows[1][1]
+            || 100 !== (int) $rows[1][2]
+            || 1 !== (int) $rows[1][3]
+        ) {
             return false;
         }
 

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -635,13 +635,18 @@ class Upgrade_270 extends XoopsUpgrade
     {
         $table = $this->db->prefix('profile_field');
 
-        // Profile module not installed → nothing to normalise; treat as done.
-        if (!$this->tableExists($table)) {
+        $exists = $this->tableExists($table);
+        if (null === $exists) {
+            // Don't silently skip — the DB is in an indeterminate state.
+            return false;
+        }
+        if (!$exists) {
+            // Profile module not installed → nothing to normalise; treat as done.
             return true;
         }
 
-        // Column width must be 64
-        $sql    = "SELECT CHARACTER_MAXIMUM_LENGTH FROM `information_schema`.`COLUMNS`"
+        // Column must be varchar(64)
+        $sql    = "SELECT `DATA_TYPE`, `CHARACTER_MAXIMUM_LENGTH` FROM `information_schema`.`COLUMNS`"
                 . " WHERE `TABLE_SCHEMA` = DATABASE()"
                 . " AND `TABLE_NAME` = " . $this->db->quote($table)
                 . " AND `COLUMN_NAME` = 'field_name' LIMIT 1";
@@ -650,7 +655,7 @@ class Upgrade_270 extends XoopsUpgrade
             return false;
         }
         $row = $this->db->fetchRow($result);
-        if (!$row || 64 !== (int) $row[0]) {
+        if (!$row || 'varchar' !== strtolower((string) $row[0]) || 64 !== (int) $row[1]) {
             return false;
         }
 
@@ -672,12 +677,20 @@ class Upgrade_270 extends XoopsUpgrade
     {
         $table = $this->db->prefix('profile_field');
 
-        if (!$this->tableExists($table)) {
+        $exists = $this->tableExists($table);
+        if (null === $exists) {
+            $this->logs[] = sprintf(
+                'Cannot verify existence of `%s`; information_schema query failed.',
+                $table
+            );
+            return false;
+        }
+        if (!$exists) {
             return true;
         }
 
         // Step 1: Ensure the column is varchar(64) — widen if narrower.
-        $sql    = "SELECT CHARACTER_MAXIMUM_LENGTH FROM `information_schema`.`COLUMNS`"
+        $sql    = "SELECT `DATA_TYPE`, `CHARACTER_MAXIMUM_LENGTH` FROM `information_schema`.`COLUMNS`"
                 . " WHERE `TABLE_SCHEMA` = DATABASE()"
                 . " AND `TABLE_NAME` = " . $this->db->quote($table)
                 . " AND `COLUMN_NAME` = 'field_name' LIMIT 1";
@@ -691,17 +704,28 @@ class Upgrade_270 extends XoopsUpgrade
             $this->logs[] = 'Unable to read profile_field.field_name column metadata';
             return false;
         }
-        $currentLen = (int) $row[0];
+        $dataType   = strtolower((string) $row[0]);
+        $currentLen = (int) $row[1];
+
         if ($currentLen > 64) {
             // Refuse to shrink silently — values could be truncated if the
             // server's sql_mode does not include STRICT_ALL_TABLES.
             $this->logs[] = sprintf(
-                'profile_field.field_name is varchar(%d); refusing to narrow to varchar(64) automatically. Reduce the column manually after verifying no values exceed 64 chars.',
+                'profile_field.field_name is %s(%d); refusing to narrow to varchar(64) automatically. Reduce the column manually after verifying no values exceed 64 chars.',
+                $dataType,
                 $currentLen
             );
             return false;
         }
-        if ($currentLen !== 64) {
+        if (!in_array($dataType, ['varchar', 'char'], true)) {
+            // Unexpected type (e.g. enum, text) — admin intervention required.
+            $this->logs[] = sprintf(
+                'profile_field.field_name has unexpected data type `%s`; refusing to convert to varchar(64) automatically.',
+                $dataType
+            );
+            return false;
+        }
+        if ('varchar' !== $dataType || $currentLen !== 64) {
             $alter = "ALTER TABLE `{$table}` MODIFY `field_name` varchar(64) NOT NULL DEFAULT ''";
             if (!$this->execOrFail($alter)) {
                 return false;
@@ -743,7 +767,11 @@ class Upgrade_270 extends XoopsUpgrade
     {
         $table = $this->db->prefix('profile_regstep');
 
-        if (!$this->tableExists($table)) {
+        $exists = $this->tableExists($table);
+        if (null === $exists) {
+            return false;
+        }
+        if (!$exists) {
             return true;
         }
 
@@ -789,7 +817,15 @@ class Upgrade_270 extends XoopsUpgrade
     {
         $table = $this->db->prefix('profile_regstep');
 
-        if (!$this->tableExists($table)) {
+        $exists = $this->tableExists($table);
+        if (null === $exists) {
+            $this->logs[] = sprintf(
+                'Cannot verify existence of `%s`; information_schema query failed.',
+                $table
+            );
+            return false;
+        }
+        if (!$exists) {
             return true;
         }
 
@@ -1002,9 +1038,16 @@ class Upgrade_270 extends XoopsUpgrade
     /**
      * Check whether a table exists in the current database.
      *
+     * Tri-state so callers can distinguish "module not installed" from
+     * "we don't know":
+     *   true  → table exists
+     *   false → table is absent (caller should skip)
+     *   null  → information_schema query failed (caller should log + fail,
+     *           never silently skip a possibly-present table)
+     *
      * @param string $table fully prefixed table name
      */
-    private function tableExists(string $table): bool
+    private function tableExists(string $table): ?bool
     {
         $sql    = "SELECT 1 FROM `information_schema`.`TABLES`"
                 . " WHERE `TABLE_SCHEMA` = DATABASE()"
@@ -1012,7 +1055,7 @@ class Upgrade_270 extends XoopsUpgrade
                 . " LIMIT 1";
         $result = $this->db->query($sql);
         if (!$this->db->isResultSet($result) || !($result instanceof \mysqli_result)) {
-            return false;
+            return null;
         }
 
         return (bool) $this->db->fetchArray($result);

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -831,16 +831,22 @@ class Upgrade_270 extends XoopsUpgrade
                 $countSql = "SELECT COUNT(*) FROM `{$table}`"
                           . " WHERE `field_name` IS NULL OR `field_name` = ''";
                 $countResult = $this->db->query($countSql);
-                if ($this->db->isResultSet($countResult) && $countResult instanceof \mysqli_result) {
-                    $countRow = $this->db->fetchRow($countResult);
-                    $conflictCount = $countRow ? (int) $countRow[0] : 0;
-                    if ($conflictCount > 1) {
-                        $this->logs[] = sprintf(
-                            'profile_field has %d rows where field_name is NULL or empty; coercing them via MODIFY ... NOT NULL DEFAULT \'\' would violate the UNIQUE index on field_name. Resolve these rows manually (assign distinct values or delete duplicates) and re-run the upgrade.',
-                            $conflictCount
-                        );
-                        return false;
-                    }
+                // Treat query failure as a hard error — falling through here
+                // would defeat the whole purpose of the pre-flight and let
+                // the subsequent MODIFY abort with a low-signal duplicate-key
+                // error instead of the actionable message below.
+                if (!$this->db->isResultSet($countResult) || !($countResult instanceof \mysqli_result)) {
+                    $this->logs[] = \sprintf(_DB_QUERY_ERROR, $countSql) . $this->db->error();
+                    return false;
+                }
+                $countRow = $this->db->fetchRow($countResult);
+                $conflictCount = $countRow ? (int) $countRow[0] : 0;
+                if ($conflictCount > 1) {
+                    $this->logs[] = sprintf(
+                        'profile_field has %d rows where field_name is NULL or empty; coercing them via MODIFY ... NOT NULL DEFAULT \'\' would violate the UNIQUE index on field_name. Resolve these rows manually (assign distinct values or delete duplicates) and re-run the upgrade.',
+                        $conflictCount
+                    );
+                    return false;
                 }
             }
 

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -672,7 +672,7 @@ class Upgrade_270 extends XoopsUpgrade
             || 'varchar' !== strtolower((string) $row[0])
             || 64 !== (int) $row[1]
             || 'NO' !== strtoupper((string) $row[2])
-            || '' !== $row[3]                  // strict: reject NULL default
+            || '' !== self::normaliseColumnDefault($row[3])  // reject NULL default
         ) {
             return false;
         }
@@ -754,10 +754,10 @@ class Upgrade_270 extends XoopsUpgrade
             $this->logs[] = 'Unable to read profile_field.field_name column metadata';
             return false;
         }
-        $dataType      = strtolower((string) $row[0]);
-        $currentLen    = (int) $row[1];
-        $isNullable    = 'YES' === strtoupper((string) $row[2]);
-        $currentDefault = $row[3];
+        $dataType       = strtolower((string) $row[0]);
+        $currentLen     = (int) $row[1];
+        $isNullable     = 'YES' === strtoupper((string) $row[2]);
+        $currentDefault = self::normaliseColumnDefault($row[3]);
 
         // Guard 1: reject unexpected types outright — admin must intervene.
         // Checked before the length guard so a `text` column (length 65535)
@@ -794,16 +794,44 @@ class Upgrade_270 extends XoopsUpgrade
                       || $isNullable
                       || ('' !== $currentDefault);
         if ($columnDiverges) {
+            // Guard 3: when the column is nullable and the UNIQUE index still
+            // exists, multiple rows may legally share NULL (SQL treats NULL !=
+            // NULL for uniqueness). Coercing NULL → '' via MODIFY NOT NULL
+            // would collapse them into duplicate '' values and either the
+            // MODIFY itself or the later ADD UNIQUE would fail with a low-
+            // signal duplicate-key error. Pre-flight a COUNT and refuse with
+            // an actionable message when > 1 row would collide.
+            if ($isNullable) {
+                $countSql = "SELECT COUNT(*) FROM `{$table}`"
+                          . " WHERE `field_name` IS NULL OR `field_name` = ''";
+                $countResult = $this->db->query($countSql);
+                if ($this->db->isResultSet($countResult) && $countResult instanceof \mysqli_result) {
+                    $countRow = $this->db->fetchRow($countResult);
+                    $conflictCount = $countRow ? (int) $countRow[0] : 0;
+                    if ($conflictCount > 1) {
+                        $this->logs[] = sprintf(
+                            'profile_field has %d rows where field_name is NULL or empty; coercing them via MODIFY ... NOT NULL DEFAULT \'\' would violate the UNIQUE index on field_name. Resolve these rows manually (assign distinct values or delete duplicates) and re-run the upgrade.',
+                            $conflictCount
+                        );
+                        return false;
+                    }
+                }
+            }
+
             // Log the specific divergence so admins can audit what changed —
             // especially important when nullability or default is being
             // rewritten (NULL values are coerced to '' by the MODIFY).
+            // Log values are htmlspecialchars-escaped because the upgrader
+            // renders $this->logs entries as HTML (joined with <br>).
             if ($isNullable || '' !== $currentDefault) {
                 $this->logs[] = sprintf(
                     'profile_field.field_name is %s(%d) %s DEFAULT %s — rewriting to varchar(64) NOT NULL DEFAULT \'\'. Any existing NULL values will be coerced to empty strings.',
-                    $dataType,
+                    htmlspecialchars($dataType, ENT_QUOTES, 'UTF-8'),
                     $currentLen,
                     $isNullable ? 'NULL' : 'NOT NULL',
-                    null === $currentDefault ? 'NULL' : "'{$currentDefault}'"
+                    null === $currentDefault
+                        ? 'NULL'
+                        : "'" . htmlspecialchars($currentDefault, ENT_QUOTES, 'UTF-8') . "'"
                 );
             }
             $alter = "ALTER TABLE `{$table}` MODIFY `field_name` varchar(64) NOT NULL DEFAULT ''";
@@ -1088,6 +1116,34 @@ class Upgrade_270 extends XoopsUpgrade
         $this->logs[] = \sprintf(_DB_QUERY_ERROR, $sql) . $this->db->error();
 
         return false;
+    }
+
+    /**
+     * Normalise an information_schema.COLUMNS.COLUMN_DEFAULT value.
+     *
+     * MariaDB 10.2.7+ wraps string-literal defaults in single quotes, so a
+     * column `DEFAULT ''` comes back as the 2-char string "''". MySQL (all
+     * versions) and MariaDB ≤10.2.6 return the bare literal (the empty
+     * string). This helper returns the unwrapped literal, or null when no
+     * default is set, so downstream callers can compare against the raw
+     * target value consistently across MySQL and MariaDB.
+     *
+     * @param mixed $default raw COLUMN_DEFAULT value as returned by mysqli
+     * @return string|null   unwrapped literal, or null when no default set
+     */
+    private static function normaliseColumnDefault(mixed $default): ?string
+    {
+        if (null === $default) {
+            return null;
+        }
+        $value = (string) $default;
+        if (strlen($value) >= 2
+            && str_starts_with($value, "'")
+            && str_ends_with($value, "'")
+        ) {
+            return substr($value, 1, -1);
+        }
+        return $value;
     }
 
     /**

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -707,9 +707,22 @@ class Upgrade_270 extends XoopsUpgrade
         $dataType   = strtolower((string) $row[0]);
         $currentLen = (int) $row[1];
 
+        // Guard 1: reject unexpected types outright — admin must intervene.
+        // Checked before the length guard so a `text` column (length 65535)
+        // produces a "type mismatch" diagnostic instead of a misleading
+        // "refusing to narrow" message.
+        if (!in_array($dataType, ['varchar', 'char'], true)) {
+            $this->logs[] = sprintf(
+                'profile_field.field_name has unexpected data type `%s`; refusing to convert to varchar(64) automatically.',
+                $dataType
+            );
+            return false;
+        }
+
+        // Guard 2: refuse to narrow a legitimate wide varchar/char column —
+        // values could be truncated if the server's sql_mode does not
+        // include STRICT_ALL_TABLES.
         if ($currentLen > 64) {
-            // Refuse to shrink silently — values could be truncated if the
-            // server's sql_mode does not include STRICT_ALL_TABLES.
             $this->logs[] = sprintf(
                 'profile_field.field_name is %s(%d); refusing to narrow to varchar(64) automatically. Reduce the column manually after verifying no values exceed 64 chars.',
                 $dataType,
@@ -717,14 +730,7 @@ class Upgrade_270 extends XoopsUpgrade
             );
             return false;
         }
-        if (!in_array($dataType, ['varchar', 'char'], true)) {
-            // Unexpected type (e.g. enum, text) — admin intervention required.
-            $this->logs[] = sprintf(
-                'profile_field.field_name has unexpected data type `%s`; refusing to convert to varchar(64) automatically.',
-                $dataType
-            );
-            return false;
-        }
+
         if ('varchar' !== $dataType || $currentLen !== 64) {
             $alter = "ALTER TABLE `{$table}` MODIFY `field_name` varchar(64) NOT NULL DEFAULT ''";
             if (!$this->execOrFail($alter)) {

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -615,29 +615,31 @@ class Upgrade_270 extends XoopsUpgrade
     //
     // Older installations have profile_field.field_name as varchar(64) with a
     // plain UNIQUE index on the full column (no explicit prefix). The
-    // normalize task enforces two invariants:
-    //   - column data type + length: varchar(64)
-    //   - index:                     UNIQUE `field_name` (`field_name`(64))
-    //                                USING BTREE
-    // Nullability and column default are not part of the checked invariant.
-    // When the MODIFY runs it sets NOT NULL DEFAULT '' to match the module's
-    // own install SQL, but a site that has intentionally made the column
-    // nullable or changed its default is left alone as long as type + length
-    // match — admin intervention required for those cases.
+    // normalize task enforces the full column and index shape defined by the
+    // module's own install SQL:
+    //   - column:  varchar(64) NOT NULL DEFAULT ''
+    //   - index:   UNIQUE `field_name` (`field_name`(64)) USING BTREE
+    // All four column attributes (type, length, nullability, default) are
+    // checked and rewritten when any diverge, so the task is truly idempotent
+    // and genuinely converges sites to the documented target. A site that has
+    // intentionally made the column nullable or changed its default will have
+    // those properties reset; existing NULL values would be coerced to '' by
+    // the MODIFY and a warning is logged so admins can audit.
     //
     // The explicit (64) prefix standardises DDL across installs so index
     // definitions read identically whether captured from schema dump or ALTER.
     // =========================================================================
 
     /**
-     * Check if profile_field.field_name is varchar(64) AND the unique index
-     * matches the canonical layout:
+     * Check if profile_field.field_name matches the full canonical shape:
+     *   varchar(64) NOT NULL DEFAULT '' AND
      *   UNIQUE `field_name` (`field_name`(64)).
      *
-     * Verifies the full index shape — not just the prefix length — so a
-     * non-UNIQUE or composite index that happens to be named `field_name`
-     * does not incorrectly pass the normalise check. Skipped silently when
-     * the table is absent (Profile module not installed).
+     * Verifies data type, length, nullability, default, and full index
+     * layout — not just prefix length — so a non-UNIQUE index, composite
+     * index, nullable column, or different default does not incorrectly
+     * pass the normalise check. Skipped silently when the table is absent
+     * (Profile module not installed).
      *
      * @return bool true if already normalised (no action needed)
      */
@@ -655,8 +657,9 @@ class Upgrade_270 extends XoopsUpgrade
             return true;
         }
 
-        // Column must be varchar(64)
-        $sql    = "SELECT `DATA_TYPE`, `CHARACTER_MAXIMUM_LENGTH` FROM `information_schema`.`COLUMNS`"
+        // Column must be varchar(64) NOT NULL DEFAULT ''
+        $sql    = "SELECT `DATA_TYPE`, `CHARACTER_MAXIMUM_LENGTH`, `IS_NULLABLE`, `COLUMN_DEFAULT`"
+                . " FROM `information_schema`.`COLUMNS`"
                 . " WHERE `TABLE_SCHEMA` = DATABASE()"
                 . " AND `TABLE_NAME` = " . $this->db->quote($table)
                 . " AND `COLUMN_NAME` = 'field_name' LIMIT 1";
@@ -665,7 +668,12 @@ class Upgrade_270 extends XoopsUpgrade
             return false;
         }
         $row = $this->db->fetchRow($result);
-        if (!$row || 'varchar' !== strtolower((string) $row[0]) || 64 !== (int) $row[1]) {
+        if (!$row
+            || 'varchar' !== strtolower((string) $row[0])
+            || 64 !== (int) $row[1]
+            || 'NO' !== strtoupper((string) $row[2])
+            || '' !== $row[3]                  // strict: reject NULL default
+        ) {
             return false;
         }
 
@@ -699,8 +707,13 @@ class Upgrade_270 extends XoopsUpgrade
     }
 
     /**
-     * Ensure profile_field.field_name is varchar(64) and its unique index
-     * uses an explicit (64) prefix.
+     * Ensure profile_field.field_name is varchar(64) NOT NULL DEFAULT ''
+     * and its unique index uses an explicit (64) prefix.
+     *
+     * Rewrites the column when any of type/length/nullability/default
+     * diverge from the target. A divergence on nullability or default is
+     * logged explicitly so admins can audit — NULL values are coerced to
+     * empty strings by the MODIFY.
      *
      * Skipped silently when the table is absent (Profile module not
      * installed). Skipped with a warning in the log when the column has
@@ -725,8 +738,9 @@ class Upgrade_270 extends XoopsUpgrade
             return true;
         }
 
-        // Step 1: Ensure the column is varchar(64) — widen if narrower.
-        $sql    = "SELECT `DATA_TYPE`, `CHARACTER_MAXIMUM_LENGTH` FROM `information_schema`.`COLUMNS`"
+        // Step 1: Ensure the column is varchar(64) NOT NULL DEFAULT ''.
+        $sql    = "SELECT `DATA_TYPE`, `CHARACTER_MAXIMUM_LENGTH`, `IS_NULLABLE`, `COLUMN_DEFAULT`"
+                . " FROM `information_schema`.`COLUMNS`"
                 . " WHERE `TABLE_SCHEMA` = DATABASE()"
                 . " AND `TABLE_NAME` = " . $this->db->quote($table)
                 . " AND `COLUMN_NAME` = 'field_name' LIMIT 1";
@@ -740,8 +754,10 @@ class Upgrade_270 extends XoopsUpgrade
             $this->logs[] = 'Unable to read profile_field.field_name column metadata';
             return false;
         }
-        $dataType   = strtolower((string) $row[0]);
-        $currentLen = (int) $row[1];
+        $dataType      = strtolower((string) $row[0]);
+        $currentLen    = (int) $row[1];
+        $isNullable    = 'YES' === strtoupper((string) $row[2]);
+        $currentDefault = $row[3];
 
         // Guard 1: reject unexpected types outright — admin must intervene.
         // Checked before the length guard so a `text` column (length 65535)
@@ -771,7 +787,25 @@ class Upgrade_270 extends XoopsUpgrade
             return true;
         }
 
-        if ('varchar' !== $dataType || $currentLen !== 64) {
+        // MODIFY if any of the four column attributes diverge from the target:
+        //   type = varchar, length = 64, NOT NULL, DEFAULT ''
+        $columnDiverges = ('varchar' !== $dataType)
+                      || (64 !== $currentLen)
+                      || $isNullable
+                      || ('' !== $currentDefault);
+        if ($columnDiverges) {
+            // Log the specific divergence so admins can audit what changed —
+            // especially important when nullability or default is being
+            // rewritten (NULL values are coerced to '' by the MODIFY).
+            if ($isNullable || '' !== $currentDefault) {
+                $this->logs[] = sprintf(
+                    'profile_field.field_name is %s(%d) %s DEFAULT %s — rewriting to varchar(64) NOT NULL DEFAULT \'\'. Any existing NULL values will be coerced to empty strings.',
+                    $dataType,
+                    $currentLen,
+                    $isNullable ? 'NULL' : 'NOT NULL',
+                    null === $currentDefault ? 'NULL' : "'{$currentDefault}'"
+                );
+            }
             $alter = "ALTER TABLE `{$table}` MODIFY `field_name` varchar(64) NOT NULL DEFAULT ''";
             if (!$this->execOrFail($alter)) {
                 return false;

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -27,7 +27,10 @@ use Xoops\Upgrade\UpgradeControl;
  *  8. cleanuplibraries       — Delete obsolete build artifacts from class/libraries/
  *  9. deletetinymce5nested   — Delete duplicate nested tinymce5/tinymce5/ directory
  * 10. deleteflashsanitizer   — Delete obsolete Flash text sanitizer plugin
- * 11. cleancache             — Clear compiled templates and cache files
+ * 11. normalizeprofilefieldname   — Normalize profile_field.field_name column + unique index (prefix 64)
+ * 12. normalizeprofileregstepsort — Normalize profile_regstep.sort index (step_name prefix 100)
+ * 13. normalizesessionpk          — Normalize session PRIMARY KEY (sess_id prefix 200)
+ * 14. cleancache             — Clear compiled templates and cache files
  *
  * @category     Upgrade
  * @copyright    (c) 2000-2026 XOOPS Project (https://xoops.org)
@@ -65,6 +68,9 @@ class Upgrade_270 extends XoopsUpgrade
             'cleanuplibraries',
             'deletetinymce5nested',
             'deleteflashsanitizer',
+            'normalizeprofilefieldname',
+            'normalizeprofileregstepsort',
+            'normalizesessionpk',
             'cleancache',
         ];
         $this->usedFiles = [];
@@ -607,7 +613,164 @@ class Upgrade_270 extends XoopsUpgrade
     }
 
     // =========================================================================
-    // Task 11: cleancache — Clear compiled templates and cache files
+    // Task 11: normalizeprofilefieldname — Normalize profile_field.field_name
+    //
+    // Older installations have profile_field.field_name as varchar(64) with a
+    // plain UNIQUE index on the full column (no explicit prefix). We want:
+    //   - column:  varchar(64) NOT NULL DEFAULT ''
+    //   - index:   UNIQUE `field_name` (`field_name`(64)) USING BTREE
+    // The explicit (64) prefix standardises DDL across installs so index
+    // definitions read identically whether captured from schema dump or ALTER.
+    // =========================================================================
+
+    /**
+     * Check if profile_field.field_name is varchar(64) AND the unique index
+     * has an explicit prefix of 64.
+     *
+     * @return bool true if already normalised (no action needed)
+     */
+    public function check_normalizeprofilefieldname(): bool
+    {
+        $table = $this->db->prefix('profile_field');
+
+        // Column width must be 64
+        $sql    = "SELECT CHARACTER_MAXIMUM_LENGTH FROM `information_schema`.`COLUMNS`"
+                . " WHERE `TABLE_SCHEMA` = DATABASE()"
+                . " AND `TABLE_NAME` = " . $this->db->quote($table)
+                . " AND `COLUMN_NAME` = 'field_name' LIMIT 1";
+        $result = $this->db->query($sql);
+        if (!$this->db->isResultSet($result) || !($result instanceof \mysqli_result)) {
+            return false;
+        }
+        $row = $this->db->fetchRow($result);
+        if (!$row || 64 !== (int) $row[0]) {
+            return false;
+        }
+
+        // Unique index `field_name` must have SUB_PART = 64
+        return 64 === $this->indexPrefixLength($table, 'field_name', 'field_name');
+    }
+
+    /**
+     * Ensure profile_field.field_name is varchar(64) and its unique index
+     * uses an explicit (64) prefix.
+     *
+     * @return bool true on success
+     */
+    public function apply_normalizeprofilefieldname(): bool
+    {
+        $table = $this->db->prefix('profile_field');
+
+        // Step 1: Ensure the column is varchar(64) — widen or narrow as needed.
+        $sql    = "SELECT CHARACTER_MAXIMUM_LENGTH FROM `information_schema`.`COLUMNS`"
+                . " WHERE `TABLE_SCHEMA` = DATABASE()"
+                . " AND `TABLE_NAME` = " . $this->db->quote($table)
+                . " AND `COLUMN_NAME` = 'field_name' LIMIT 1";
+        $result = $this->db->query($sql);
+        if (!$this->db->isResultSet($result) || !($result instanceof \mysqli_result)) {
+            $this->logs[] = \sprintf(_DB_QUERY_ERROR, $sql) . $this->db->error();
+            return false;
+        }
+        $row = $this->db->fetchRow($result);
+        if (!$row) {
+            $this->logs[] = 'Unable to read profile_field.field_name column metadata';
+            return false;
+        }
+        if (64 !== (int) $row[0]) {
+            $alter = "ALTER TABLE `{$table}` MODIFY `field_name` varchar(64) NOT NULL DEFAULT ''";
+            if (!$this->execOrFail($alter)) {
+                return false;
+            }
+        }
+
+        // Step 2: Recreate the unique index with an explicit prefix of 64.
+        if ($this->indexExists($table, 'field_name')) {
+            if (!$this->execOrFail("ALTER TABLE `{$table}` DROP INDEX `field_name`")) {
+                return false;
+            }
+        }
+        $addIndex = "ALTER TABLE `{$table}` ADD UNIQUE `field_name` (`field_name`(64)) USING BTREE";
+
+        return $this->execOrFail($addIndex);
+    }
+
+    // =========================================================================
+    // Task 12: normalizeprofileregstepsort — Normalize profile_regstep.sort index
+    //
+    // The historical prefix (100) on step_name is the canonical form. Target:
+    //   KEY `sort` (`step_order`, `step_name`(100)) USING BTREE
+    // Composite size under utf8mb4: 2 (smallint) + 100*4 = 402 bytes — safe
+    // on MyISAM (1000), default InnoDB 5.7 (767), and modern InnoDB (3072).
+    // =========================================================================
+
+    /**
+     * Check if the `sort` index already uses a 100-char prefix on step_name.
+     *
+     * @return bool true if already normalised (no action needed)
+     */
+    public function check_normalizeprofileregstepsort(): bool
+    {
+        $table = $this->db->prefix('profile_regstep');
+
+        return 100 === $this->indexPrefixLength($table, 'sort', 'step_name');
+    }
+
+    /**
+     * Recreate the `sort` index with an explicit (100) prefix on step_name.
+     *
+     * @return bool true on success
+     */
+    public function apply_normalizeprofileregstepsort(): bool
+    {
+        $table = $this->db->prefix('profile_regstep');
+
+        if ($this->indexExists($table, 'sort')) {
+            if (!$this->execOrFail("ALTER TABLE `{$table}` DROP INDEX `sort`")) {
+                return false;
+            }
+        }
+        $sql = "ALTER TABLE `{$table}` ADD KEY `sort` (`step_order`, `step_name`(100)) USING BTREE";
+
+        return $this->execOrFail($sql);
+    }
+
+    // =========================================================================
+    // Task 13: normalizesessionpk — Normalize session PRIMARY KEY
+    //
+    // Older installations used PRIMARY KEY (sess_id) indexing the full
+    // varchar(256) column. Target:
+    //   PRIMARY KEY (`sess_id`(200)) USING BTREE
+    // A 200-byte prefix keeps the PK inside InnoDB's 767-byte default limit
+    // if the table is ever migrated from MyISAM.
+    // =========================================================================
+
+    /**
+     * Check if the session PRIMARY KEY already uses a 200-char prefix on sess_id.
+     *
+     * @return bool true if already normalised (no action needed)
+     */
+    public function check_normalizesessionpk(): bool
+    {
+        $table = $this->db->prefix('session');
+
+        return 200 === $this->indexPrefixLength($table, 'PRIMARY', 'sess_id');
+    }
+
+    /**
+     * Recreate the session PRIMARY KEY with an explicit (200) prefix.
+     *
+     * @return bool true on success
+     */
+    public function apply_normalizesessionpk(): bool
+    {
+        $table = $this->db->prefix('session');
+        $sql   = "ALTER TABLE `{$table}` DROP PRIMARY KEY, ADD PRIMARY KEY (`sess_id`(200)) USING BTREE";
+
+        return $this->execOrFail($sql);
+    }
+
+    // =========================================================================
+    // Task 14: cleancache — Clear compiled templates and cache files
     // =========================================================================
 
     /**
@@ -753,6 +916,58 @@ class Upgrade_270 extends XoopsUpgrade
         $this->logs[] = \sprintf(_DB_QUERY_ERROR, $sql) . $this->db->error();
 
         return false;
+    }
+
+    /**
+     * Check whether an index exists on a table.
+     *
+     * @param string $table     fully prefixed table name
+     * @param string $indexName index name (use 'PRIMARY' for the primary key)
+     */
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $sql    = "SELECT 1 FROM `information_schema`.`STATISTICS`"
+                . " WHERE `TABLE_SCHEMA` = DATABASE()"
+                . " AND `TABLE_NAME` = " . $this->db->quote($table)
+                . " AND `INDEX_NAME` = " . $this->db->quote($indexName)
+                . " LIMIT 1";
+        $result = $this->db->query($sql);
+        if (!$this->db->isResultSet($result) || !($result instanceof \mysqli_result)) {
+            return false;
+        }
+
+        return (bool) $this->db->fetchArray($result);
+    }
+
+    /**
+     * Return the explicit prefix length for an index column, or null if the
+     * index/column pair does not exist or indexes the full column width.
+     *
+     * SUB_PART is NULL in information_schema.STATISTICS when no prefix was
+     * supplied at index-creation time — callers treat NULL as "not normalised".
+     *
+     * @param string $table      fully prefixed table name
+     * @param string $indexName  index name (use 'PRIMARY' for the primary key)
+     * @param string $columnName column name within the index
+     */
+    private function indexPrefixLength(string $table, string $indexName, string $columnName): ?int
+    {
+        $sql    = "SELECT `SUB_PART` FROM `information_schema`.`STATISTICS`"
+                . " WHERE `TABLE_SCHEMA` = DATABASE()"
+                . " AND `TABLE_NAME` = " . $this->db->quote($table)
+                . " AND `INDEX_NAME` = " . $this->db->quote($indexName)
+                . " AND `COLUMN_NAME` = " . $this->db->quote($columnName)
+                . " LIMIT 1";
+        $result = $this->db->query($sql);
+        if (!$this->db->isResultSet($result) || !($result instanceof \mysqli_result)) {
+            return null;
+        }
+        $row = $this->db->fetchRow($result);
+        if (!$row || null === $row[0]) {
+            return null;
+        }
+
+        return (int) $row[0];
     }
 }
 

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -627,11 +627,18 @@ class Upgrade_270 extends XoopsUpgrade
      * Check if profile_field.field_name is varchar(64) AND the unique index
      * has an explicit prefix of 64.
      *
+     * Skipped silently when the table is absent (Profile module not installed).
+     *
      * @return bool true if already normalised (no action needed)
      */
     public function check_normalizeprofilefieldname(): bool
     {
         $table = $this->db->prefix('profile_field');
+
+        // Profile module not installed → nothing to normalise; treat as done.
+        if (!$this->tableExists($table)) {
+            return true;
+        }
 
         // Column width must be 64
         $sql    = "SELECT CHARACTER_MAXIMUM_LENGTH FROM `information_schema`.`COLUMNS`"
@@ -655,13 +662,21 @@ class Upgrade_270 extends XoopsUpgrade
      * Ensure profile_field.field_name is varchar(64) and its unique index
      * uses an explicit (64) prefix.
      *
-     * @return bool true on success
+     * Skipped silently when the table is absent (Profile module not
+     * installed). Refuses to silently narrow a column that has been widened
+     * beyond 64 chars locally — the admin must resolve that manually.
+     *
+     * @return bool true on success (or table absent)
      */
     public function apply_normalizeprofilefieldname(): bool
     {
         $table = $this->db->prefix('profile_field');
 
-        // Step 1: Ensure the column is varchar(64) — widen or narrow as needed.
+        if (!$this->tableExists($table)) {
+            return true;
+        }
+
+        // Step 1: Ensure the column is varchar(64) — widen if narrower.
         $sql    = "SELECT CHARACTER_MAXIMUM_LENGTH FROM `information_schema`.`COLUMNS`"
                 . " WHERE `TABLE_SCHEMA` = DATABASE()"
                 . " AND `TABLE_NAME` = " . $this->db->quote($table)
@@ -676,7 +691,17 @@ class Upgrade_270 extends XoopsUpgrade
             $this->logs[] = 'Unable to read profile_field.field_name column metadata';
             return false;
         }
-        if (64 !== (int) $row[0]) {
+        $currentLen = (int) $row[0];
+        if ($currentLen > 64) {
+            // Refuse to shrink silently — values could be truncated if the
+            // server's sql_mode does not include STRICT_ALL_TABLES.
+            $this->logs[] = sprintf(
+                'profile_field.field_name is varchar(%d); refusing to narrow to varchar(64) automatically. Reduce the column manually after verifying no values exceed 64 chars.',
+                $currentLen
+            );
+            return false;
+        }
+        if ($currentLen !== 64) {
             $alter = "ALTER TABLE `{$table}` MODIFY `field_name` varchar(64) NOT NULL DEFAULT ''";
             if (!$this->execOrFail($alter)) {
                 return false;
@@ -704,7 +729,13 @@ class Upgrade_270 extends XoopsUpgrade
     // =========================================================================
 
     /**
-     * Check if the `sort` index already uses a 100-char prefix on step_name.
+     * Check if the `sort` index already uses the canonical layout:
+     *   (step_order, step_name(100)).
+     *
+     * Verifies the full layout (column order and prefixes), not just the
+     * prefix length on step_name — a partial hand-patch that left step_order
+     * out of the index must still be rebuilt. Skipped silently when the
+     * table is absent (Profile module not installed).
      *
      * @return bool true if already normalised (no action needed)
      */
@@ -712,17 +743,55 @@ class Upgrade_270 extends XoopsUpgrade
     {
         $table = $this->db->prefix('profile_regstep');
 
-        return 100 === $this->indexPrefixLength($table, 'sort', 'step_name');
+        if (!$this->tableExists($table)) {
+            return true;
+        }
+
+        $sql    = "SELECT `COLUMN_NAME`, `SEQ_IN_INDEX`, `SUB_PART`"
+                . " FROM `information_schema`.`STATISTICS`"
+                . " WHERE `TABLE_SCHEMA` = DATABASE()"
+                . " AND `TABLE_NAME` = " . $this->db->quote($table)
+                . " AND `INDEX_NAME` = 'sort'"
+                . " ORDER BY `SEQ_IN_INDEX`";
+        $result = $this->db->query($sql);
+        if (!$this->db->isResultSet($result) || !($result instanceof \mysqli_result)) {
+            return false;
+        }
+
+        $rows = [];
+        while ($row = $this->db->fetchRow($result)) {
+            $rows[] = $row;
+        }
+
+        // Expect exactly: [('step_order', 1, NULL), ('step_name', 2, 100)]
+        if (2 !== count($rows)) {
+            return false;
+        }
+        if ('step_order' !== $rows[0][0] || 1 !== (int) $rows[0][1] || null !== $rows[0][2]) {
+            return false;
+        }
+        if ('step_name' !== $rows[1][0] || 2 !== (int) $rows[1][1] || 100 !== (int) $rows[1][2]) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
-     * Recreate the `sort` index with an explicit (100) prefix on step_name.
+     * Recreate the `sort` index with the canonical layout
+     *   (step_order, step_name(100)) USING BTREE.
      *
-     * @return bool true on success
+     * Skipped silently when the table is absent (Profile module not installed).
+     *
+     * @return bool true on success (or table absent)
      */
     public function apply_normalizeprofileregstepsort(): bool
     {
         $table = $this->db->prefix('profile_regstep');
+
+        if (!$this->tableExists($table)) {
+            return true;
+        }
 
         if ($this->indexExists($table, 'sort')) {
             if (!$this->execOrFail("ALTER TABLE `{$table}` DROP INDEX `sort`")) {
@@ -759,14 +828,26 @@ class Upgrade_270 extends XoopsUpgrade
     /**
      * Recreate the session PRIMARY KEY with an explicit (200) prefix.
      *
+     * DROP and ADD are issued as separate statements so a session table
+     * that somehow lost its PRIMARY KEY (manual intervention, earlier
+     * failed migration) can still be normalised — a combined
+     * "DROP PRIMARY KEY, ADD PRIMARY KEY ..." would abort on the DROP.
+     *
      * @return bool true on success
      */
     public function apply_normalizesessionpk(): bool
     {
         $table = $this->db->prefix('session');
-        $sql   = "ALTER TABLE `{$table}` DROP PRIMARY KEY, ADD PRIMARY KEY (`sess_id`(200)) USING BTREE";
 
-        return $this->execOrFail($sql);
+        if ($this->indexExists($table, 'PRIMARY')) {
+            if (!$this->execOrFail("ALTER TABLE `{$table}` DROP PRIMARY KEY")) {
+                return false;
+            }
+        }
+
+        return $this->execOrFail(
+            "ALTER TABLE `{$table}` ADD PRIMARY KEY (`sess_id`(200)) USING BTREE"
+        );
     }
 
     // =========================================================================
@@ -916,6 +997,25 @@ class Upgrade_270 extends XoopsUpgrade
         $this->logs[] = \sprintf(_DB_QUERY_ERROR, $sql) . $this->db->error();
 
         return false;
+    }
+
+    /**
+     * Check whether a table exists in the current database.
+     *
+     * @param string $table fully prefixed table name
+     */
+    private function tableExists(string $table): bool
+    {
+        $sql    = "SELECT 1 FROM `information_schema`.`TABLES`"
+                . " WHERE `TABLE_SCHEMA` = DATABASE()"
+                . " AND `TABLE_NAME` = " . $this->db->quote($table)
+                . " LIMIT 1";
+        $result = $this->db->query($sql);
+        if (!$this->db->isResultSet($result) || !($result instanceof \mysqli_result)) {
+            return false;
+        }
+
+        return (bool) $this->db->fetchArray($result);
     }
 
     /**

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -616,9 +616,17 @@ class Upgrade_270 extends XoopsUpgrade
     // Task 11: normalizeprofilefieldname — Normalize profile_field.field_name
     //
     // Older installations have profile_field.field_name as varchar(64) with a
-    // plain UNIQUE index on the full column (no explicit prefix). We want:
-    //   - column:  varchar(64) NOT NULL DEFAULT ''
-    //   - index:   UNIQUE `field_name` (`field_name`(64)) USING BTREE
+    // plain UNIQUE index on the full column (no explicit prefix). The
+    // normalize task enforces two invariants:
+    //   - column data type + length: varchar(64)
+    //   - index:                     UNIQUE `field_name` (`field_name`(64))
+    //                                USING BTREE
+    // Nullability and column default are not part of the checked invariant.
+    // When the MODIFY runs it sets NOT NULL DEFAULT '' to match the module's
+    // own install SQL, but a site that has intentionally made the column
+    // nullable or changed its default is left alone as long as type + length
+    // match — admin intervention required for those cases.
+    //
     // The explicit (64) prefix standardises DDL across installs so index
     // definitions read identically whether captured from schema dump or ALTER.
     // =========================================================================

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -48,6 +48,14 @@ class Upgrade_270 extends XoopsUpgrade
     protected string $cleanCacheKey = 'cache-cleaned-270';
 
     /**
+     * @var string Session key set when apply_normalizeprofilefieldname has
+     *             already taken the skip-with-warning path for a widened
+     *             column this session. Read by check_ so the patch doesn't
+     *             stay permanently "not applied" on widened-column installs.
+     */
+    protected string $widenedFieldNameSkipKey = 'normalize-profilefield-widened-270';
+
+    /**
      * @param XoopsMySQLDatabase $db      database connection
      * @param UpgradeControl     $control upgrade control instance
      */
@@ -657,6 +665,14 @@ class Upgrade_270 extends XoopsUpgrade
             return true;
         }
 
+        // Skip-with-warning path was already taken this session for a widened
+        // column. apply_ logged the advisory and deferred to manual action —
+        // treat the task as settled so the overall patch can complete rather
+        // than looping forever on check_ returning false.
+        if (!empty($_SESSION[$this->widenedFieldNameSkipKey])) {
+            return true;
+        }
+
         // Column must be varchar(64) NOT NULL DEFAULT ''
         $sql    = "SELECT `DATA_TYPE`, `CHARACTER_MAXIMUM_LENGTH`, `IS_NULLABLE`, `COLUMN_DEFAULT`"
                 . " FROM `information_schema`.`COLUMNS`"
@@ -776,14 +792,18 @@ class Upgrade_270 extends XoopsUpgrade
         // STRICT_ALL_TABLES); recreating the UNIQUE index with prefix(64)
         // on a wider column would weaken uniqueness from "full width" to
         // "first 64 chars". Either outcome is worse than leaving the
-        // customised column alone, so the task logs a warning and returns
-        // true so the rest of the 2.7.0 upgrade is not blocked.
+        // customised column alone, so the task logs a warning, sets a
+        // session flag so check_ treats the task as resolved on subsequent
+        // isApplied() calls (otherwise the patch would remain permanently
+        // "not applied"), and returns true so the rest of the 2.7.0
+        // upgrade is not blocked.
         if ($currentLen > 64) {
             $this->logs[] = sprintf(
                 'profile_field.field_name is %s(%d); skipping index normalisation — column is wider than 64 chars. Reduce the column manually after verifying no values exceed 64 chars, then re-run the upgrade.',
                 $dataType,
                 $currentLen
             );
+            $_SESSION[$this->widenedFieldNameSkipKey] = true;
             return true;
         }
 

--- a/upgrade/upd_2.5.11-to-2.7.0/index.php
+++ b/upgrade/upd_2.5.11-to-2.7.0/index.php
@@ -633,9 +633,13 @@ class Upgrade_270 extends XoopsUpgrade
 
     /**
      * Check if profile_field.field_name is varchar(64) AND the unique index
-     * has an explicit prefix of 64.
+     * matches the canonical layout:
+     *   UNIQUE `field_name` (`field_name`(64)).
      *
-     * Skipped silently when the table is absent (Profile module not installed).
+     * Verifies the full index shape — not just the prefix length — so a
+     * non-UNIQUE or composite index that happens to be named `field_name`
+     * does not incorrectly pass the normalise check. Skipped silently when
+     * the table is absent (Profile module not installed).
      *
      * @return bool true if already normalised (no action needed)
      */
@@ -667,8 +671,33 @@ class Upgrade_270 extends XoopsUpgrade
             return false;
         }
 
-        // Unique index `field_name` must have SUB_PART = 64
-        return 64 === $this->indexPrefixLength($table, 'field_name', 'field_name');
+        // Unique index `field_name` must be the sole, single-column entry
+        // with SUB_PART = 64 and NON_UNIQUE = 0.
+        $sql    = "SELECT `COLUMN_NAME`, `SEQ_IN_INDEX`, `SUB_PART`, `NON_UNIQUE`"
+                . " FROM `information_schema`.`STATISTICS`"
+                . " WHERE `TABLE_SCHEMA` = DATABASE()"
+                . " AND `TABLE_NAME` = " . $this->db->quote($table)
+                . " AND `INDEX_NAME` = 'field_name'"
+                . " ORDER BY `SEQ_IN_INDEX`";
+        $result = $this->db->query($sql);
+        if (!$this->db->isResultSet($result) || !($result instanceof \mysqli_result)) {
+            return false;
+        }
+
+        $rows = [];
+        while ($row = $this->db->fetchRow($result)) {
+            $rows[] = $row;
+        }
+
+        // Expect exactly: [('field_name', 1, 64, 0)]
+        if (1 !== count($rows)) {
+            return false;
+        }
+
+        return 'field_name' === $rows[0][0]
+            && 1 === (int) $rows[0][1]
+            && 64 === (int) $rows[0][2]
+            && 0 === (int) $rows[0][3];
     }
 
     /**
@@ -876,7 +905,12 @@ class Upgrade_270 extends XoopsUpgrade
     // =========================================================================
 
     /**
-     * Check if the session PRIMARY KEY already uses a 200-char prefix on sess_id.
+     * Check if the session PRIMARY KEY matches the canonical layout:
+     *   PRIMARY KEY (`sess_id`(200)).
+     *
+     * Verifies the full PK shape — not just the prefix length on sess_id —
+     * so a composite PRIMARY KEY that happens to include `sess_id` with
+     * SUB_PART=200 does not incorrectly pass the normalise check.
      *
      * @return bool true if already normalised (no action needed)
      */
@@ -884,7 +918,30 @@ class Upgrade_270 extends XoopsUpgrade
     {
         $table = $this->db->prefix('session');
 
-        return 200 === $this->indexPrefixLength($table, 'PRIMARY', 'sess_id');
+        $sql    = "SELECT `COLUMN_NAME`, `SEQ_IN_INDEX`, `SUB_PART`"
+                . " FROM `information_schema`.`STATISTICS`"
+                . " WHERE `TABLE_SCHEMA` = DATABASE()"
+                . " AND `TABLE_NAME` = " . $this->db->quote($table)
+                . " AND `INDEX_NAME` = 'PRIMARY'"
+                . " ORDER BY `SEQ_IN_INDEX`";
+        $result = $this->db->query($sql);
+        if (!$this->db->isResultSet($result) || !($result instanceof \mysqli_result)) {
+            return false;
+        }
+
+        $rows = [];
+        while ($row = $this->db->fetchRow($result)) {
+            $rows[] = $row;
+        }
+
+        // Expect exactly: [('sess_id', 1, 200)]
+        if (1 !== count($rows)) {
+            return false;
+        }
+
+        return 'sess_id' === $rows[0][0]
+            && 1 === (int) $rows[0][1]
+            && 200 === (int) $rows[0][2];
     }
 
     /**


### PR DESCRIPTION
Add two idempotent upgrade tasks to the 2.5.11 → 2.7.0 patch that
standardise index DDL across fresh and upgraded installations:

- normalizeprofilefieldname   — ensures profile_field.field_name is
                                varchar(64) NOT NULL DEFAULT '' and its
                                UNIQUE index uses explicit prefix (64)
                                USING BTREE.
- normalizeprofileregstepsort — recreates profile_regstep.sort as
                                KEY (step_order, step_name(100)) USING BTREE,
                                non-UNIQUE.

Each check queries information_schema.COLUMNS / STATISTICS and asserts
the full expected layout (data type, length, nullability, default,
column order, prefix lengths, and NON_UNIQUE), so the tasks are both
strict about what they accept as "already normalised" and safe to
re-run against installations at any intermediate state. Two private
helpers (tableExists, indexExists) back the checks — both return ?bool
so callers can distinguish "object absent" from "information_schema
query failed" and log/abort appropriately rather than silently skip.

Edge cases:

- Task skips with a warning (not an abort) when the Profile module
  isn't installed or when field_name has been widened beyond 64 chars
  locally, so the remaining 2.7.0 upgrade tasks still run.
- Task rewrites nullability/default when they diverge from the
  documented target; a warning is logged explicitly because NULL
  values are coerced to '' by the MODIFY — admin-auditable.

Fresh-install SQL updated to converge on the same final state:

- modules/profile/sql/mysql.sql:
    profile_field UNIQUE KEY field_name → (field_name(64)) USING BTREE.
    profile_regstep KEY sort → (step_order, step_name(100)) USING BTREE.

Index sizes under utf8mb4 (4 bytes/char) stay within the 767-byte
InnoDB 5.7 default limit, keeping the schema portable to InnoDB
without innodb_large_prefix:

  profile_field.field_name : 64*4 = 256 bytes
  profile_regstep.sort     : 2 + 100*4 = 402 bytes

The session PRIMARY KEY change initially included in this branch has
been reverted (commit 0498b0d0). Reducing sess_id to a prefix(200)
index while the column stayed varchar(256) would have allowed two
distinct session IDs sharing the first 200 chars to collide under
ON DUPLICATE KEY UPDATE in kernel/session.php, silently overwriting
session data whenever PHP's session.sid_length was tuned beyond the
defaults. The 2.5.11 session PK had no correctness issue to fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * During upgrade to 2.7.0, profile module database schema definitions were standardized and normalized (indexes and field constraints) to ensure consistency and performance.
  * The upgrade now includes idempotent validation-and-fix tasks that detect schema drift and apply corrections automatically when needed.
  * Rearranged upgrade task ordering (cache-clean step moved).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->