### PR TITLE
TinyMCE default config was not actually loading the full plugin set.

### DIFF
--- a/htdocs/class/xoopseditor/tinymce7/settings.php
+++ b/htdocs/class/xoopseditor/tinymce7/settings.php
@@ -23,15 +23,15 @@
 return [
 	'theme' => 'silver',
 	'selector' => 'textarea#summary, textarea#body, textarea#message', // keep if targeting multiple fields
-	'plugins' => 'advlist anchor autolink charmap code hr image imagetools lists link media preview searchreplace table xoopsemoticons xoopscode', // removed 'xoopsimagemanager'
-	'toolbar' => 'undo redo | styleselect | bold italic | forecolor backcolor removeformat | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | table tabledelete | insertfile image media link | hr | xoopsemoticons xoopscode | code',
+	'plugins' => 'advlist,anchor,autolink,charmap,code,hr,image,imagetools,lists,link,media,preview,searchreplace,table,xoopsimagemanager,xoopsemoticons,xoopscode',
+	'toolbar' => 'undo redo | styles | bold italic | forecolor backcolor removeformat | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | table tabledelete | image media link | hr | xoopsimagemanager xoopsemoticons xoopscode | code',
 	'image_title' => true,
 	'table_use_colgroups' => true,
     // This option prevents tinyeditor from deleting empty tags
 	'valid_elements' => '*[*]',
 	'relative_urls' => false,
 	'body_class' => 'tinymce7-body',
-	'menubar' => false,
+	'menubar' => true,
 //	'content_css' => 'https://diversitybridge.net/themes/xswatch4/style.css', // newly added
 	'content_css' => XOOPS_THEME_URL . '/' . $GLOBALS['xoopsConfig']['theme_set'] . '/style.css',
 	'width' => '100%', // newly added

--- a/htdocs/class/xoopseditor/tinymce7/settings.php
+++ b/htdocs/class/xoopseditor/tinymce7/settings.php
@@ -23,7 +23,7 @@
 return [
 	'theme' => 'silver',
 	'selector' => 'textarea#summary, textarea#body, textarea#message', // keep if targeting multiple fields
-	'plugins' => 'advlist,anchor,autolink,charmap,code,hr,image,imagetools,lists,link,media,preview,searchreplace,table,xoopsimagemanager,xoopsemoticons,xoopscode',
+	'plugins' => 'advlist,anchor,autolink,charmap,code,hr,image,lists,link,media,preview,searchreplace,table,xoopsimagemanager,xoopsemoticons,xoopscode',
 	'toolbar' => 'undo redo | styles | bold italic | forecolor backcolor removeformat | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | table tabledelete | image media link | hr | xoopsimagemanager xoopsemoticons xoopscode | code',
 	'image_title' => true,
 	'table_use_colgroups' => true,


### PR DESCRIPTION
  - uses a comma-separated plugins list, which is what the XOOPS TinyMCE 7 loader expects
  - restores xoopsimagemanager to the loaded plugins and toolbar
  - enables the menubar again
  - replaces legacy styleselect with TinyMCE 7’s styles control
  - removes insertfile, which is not needed here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized editor toolbar with improved functionality
  * Enabled menu bar in the text editor
  * Enhanced plugin support for image management and emojis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->