### PR TITLE
RC-scoped 3.6.4 fixes for PHP 8, dblayertrap, and filter loading

### DIFF
--- a/htdocs/xoops_lib/modules/protector/class/ProtectorFilter.php
+++ b/htdocs/xoops_lib/modules/protector/class/ProtectorFilter.php
@@ -129,6 +129,14 @@ class ProtectorFilterHandler
                 || !str_starts_with($realPath, $baseReal . DIRECTORY_SEPARATOR)) {
                 continue;
             }
+            // Only include regular, readable files. realpath() succeeds for
+            // directories too, so an entry like "precommon_something.php/"
+            // (a directory that happens to end in .php) would otherwise reach
+            // include_once and emit a "failed to open stream: Is a directory"
+            // warning on every request. Same for permission-denied files.
+            if (!is_file($realPath) || !is_readable($realPath)) {
+                continue;
+            }
 
             include_once $realPath;
             $plugin_name = 'protector_' . substr($file, 0, -4);

--- a/htdocs/xoops_lib/modules/protector/class/ProtectorFilter.php
+++ b/htdocs/xoops_lib/modules/protector/class/ProtectorFilter.php
@@ -100,7 +100,13 @@ class ProtectorFilterHandler
         // every file readdir() returned, which allowed a writable filters_enabled
         // directory to achieve RCE if an attacker could place or symlink a file
         // whose name happened to start with the requested type prefix.
+        // If realpath() fails (missing dir, broken symlink), bail out now — every
+        // per-file containment check below would fail the same way.
         $baseReal = realpath($this->filters_base);
+        if (false === $baseReal) {
+            closedir($dh);
+            return $ret;
+        }
 
         while (($file = readdir($dh)) !== false) {
             if (strncmp($file, $type . '_', strlen($type) + 1) !== 0) {
@@ -120,7 +126,6 @@ class ProtectorFilterHandler
             // whose canonical path escapes the base.
             $realPath = realpath($this->filters_base . '/' . $file);
             if (false === $realPath
-                || false === $baseReal
                 || !str_starts_with($realPath, $baseReal . DIRECTORY_SEPARATOR)) {
                 continue;
             }

--- a/htdocs/xoops_lib/modules/protector/class/ProtectorFilter.php
+++ b/htdocs/xoops_lib/modules/protector/class/ProtectorFilter.php
@@ -91,18 +91,49 @@ class ProtectorFilterHandler
         $ret = 0;
 
         $dh = opendir($this->filters_base);
+        if (false === $dh) {
+            return $ret;
+        }
+
+        // Fix 9.1: resolve the filters_enabled base path once so every candidate
+        // filter can be verified to live inside it. The previous loader included
+        // every file readdir() returned, which allowed a writable filters_enabled
+        // directory to achieve RCE if an attacker could place or symlink a file
+        // whose name happened to start with the requested type prefix.
+        $baseReal = realpath($this->filters_base);
+
         while (($file = readdir($dh)) !== false) {
-            if (strncmp($file, $type . '_', strlen($type) + 1) === 0) {
-                include_once $this->filters_base . '/' . $file;
-                $plugin_name = 'protector_' . substr($file, 0, -4);
-                if (function_exists($plugin_name)) {
-                    // old way
-                    $ret |= call_user_func($plugin_name);
-                } elseif (class_exists($plugin_name)) {
-                    // newer way
-                    $plugin_obj = new $plugin_name(); //old code is -> $plugin_obj =& new $plugin_name() ; //hack by Trabis
-                    $ret |= $plugin_obj->execute();
-                }
+            if (strncmp($file, $type . '_', strlen($type) + 1) !== 0) {
+                continue;
+            }
+            // Require .php suffix — blocks .phtml, .inc, .phar and other executable
+            // extensions that may be interpreted as PHP by misconfigured servers.
+            // Case-insensitive: Windows NTFS and macOS HFS+ resolve case-variant
+            // filenames as the same file, and pre-existing custom filters may use
+            // .PHP / .Php. strcasecmp lets those continue to load on case-sensitive
+            // filesystems too.
+            if (0 !== strcasecmp(substr($file, -4), '.php')) {
+                continue;
+            }
+            // Resolve the real path and ensure it stays inside filters_enabled.
+            // Blocks symlinks pointing outside the directory and any crafted name
+            // whose canonical path escapes the base.
+            $realPath = realpath($this->filters_base . '/' . $file);
+            if (false === $realPath
+                || false === $baseReal
+                || !str_starts_with($realPath, $baseReal . DIRECTORY_SEPARATOR)) {
+                continue;
+            }
+
+            include_once $realPath;
+            $plugin_name = 'protector_' . substr($file, 0, -4);
+            if (function_exists($plugin_name)) {
+                // old way
+                $ret |= call_user_func($plugin_name);
+            } elseif (class_exists($plugin_name)) {
+                // newer way
+                $plugin_obj = new $plugin_name(); //old code is -> $plugin_obj =& new $plugin_name() ; //hack by Trabis
+                $ret |= $plugin_obj->execute();
             }
         }
         closedir($dh);

--- a/htdocs/xoops_lib/modules/protector/class/ProtectorMysqlDatabase.class.php
+++ b/htdocs/xoops_lib/modules/protector/class/ProtectorMysqlDatabase.class.php
@@ -45,7 +45,16 @@ class ProtectorMySQLDatabase extends XoopsMySQLDatabaseProxy
         $protector->last_error_type = 'SQL Injection';
         $protector->message .= $sql;
         $protector->output_log($protector->last_error_type);
-        die('SQL Injection found');
+
+        // Fix 1.4: reply with HTTP 403 and a generic body. The previous
+        // terminator returned HTTP 200 with a distinctive plain-text body,
+        // which fingerprinted the dblayertrap response and allowed attackers
+        // to probe the module's sensitivity character-by-character. A generic
+        // 'Forbidden' response matches any other blocked-request path.
+        if (!headers_sent()) {
+            http_response_code(403);
+        }
+        die('Forbidden');
     }
 
     /**

--- a/htdocs/xoops_lib/modules/protector/class/protector.php
+++ b/htdocs/xoops_lib/modules/protector/class/protector.php
@@ -141,7 +141,10 @@ class Protector
             }
 
             // register as doubtful requests against SQL Injections
-            if (preg_match('?[\s\'"`/]?', $val)) {
+            // Fix 1.1: '?' is not a valid PCRE delimiter. The previous pattern returned
+            // false from preg_match() on every call, disabling _doubtful_requests
+            // population and neutralising check_sql_union() and check_sql_isolatedcommentin().
+            if (preg_match('#[\s\'"`/]#', $val)) {
                 $this->_doubtful_requests[(string)$key] = $val;
             }
         }
@@ -242,7 +245,11 @@ class Protector
     public function purgeCookies()
     {
         if (!headers_sent()) {
-            $domain =  defined(XOOPS_COOKIE_DOMAIN) ? XOOPS_COOKIE_DOMAIN : '';
+            // Fix 1.2: defined() requires the constant name as a string literal.
+            // Without quotes PHP 8 throws a Fatal Error when XOOPS_COOKIE_DOMAIN is absent;
+            // when it is defined, PHP evaluates it first and passes its value to defined(),
+            // which is then always false.
+            $domain =  defined('XOOPS_COOKIE_DOMAIN') ? XOOPS_COOKIE_DOMAIN : '';
             $past = time() - 3600;
             foreach ($_COOKIE as $key => $value) {
                 setcookie($key, '', $past, '', $domain);
@@ -681,7 +688,44 @@ class Protector
         $this->_dblayertrap_check_recursive($_POST);
         $this->_dblayertrap_check_recursive($_COOKIE);
         if (empty($this->_conf['dblayertrap_wo_server'])) {
-            $this->_dblayertrap_check_recursive($_SERVER);
+            // Fix 1.5: scan only a positive allowlist of server-intrinsic $_SERVER keys.
+            // Any denylist over this surface is incomplete. Request-derived keys are
+            // excluded — attacker-controlled values in them would otherwise poison
+            // _dblayertrap_doubtfuls and trigger false-positive cascades on queries
+            // that happen to share a substring with the attacker's input.
+            //
+            // Excluded classes:
+            //   - HTTP_* (all request headers expand to this namespace)
+            //   - CONTENT_TYPE, CONTENT_LENGTH (request headers outside HTTP_*)
+            //   - PHP_AUTH_USER, PHP_AUTH_PW, PHP_AUTH_DIGEST, AUTH_TYPE (auth headers)
+            //   - QUERY_STRING, REQUEST_URI, PATH_INFO, PATH_TRANSLATED, ORIG_PATH_INFO (URL parts)
+            //   - REDIRECT_* (mod_rewrite/redirect context)
+            //   - PHP_SELF, SCRIPT_NAME (request-derived on URL-rewriting deployments;
+            //     Protector itself has documented XSS handling for these elsewhere)
+            //   - SERVER_NAME (reflects the Host header when UseCanonicalName is Off,
+            //     which is common on Apache and default on many reverse-proxied setups)
+            //   - REQUEST_METHOD (client-supplied token from the request line; Apache
+            //     and many other servers pass arbitrary method names like SELECT or
+            //     UNION straight through to PHP)
+            //   - SERVER_PROTOCOL (client-supplied token from the request line; a
+            //     lenient server can surface values like SELECT/1.0, and its realistic
+            //     contents HTTP/1.0 | HTTP/1.1 | HTTP/2.0 offer no SQLi signal anyway)
+            //
+            // The existing dblayertrap_wo_server config flag remains as the escape hatch
+            // for admins who want to skip the $_SERVER scan entirely.
+            static $serverScanAllowlist = [
+                'SERVER_ADDR'       => true,
+                'SERVER_PORT'       => true,
+                'SERVER_SOFTWARE'   => true,
+                'GATEWAY_INTERFACE' => true,
+                'DOCUMENT_ROOT'     => true,
+                'REQUEST_SCHEME'    => true,
+                'REMOTE_ADDR'       => true,
+                'REMOTE_PORT'       => true,
+                'SCRIPT_FILENAME'   => true,
+            ];
+            $serverSafe = array_intersect_key($_SERVER, $serverScanAllowlist);
+            $this->_dblayertrap_check_recursive($serverSafe);
         }
 
         if (!empty($this->_dblayertrap_doubtfuls) || $force_override) {
@@ -1284,7 +1328,15 @@ class Protector
         }
 
         // Check its Agent
-        if ('' != trim($this->_conf['dos_crsafe']) && isset($_SERVER['HTTP_USER_AGENT']) && preg_match($this->_conf['dos_crsafe'], $_SERVER['HTTP_USER_AGENT'])) {
+        // Fix 1.3 (runtime guard): an admin-supplied regex that is syntactically invalid
+        // would emit a PHP warning on every request. Probe validity against an empty
+        // subject first; silently ignore the setting if invalid.
+        // NOTE: this check covers SYNTAX only. A syntactically-valid but catastrophically
+        // backtracking pattern (ReDoS) still runs against the real User-Agent. Full
+        // admin-side validation and PCRE backtrack-limit handling defer to 3.7.0.
+        $crsafe_pattern = trim((string)($this->_conf['dos_crsafe'] ?? ''));
+        $crsafe_valid   = '' !== $crsafe_pattern && false !== @preg_match($crsafe_pattern, '');
+        if ($crsafe_valid && isset($_SERVER['HTTP_USER_AGENT']) && preg_match($crsafe_pattern, $_SERVER['HTTP_USER_AGENT'])) {
             // welcomed crawler
             $this->_done_dos = true;
 

--- a/htdocs/xoops_lib/modules/protector/class/protector.php
+++ b/htdocs/xoops_lib/modules/protector/class/protector.php
@@ -141,9 +141,11 @@ class Protector
             }
 
             // register as doubtful requests against SQL Injections
-            // Fix 1.1: '?' is not a valid PCRE delimiter. The previous pattern returned
-            // false from preg_match() on every call, disabling _doubtful_requests
-            // population and neutralising check_sql_union() and check_sql_isolatedcommentin().
+            // Fix 1.1: pin the PCRE delimiter to '#' for clarity. The legacy '?' form
+            // parsed correctly (PHP accepts '?' as a delimiter) but was visually
+            // ambiguous because '?' also serves as the zero-or-one quantifier. No
+            // detection-semantic change — the character class and match behaviour
+            // are identical to the previous form.
             if (preg_match('#[\s\'"`/]#', $val)) {
                 $this->_doubtful_requests[(string)$key] = $val;
             }

--- a/htdocs/xoops_lib/modules/protector/class/protector.php
+++ b/htdocs/xoops_lib/modules/protector/class/protector.php
@@ -250,7 +250,7 @@ class Protector
             // Fix 1.2: defined() requires the constant name as a string literal.
             // Without quotes PHP 8 throws a Fatal Error when XOOPS_COOKIE_DOMAIN is absent;
             // when it is defined, PHP evaluates it first and passes its value to defined(),
-            // which is then always false.
+            // so defined() checks the wrong constant name and will typically return false.
             $domain =  defined('XOOPS_COOKIE_DOMAIN') ? XOOPS_COOKIE_DOMAIN : '';
             $past = time() - 3600;
             foreach ($_COOKIE as $key => $value) {

--- a/tests/unit/htdocs/modules/protector/Protector364RcFixesTest.php
+++ b/tests/unit/htdocs/modules/protector/Protector364RcFixesTest.php
@@ -1,0 +1,441 @@
+<?php
+
+declare(strict_types=1);
+
+namespace modulesprotector;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for the Protector 3.6.4 RC fix tranche.
+ *
+ * Each test pins exactly one RC-safe fix so that a future regression is
+ * attributable to a single, small change. The fixes are intentionally
+ * low-blast-radius (pure bug fixes, no new detection features) because
+ * they ship during the XOOPS 2.7.0 RC window.
+ *
+ * Tests are source-level assertions where behavioural tests would require
+ * a live HTTP response, database connection, or terminating die() call.
+ * Each test documents what would be required for a full behavioural test
+ * and why the source assertion is sufficient for RC.
+ */
+#[CoversNothing]
+final class Protector364RcFixesTest extends TestCase
+{
+    private const PROTECTOR_FILE = XOOPS_PATH . '/modules/protector/class/protector.php';
+    private const DB_FILE        = XOOPS_PATH . '/modules/protector/class/ProtectorMysqlDatabase.class.php';
+    private const FILTER_FILE    = XOOPS_PATH . '/modules/protector/class/ProtectorFilter.php';
+
+    private static function readSource(string $path): string
+    {
+        $content = file_get_contents($path);
+        self::assertNotFalse($content, 'Unable to read source: ' . $path);
+        return $content;
+    }
+
+    /**
+     * Return the substring between two delimiter strings, or '' if not found.
+     * Used to assert "contains / does not contain" inside a specific block
+     * (e.g. inside an array literal) without getting false hits from comments.
+     */
+    private static function readBetween(string $haystack, string $start, string $end): string
+    {
+        $startPos = strpos($haystack, $start);
+        if (false === $startPos) {
+            return '';
+        }
+        $startPos += strlen($start);
+        $endPos    = strpos($haystack, $end, $startPos);
+        if (false === $endPos) {
+            return '';
+        }
+        return substr($haystack, $startPos, $endPos - $startPos);
+    }
+
+    // -------------------------------------------------------------------
+    // Fix 1.1 — doubtful-request regex delimiter
+    // -------------------------------------------------------------------
+
+    #[Test]
+    public function fix11_doubtfulRequestRegexUsesValidDelimiter(): void
+    {
+        $source = self::readSource(self::PROTECTOR_FILE);
+
+        // The broken "?...?" delimiter must not survive anywhere in the file.
+        $this->assertStringNotContainsString(
+            "preg_match('?[",
+            $source,
+            '"?" is not a valid PCRE delimiter — preg_match() returned false on every call'
+        );
+
+        // The replacement delimiter (#) plus opening \s in the character class
+        // must be present. Combined with the fix11_...Pattern test below, which
+        // verifies the pattern's semantics, this pins both the source change
+        // and its meaning.
+        $this->assertMatchesRegularExpression(
+            '/preg_match\(\s*\'#\[\\\\s/',
+            $source,
+            'Fix 1.1 must use # as the PCRE delimiter with \\s at the start of the character class'
+        );
+    }
+
+    #[Test]
+    public function fix11_doubtfulRequestPatternClassifiesInputCorrectly(): void
+    {
+        // Re-execute the exact regex the fix installed. Asserts the pattern
+        // itself matches the intended inputs; combined with the source
+        // assertion above, this pins both "what the code says" and
+        // "what the pattern means" against regression.
+        $pattern = '#[\s\'"`/]#';
+
+        $this->assertSame(1, preg_match($pattern, "1' OR '1'='1"), "SQL injection with quote");
+        $this->assertSame(1, preg_match($pattern, '1 UNION SELECT'), 'SQL injection with whitespace');
+        $this->assertSame(1, preg_match($pattern, "admin'--"), 'SQL comment injection');
+        $this->assertSame(1, preg_match($pattern, '/etc/passwd'), 'Path traversal');
+        $this->assertSame(1, preg_match($pattern, 'a b'), 'Plain whitespace');
+        $this->assertSame(0, preg_match($pattern, '42'), 'Plain integer');
+        $this->assertSame(0, preg_match($pattern, 'hello'), 'Plain alphanumeric');
+    }
+
+    // -------------------------------------------------------------------
+    // Fix 1.2 — defined() with quoted constant name
+    // -------------------------------------------------------------------
+
+    #[Test]
+    public function fix12_definedCallQuotesConstantName(): void
+    {
+        $source = self::readSource(self::PROTECTOR_FILE);
+
+        $this->assertStringNotContainsString(
+            'defined(XOOPS_COOKIE_DOMAIN)',
+            $source,
+            'Unquoted defined() triggers PHP 8 Fatal Error when the constant is absent'
+        );
+        $this->assertStringContainsString(
+            "defined('XOOPS_COOKIE_DOMAIN')",
+            $source,
+            'Constant name must be quoted as a string literal'
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // Fix 1.3 — dos_crsafe runtime validity guard
+    // -------------------------------------------------------------------
+
+    #[Test]
+    public function fix13_dosCrsafePatternIsValidatedBeforeUse(): void
+    {
+        $source = self::readSource(self::PROTECTOR_FILE);
+
+        // The guard probes the pattern with an empty subject. preg_match()
+        // returns false on a malformed pattern, so the === false comparison
+        // is the discriminator.
+        $this->assertMatchesRegularExpression(
+            '/false\s*!==\s*@preg_match\(/',
+            $source,
+            'Fix 1.3 must use @preg_match($pattern, "") !== false to probe validity'
+        );
+
+        // The original unguarded call pattern must be gone.
+        $this->assertStringNotContainsString(
+            "preg_match(\$this->_conf['dos_crsafe']",
+            $source,
+            'The unguarded preg_match() on admin-supplied regex must be replaced'
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // Fix 1.4 — injectionFound uses HTTP 403, not distinctive text body
+    // -------------------------------------------------------------------
+
+    #[Test]
+    public function fix14_injectionResponseUsesHttpForbidden(): void
+    {
+        $source = self::readSource(self::DB_FILE);
+
+        // A behavioural test would need to fork a process, issue a
+        // detectable SQL payload, and inspect the HTTP response — too
+        // heavy for RC. Source check: die text is generic and 403 is set.
+        $this->assertStringNotContainsString(
+            "die('SQL Injection found')",
+            $source,
+            'The distinctive "SQL Injection found" body allowed attackers to probe dblayertrap response'
+        );
+        $this->assertStringContainsString(
+            'http_response_code(403)',
+            $source,
+            'Must set HTTP 403 before terminating the request'
+        );
+        $this->assertMatchesRegularExpression(
+            "/die\(\s*'Forbidden'\s*\)/",
+            $source,
+            'Response body must be generic (matches other blocked-request paths)'
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // Fix 1.5 — ALL HTTP_* keys excluded from dblayertrap scan
+    // -------------------------------------------------------------------
+
+    #[Test]
+    public function fix15_dblayertrapUsesPositiveAllowlistForServerScan(): void
+    {
+        $source = self::readSource(self::PROTECTOR_FILE);
+
+        // The raw $_SERVER call must not reappear.
+        $this->assertStringNotContainsString(
+            '_dblayertrap_check_recursive($_SERVER)',
+            $source,
+            'Raw $_SERVER must not be scanned directly — attacker-controlled keys would poison doubtfuls'
+        );
+
+        // Positive allowlist is the discriminator. Any denylist approach
+        // (even filtering HTTP_*) is incomplete because CONTENT_TYPE,
+        // CONTENT_LENGTH, PHP_AUTH_*, AUTH_TYPE, QUERY_STRING, REQUEST_URI,
+        // PATH_INFO, PATH_TRANSLATED, ORIG_PATH_INFO, REDIRECT_* are also
+        // attacker-controlled outside HTTP_*.
+        $this->assertStringContainsString(
+            '$serverScanAllowlist',
+            $source,
+            'Fix 1.5 must use a positive allowlist, not a denylist'
+        );
+        $this->assertStringContainsString(
+            'array_intersect_key($_SERVER, $serverScanAllowlist)',
+            $source,
+            'Allowlist must be intersected against $_SERVER to keep ONLY named keys'
+        );
+
+        // Confirm the allowlist does NOT include attacker-controlled keys
+        // that a reviewer might be tempted to add. Keeping these out is the
+        // whole point of the fix.
+        //
+        // PHP_SELF and SCRIPT_NAME are excluded because they are reconstructed
+        // from the request path on URL-rewriting deployments (Protector's own
+        // IIS bootstrap at precheck.inc.php does exactly that) and Protector
+        // historically treats PHP_SELF as untrusted (explicit XSS handling).
+        //
+        // SERVER_NAME is excluded because it reflects the Host header when
+        // UseCanonicalName is Off, which is common on Apache and default on
+        // many reverse-proxied setups.
+        foreach (
+            [
+                'CONTENT_TYPE',
+                'CONTENT_LENGTH',
+                'PHP_AUTH_USER',
+                'PHP_AUTH_PW',
+                'PHP_AUTH_DIGEST',
+                'AUTH_TYPE',
+                'QUERY_STRING',
+                'REQUEST_URI',
+                'PATH_INFO',
+                'PATH_TRANSLATED',
+                'ORIG_PATH_INFO',
+                'PHP_SELF',
+                'SCRIPT_NAME',
+                'SERVER_NAME',
+                'REQUEST_METHOD',
+                'SERVER_PROTOCOL',
+            ] as $attackerControlledKey
+        ) {
+            $this->assertStringNotContainsString(
+                "'" . $attackerControlledKey . "'",
+                self::readBetween($source, 'serverScanAllowlist = [', '];'),
+                "Allowlist must not include request-influenced key {$attackerControlledKey}"
+            );
+        }
+    }
+
+    #[Test]
+    public function fix15_behaviouralRequestMetadataDoesNotPoisonDoubtfuls(): void
+    {
+        // Behavioural test for the whole attacker-controlled metadata surface.
+        // Each of these can legitimately carry an SQL-keyword substring in a
+        // crafted request:
+        //   - HTTP_X_SQL_PROBE  (arbitrary custom header via HTTP_* expansion)
+        //   - HTTP_USER_AGENT   (stock header)
+        //   - HTTP_FORWARDED    (RFC 7239 header)
+        //   - CONTENT_TYPE      (Content-Type header; not in HTTP_* namespace)
+        //   - CONTENT_LENGTH    (Content-Length header; not in HTTP_*)
+        //   - PHP_AUTH_USER     (Basic auth username)
+        //   - QUERY_STRING      (= $_GET serialized; already scanned via $_GET)
+        //   - REQUEST_URI       (URL path + query)
+        //   - PATH_INFO         (URL segment)
+        // None of them must appear in _dblayertrap_doubtfuls after the scan.
+        require_once XOOPS_PATH . '/modules/protector/class/protector.php';
+        $protector = \Protector::getInstance();
+
+        $priorServer   = $_SERVER;
+        $priorGet      = $_GET;
+        $priorPost     = $_POST;
+        $priorCookie   = $_COOKIE;
+        $priorWoServer = $protector->_conf['dblayertrap_wo_server'] ?? null;
+
+        $_GET                                      = [];
+        $_POST                                     = [];
+        $_COOKIE                                   = [];
+        $protector->_conf['dblayertrap_wo_server'] = 0;
+
+        $_SERVER['HTTP_USER_AGENT']  = 'stock-union-header';
+        $_SERVER['HTTP_X_SQL_PROBE'] = 'custom-select-header';
+        $_SERVER['HTTP_FORWARDED']   = 'rfc-information_schema-header';
+        $_SERVER['CONTENT_TYPE']     = 'application/select';
+        $_SERVER['CONTENT_LENGTH']   = 'union';
+        $_SERVER['PHP_AUTH_USER']    = 'admin-union';
+        $_SERVER['QUERY_STRING']     = 'q=select';
+        $_SERVER['REQUEST_URI']      = '/path-with-select-keyword';
+        $_SERVER['PATH_INFO']        = '/information_schema/segment';
+        // Request-derived-but-not-HTTP_* keys flagged by Codex as still-exploitable
+        // before the allowlist was trimmed.
+        $_SERVER['PHP_SELF']       = '/index.php/union/script';
+        $_SERVER['SCRIPT_NAME']    = '/index.php/select-suffix';
+        $_SERVER['SERVER_NAME']    = 'information_schema.attacker.example';
+        // REQUEST_METHOD is client-supplied from the HTTP request line. Apache and
+        // many other servers pass arbitrary method tokens through to PHP, so a
+        // request "SELECT /index.php HTTP/1.1" sets REQUEST_METHOD = "SELECT"
+        // which is 6 chars and matches the "select" needle.
+        $_SERVER['REQUEST_METHOD']   = 'SELECT';
+        // SERVER_PROTOCOL is also from the request line. A lenient server can pass
+        // through nonstandard tokens like SELECT/1.0 (10 chars — above the 6-char
+        // threshold and containing the "select" needle).
+        $_SERVER['SERVER_PROTOCOL'] = 'SELECT/1.0';
+
+        try {
+            $protector->dblayertrap_init(false);
+            $doubtfuls = $protector->getDblayertrapDoubtfuls();
+
+            $poisoning = [
+                'stock-union-header',
+                'custom-select-header',
+                'rfc-information_schema-header',
+                'application/select',
+                'union',
+                'admin-union',
+                'q=select',
+                '/path-with-select-keyword',
+                '/information_schema/segment',
+                '/index.php/union/script',
+                '/index.php/select-suffix',
+                'information_schema.attacker.example',
+                'SELECT',
+                'SELECT/1.0',
+            ];
+            foreach ($poisoning as $value) {
+                $this->assertNotContains(
+                    $value,
+                    $doubtfuls,
+                    "Attacker-controlled request metadata value '{$value}' must not poison doubtfuls"
+                );
+            }
+        } finally {
+            $_SERVER                                   = $priorServer;
+            $_GET                                      = $priorGet;
+            $_POST                                     = $priorPost;
+            $_COOKIE                                   = $priorCookie;
+            $protector->_conf['dblayertrap_wo_server'] = $priorWoServer;
+            $protector->_dblayertrap_doubtfuls         = [];
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Fix 9.1 — filter filename containment
+    // -------------------------------------------------------------------
+
+    #[Test]
+    public function fix91_filterLoaderRequiresPhpSuffixAndRealPathContainment(): void
+    {
+        $source = self::readSource(self::FILTER_FILE);
+
+        // Minimal RC hardening per Codex: require .php suffix (case-insensitive
+        // so NTFS / HFS+ deployments with .PHP / .Php filenames still load),
+        // resolve realpath, and verify the resolved file lives inside
+        // filters_enabled. Strict filename allowlist (precommon_/postcommon_/...)
+        // defers to 3.7.0 to avoid breaking custom deployments.
+        $this->assertMatchesRegularExpression(
+            "/strcasecmp\(\s*substr\(\\\$file, -4\)\s*,\s*'\.php'\s*\)/",
+            $source,
+            'Filter loader must require .php suffix case-insensitively'
+        );
+        $this->assertStringContainsString(
+            "realpath(\$this->filters_base . '/' . \$file)",
+            $source,
+            'Filter loader must resolve the real path for each candidate'
+        );
+        $this->assertStringContainsString(
+            'str_starts_with($realPath, $baseReal . DIRECTORY_SEPARATOR)',
+            $source,
+            'Filter loader must verify the resolved path stays inside filters_enabled'
+        );
+    }
+
+    #[Test]
+    public function fix91_behaviouralFilterLoaderAcceptsMixedCasePhpExtension(): void
+    {
+        // Behavioural test: set up a tempdir with a mixed-case .PHP filter file,
+        // point ProtectorFilterHandler at it, and assert execute() actually loads
+        // the file. Also verify the containment check rejects a filter placed
+        // outside the tempdir via a relative traversal path.
+        require_once XOOPS_PATH . '/modules/protector/class/protector.php';
+        require_once XOOPS_PATH . '/modules/protector/class/ProtectorFilter.php';
+
+        $tempDir = sys_get_temp_dir() . '/protector364test_' . uniqid();
+        mkdir($tempDir);
+
+        // Mixed-case extension — must load on case-sensitive filesystems too.
+        $mixedCasePath = $tempDir . '/precommon_mixcase.PHP';
+        file_put_contents(
+            $mixedCasePath,
+            "<?php function protector_precommon_mixcase() { return 42; }\n"
+        );
+
+        // A file with a non-PHP extension must be rejected even if its name prefix matches.
+        $phtmlPath = $tempDir . '/precommon_phtml_bait.phtml';
+        file_put_contents(
+            $phtmlPath,
+            "<?php function protector_precommon_phtml_bait() { return 99; }\n"
+        );
+
+        $handler = \ProtectorFilterHandler::getInstance();
+        $priorBase = $handler->filters_base;
+        $handler->filters_base = $tempDir;
+
+        try {
+            $result = $handler->execute('precommon');
+            $this->assertTrue(
+                function_exists('protector_precommon_mixcase'),
+                'Mixed-case .PHP filter must be loaded by the execute() loader'
+            );
+            $this->assertFalse(
+                function_exists('protector_precommon_phtml_bait'),
+                '.phtml filter must be rejected — not a valid PHP filter extension'
+            );
+            // Return value reflects the bitwise-OR of loaded filter returns.
+            $this->assertSame(42, $result, 'execute() should return the loaded filter result');
+        } finally {
+            $handler->filters_base = $priorBase;
+            @unlink($mixedCasePath);
+            @unlink($phtmlPath);
+            @rmdir($tempDir);
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Smoke test — core SQLi detection tokens still present
+    // -------------------------------------------------------------------
+
+    #[Test]
+    public function smokeTest_coreSqlInjectionNeedlesRemainInPlace(): void
+    {
+        // The 3.6.4 tranche must not remove detection tokens. A future
+        // FP-reduction pass (3.7.0) may demote 'select' once the Stage 2
+        // matcher has been fixed and measured, but not in RC.
+        $source = self::readSource(self::DB_FILE);
+
+        $this->assertStringContainsString("'union'", $source, 'UNION injection token must remain');
+        $this->assertStringContainsString("'information_schema'", $source, 'information_schema token must remain');
+        $this->assertStringContainsString("'/*'", $source, 'SQL block-comment token must remain');
+        $this->assertStringContainsString("'--'", $source, 'SQL line-comment token must remain');
+        $this->assertStringContainsString("'select'", $source, "'select' is retained in 3.6.4 — do not remove until 3.7.0 matcher fix validated");
+    }
+}

--- a/tests/unit/htdocs/modules/protector/Protector364RcFixesTest.php
+++ b/tests/unit/htdocs/modules/protector/Protector364RcFixesTest.php
@@ -36,44 +36,59 @@ final class Protector364RcFixesTest extends TestCase
     }
 
     /**
-     * Return the substring between two delimiter strings, or '' if not found.
+     * Return the substring between two delimiter strings, failing the test
+     * loudly if either delimiter is missing or the extracted block is empty.
+     *
      * Used to assert "contains / does not contain" inside a specific block
      * (e.g. inside an array literal) without getting false hits from comments.
+     * Fails-loud so that a future variable rename or formatting tweak that
+     * causes delimiter drift does NOT silently make "not-contains" assertions
+     * vacuous.
      */
     private static function readBetween(string $haystack, string $start, string $end): string
     {
         $startPos = strpos($haystack, $start);
-        if (false === $startPos) {
-            return '';
-        }
+        self::assertNotFalse(
+            $startPos,
+            "readBetween: start delimiter not found in source: {$start}"
+        );
         $startPos += strlen($start);
-        $endPos    = strpos($haystack, $end, $startPos);
-        if (false === $endPos) {
-            return '';
-        }
-        return substr($haystack, $startPos, $endPos - $startPos);
+        $endPos   = strpos($haystack, $end, $startPos);
+        self::assertNotFalse(
+            $endPos,
+            "readBetween: end delimiter not found after start in source: {$end}"
+        );
+        $block = substr($haystack, $startPos, $endPos - $startPos);
+        self::assertNotSame(
+            '',
+            trim($block),
+            "readBetween: extracted block between '{$start}' and '{$end}' is empty"
+        );
+        return $block;
     }
 
     // -------------------------------------------------------------------
-    // Fix 1.1 — doubtful-request regex delimiter
+    // Fix 1.1 — doubtful-request regex delimiter convention
     // -------------------------------------------------------------------
 
     #[Test]
-    public function fix11_doubtfulRequestRegexUsesValidDelimiter(): void
+    public function fix11_doubtfulRequestRegexUsesConventionalDelimiter(): void
     {
         $source = self::readSource(self::PROTECTOR_FILE);
 
-        // The broken "?...?" delimiter must not survive anywhere in the file.
+        // Pin the delimiter change for this file. '?' is a technically-valid
+        // PCRE delimiter in PHP, but '#' is the project convention and removes
+        // visual collision with the '?' zero-or-one quantifier. This test
+        // fails if anyone reverts the choice.
         $this->assertStringNotContainsString(
             "preg_match('?[",
             $source,
-            '"?" is not a valid PCRE delimiter — preg_match() returned false on every call'
+            'Legacy ?-delimited doubtful-request pattern must not be reintroduced'
         );
 
         // The replacement delimiter (#) plus opening \s in the character class
-        // must be present. Combined with the fix11_...Pattern test below, which
-        // verifies the pattern's semantics, this pins both the source change
-        // and its meaning.
+        // must be present. Combined with the pattern-semantics test below,
+        // this pins both the source change and its meaning.
         $this->assertMatchesRegularExpression(
             '/preg_match\(\s*\'#\[\\\\s/',
             $source,

--- a/tests/unit/htdocs/modules/protector/Protector364RcFixesTest.php
+++ b/tests/unit/htdocs/modules/protector/Protector364RcFixesTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace modulesprotector;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -263,8 +265,17 @@ final class Protector364RcFixesTest extends TestCase
     }
 
     #[Test]
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function fix15_behaviouralRequestMetadataDoesNotPoisonDoubtfuls(): void
     {
+        // Isolate this method in a forked process. dblayertrap_init() can
+        // @define('XOOPS_DB_ALTERNATIVE', ...) as a side effect if any poisoning
+        // value were to leak through (i.e. if Fix 1.5 regresses). On regression
+        // the assertion below fails — but without process isolation the constant
+        // would remain defined for the rest of the PHPUnit run and cascade into
+        // unrelated failures (notably ProtectorCorePreloadTest, which define()s
+        // the same constant itself). Forking keeps the failure local.
         // Behavioural test for the whole attacker-controlled metadata surface.
         // Each of these can legitimately carry an SQL-keyword substring in a
         // crafted request:

--- a/tests/unit/htdocs/modules/protector/Protector364RcFixesTest.php
+++ b/tests/unit/htdocs/modules/protector/Protector364RcFixesTest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace modulesprotector;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -265,17 +263,17 @@ final class Protector364RcFixesTest extends TestCase
     }
 
     #[Test]
-    #[RunInSeparateProcess]
-    #[PreserveGlobalState(false)]
     public function fix15_behaviouralRequestMetadataDoesNotPoisonDoubtfuls(): void
     {
-        // Isolate this method in a forked process. dblayertrap_init() can
-        // @define('XOOPS_DB_ALTERNATIVE', ...) as a side effect if any poisoning
-        // value were to leak through (i.e. if Fix 1.5 regresses). On regression
-        // the assertion below fails — but without process isolation the constant
-        // would remain defined for the rest of the PHPUnit run and cascade into
-        // unrelated failures (notably ProtectorCorePreloadTest, which define()s
-        // the same constant itself). Forking keeps the failure local.
+        // Failure-locality note: dblayertrap_init() can @define('XOOPS_DB_ALTERNATIVE', ...)
+        // as a side effect when _dblayertrap_doubtfuls is non-empty. On the happy path this
+        // test is deterministic (doubtfuls stay empty after the scan, so the define is
+        // skipped), but on a Fix 1.5 REGRESSION the define would fire before the assertion
+        // reports the failure — leaving the constant defined for the rest of the PHPUnit
+        // run. Process isolation via #[RunInSeparateProcess] would contain that, but hangs
+        // on Windows under PHPUnit 11's IPC stack with the XOOPS bootstrap. The accepted
+        // tradeoff: on regression, this test AND ProtectorCorePreloadTest fail loudly —
+        // the overall CI signal is still "fix needed", not a silent pass.
         // Behavioural test for the whole attacker-controlled metadata surface.
         // Each of these can legitimately carry an SQL-keyword substring in a
         // crafted request:
@@ -289,18 +287,27 @@ final class Protector364RcFixesTest extends TestCase
         //   - REQUEST_URI       (URL path + query)
         //   - PATH_INFO         (URL segment)
         // None of them must appear in _dblayertrap_doubtfuls after the scan.
+
+        // Snapshot and sanitise superglobals BEFORE getInstance(), not after.
+        // Protector::__construct() calls _initial_recursive($_GET/$_POST/$_COOKIE)
+        // during its first invocation in the process, so any inherited state
+        // from the runner or from a sibling test's mutations would be captured
+        // into $_doubtful_requests and survive the per-test cleanup below. In
+        // this suite Protector364RcFixesTest runs first alphabetically, so this
+        // behavioural test may be the first call to getInstance() in the whole
+        // PHPUnit process.
+        $priorServer = $_SERVER;
+        $priorGet    = $_GET;
+        $priorPost   = $_POST;
+        $priorCookie = $_COOKIE;
+
+        $_GET    = [];
+        $_POST   = [];
+        $_COOKIE = [];
+
         require_once XOOPS_PATH . '/modules/protector/class/protector.php';
-        $protector = \Protector::getInstance();
-
-        $priorServer   = $_SERVER;
-        $priorGet      = $_GET;
-        $priorPost     = $_POST;
-        $priorCookie   = $_COOKIE;
+        $protector     = \Protector::getInstance();
         $priorWoServer = $protector->_conf['dblayertrap_wo_server'] ?? null;
-
-        $_GET                                      = [];
-        $_POST                                     = [];
-        $_COOKIE                                   = [];
         $protector->_conf['dblayertrap_wo_server'] = 0;
 
         // Replace $_SERVER with a minimal deterministic fixture. Without this

--- a/tests/unit/htdocs/modules/protector/Protector364RcFixesTest.php
+++ b/tests/unit/htdocs/modules/protector/Protector364RcFixesTest.php
@@ -292,29 +292,45 @@ final class Protector364RcFixesTest extends TestCase
         $_COOKIE                                   = [];
         $protector->_conf['dblayertrap_wo_server'] = 0;
 
-        $_SERVER['HTTP_USER_AGENT']  = 'stock-union-header';
-        $_SERVER['HTTP_X_SQL_PROBE'] = 'custom-select-header';
-        $_SERVER['HTTP_FORWARDED']   = 'rfc-information_schema-header';
-        $_SERVER['CONTENT_TYPE']     = 'application/select';
-        $_SERVER['CONTENT_LENGTH']   = 'union';
-        $_SERVER['PHP_AUTH_USER']    = 'admin-union';
-        $_SERVER['QUERY_STRING']     = 'q=select';
-        $_SERVER['REQUEST_URI']      = '/path-with-select-keyword';
-        $_SERVER['PATH_INFO']        = '/information_schema/segment';
-        // Request-derived-but-not-HTTP_* keys flagged by Codex as still-exploitable
-        // before the allowlist was trimmed.
-        $_SERVER['PHP_SELF']       = '/index.php/union/script';
-        $_SERVER['SCRIPT_NAME']    = '/index.php/select-suffix';
-        $_SERVER['SERVER_NAME']    = 'information_schema.attacker.example';
-        // REQUEST_METHOD is client-supplied from the HTTP request line. Apache and
-        // many other servers pass arbitrary method tokens through to PHP, so a
-        // request "SELECT /index.php HTTP/1.1" sets REQUEST_METHOD = "SELECT"
-        // which is 6 chars and matches the "select" needle.
-        $_SERVER['REQUEST_METHOD']   = 'SELECT';
-        // SERVER_PROTOCOL is also from the request line. A lenient server can pass
-        // through nonstandard tokens like SELECT/1.0 (10 chars — above the 6-char
-        // threshold and containing the "select" needle).
-        $_SERVER['SERVER_PROTOCOL'] = 'SELECT/1.0';
+        // Replace $_SERVER with a minimal deterministic fixture. Without this
+        // the runner-provided values for allowlisted keys (DOCUMENT_ROOT,
+        // SCRIPT_FILENAME, REMOTE_ADDR, etc.) could happen to contain an SQL
+        // keyword substring from the CI environment and populate doubtfuls,
+        // triggering unrelated define(XOOPS_DB_ALTERNATIVE) side effects.
+        $_SERVER = [
+            // Poisoning payloads — each contains an SQL-keyword substring in
+            // a key that the allowlist MUST exclude (HTTP_*, CONTENT_*,
+            // PHP_AUTH_*, URL-derived, PHP_SELF/SCRIPT_NAME/SERVER_NAME,
+            // REQUEST_METHOD, SERVER_PROTOCOL).
+            'HTTP_USER_AGENT'  => 'stock-union-header',
+            'HTTP_X_SQL_PROBE' => 'custom-select-header',
+            'HTTP_FORWARDED'   => 'rfc-information_schema-header',
+            'CONTENT_TYPE'     => 'application/select',
+            'CONTENT_LENGTH'   => 'union',
+            'PHP_AUTH_USER'    => 'admin-union',
+            'QUERY_STRING'     => 'q=select',
+            'REQUEST_URI'      => '/path-with-select-keyword',
+            'PATH_INFO'        => '/information_schema/segment',
+            // Request-derived-but-not-HTTP_* keys that were still exploitable
+            // before the allowlist was trimmed.
+            'PHP_SELF'         => '/index.php/union/script',
+            'SCRIPT_NAME'      => '/index.php/select-suffix',
+            'SERVER_NAME'      => 'information_schema.attacker.example',
+            'REQUEST_METHOD'   => 'SELECT',
+            'SERVER_PROTOCOL'  => 'SELECT/1.0',
+            // Explicit safe values for every key in the production allowlist
+            // so CI environment values cannot seed doubtfuls independently of
+            // the attack surface under test.
+            'SERVER_ADDR'       => '127.0.0.1',
+            'SERVER_PORT'       => '80',
+            'SERVER_SOFTWARE'   => 'test-runner',
+            'GATEWAY_INTERFACE' => 'CGI/1.1',
+            'DOCUMENT_ROOT'     => '/tmp',
+            'REQUEST_SCHEME'    => 'http',
+            'REMOTE_ADDR'       => '192.0.2.1',
+            'REMOTE_PORT'       => '12345',
+            'SCRIPT_FILENAME'   => '/tmp/test.php',
+        ];
 
         try {
             $protector->dblayertrap_init(false);
@@ -394,22 +410,31 @@ final class Protector364RcFixesTest extends TestCase
         require_once XOOPS_PATH . '/modules/protector/class/protector.php';
         require_once XOOPS_PATH . '/modules/protector/class/ProtectorFilter.php';
 
-        $tempDir = sys_get_temp_dir() . '/protector364test_' . uniqid();
-        mkdir($tempDir);
+        // Allocate a unique, collision-resistant path via tempnam(), then swap
+        // the placeholder file for a directory of the same name. This is safer
+        // than sys_get_temp_dir() + uniqid() under parallel test runs, and any
+        // failure along the way fails the test with a clear message instead
+        // of propagating as a later "file not found" from execute().
+        $tempDir = tempnam(sys_get_temp_dir(), 'protector364test_');
+        $this->assertNotFalse($tempDir, 'Failed to allocate a unique temporary path for the filter loader test');
+        $this->assertTrue(@unlink($tempDir), 'Failed to clear temporary placeholder before creating test directory');
+        $this->assertTrue(@mkdir($tempDir, 0700), 'Failed to create temporary filter test directory');
 
         // Mixed-case extension — must load on case-sensitive filesystems too.
-        $mixedCasePath = $tempDir . '/precommon_mixcase.PHP';
-        file_put_contents(
+        $mixedCasePath  = $tempDir . '/precommon_mixcase.PHP';
+        $mixedCaseBytes = file_put_contents(
             $mixedCasePath,
             "<?php function protector_precommon_mixcase() { return 42; }\n"
         );
+        $this->assertNotFalse($mixedCaseBytes, 'Failed to write mixed-case PHP filter fixture');
 
         // A file with a non-PHP extension must be rejected even if its name prefix matches.
-        $phtmlPath = $tempDir . '/precommon_phtml_bait.phtml';
-        file_put_contents(
+        $phtmlPath  = $tempDir . '/precommon_phtml_bait.phtml';
+        $phtmlBytes = file_put_contents(
             $phtmlPath,
             "<?php function protector_precommon_phtml_bait() { return 99; }\n"
         );
+        $this->assertNotFalse($phtmlBytes, 'Failed to write non-PHP filter fixture');
 
         $handler = \ProtectorFilterHandler::getInstance();
         $priorBase = $handler->filters_base;

--- a/tests/unit/htdocs/modules/protector/Protector364RcFixesTest.php
+++ b/tests/unit/htdocs/modules/protector/Protector364RcFixesTest.php
@@ -234,6 +234,10 @@ final class Protector364RcFixesTest extends TestCase
         // SERVER_NAME is excluded because it reflects the Host header when
         // UseCanonicalName is Off, which is common on Apache and default on
         // many reverse-proxied setups.
+        // Extract the allowlist block once, then assert via regex that catches
+        // both quote styles. A plain substring check against "'KEY'" would miss
+        // a regression written as "KEY" => true.
+        $allowlistSource = self::readBetween($source, 'serverScanAllowlist = [', '];');
         foreach (
             [
                 'CONTENT_TYPE',
@@ -254,9 +258,9 @@ final class Protector364RcFixesTest extends TestCase
                 'SERVER_PROTOCOL',
             ] as $attackerControlledKey
         ) {
-            $this->assertStringNotContainsString(
-                "'" . $attackerControlledKey . "'",
-                self::readBetween($source, 'serverScanAllowlist = [', '];'),
+            $this->assertDoesNotMatchRegularExpression(
+                '/[\'"]' . preg_quote($attackerControlledKey, '/') . '[\'"]\s*=>/',
+                $allowlistSource,
                 "Allowlist must not include request-influenced key {$attackerControlledKey}"
             );
         }

--- a/tests/unit/htdocs/modules/protector/Protector364RcFixesTest.php
+++ b/tests/unit/htdocs/modules/protector/Protector364RcFixesTest.php
@@ -454,9 +454,27 @@ final class Protector364RcFixesTest extends TestCase
         );
         $this->assertNotFalse($phtmlBytes, 'Failed to write non-PHP filter fixture');
 
+        // A DIRECTORY that matches the {type}_*.php pattern must be skipped silently.
+        // realpath() succeeds on directories, so without the is_file() guard the loader
+        // would reach include_once() on a directory path and emit a PHP warning on
+        // every request. This covers the silent-continue guard at ProtectorFilter.php.
+        $directoryTrapPath = $tempDir . '/precommon_directory_trap.php';
+        $this->assertTrue(
+            @mkdir($directoryTrapPath, 0700),
+            'Failed to create directory-trap fixture'
+        );
+
         $handler = \ProtectorFilterHandler::getInstance();
         $priorBase = $handler->filters_base;
         $handler->filters_base = $tempDir;
+
+        // Capture any PHP warnings emitted during execute() — the directory-trap
+        // guard means there must be none.
+        $warnings = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$warnings): bool {
+            $warnings[] = [$errno, $errstr];
+            return true;
+        });
 
         try {
             $result = $handler->execute('precommon');
@@ -470,10 +488,19 @@ final class Protector364RcFixesTest extends TestCase
             );
             // Return value reflects the bitwise-OR of loaded filter returns.
             $this->assertSame(42, $result, 'execute() should return the loaded filter result');
+            // No warnings should have been emitted — the directory trap must be
+            // skipped silently, not trigger an include_once() warning.
+            $this->assertSame(
+                [],
+                $warnings,
+                'Directory matching {type}_*.php must not cause include warnings'
+            );
         } finally {
+            restore_error_handler();
             $handler->filters_base = $priorBase;
             @unlink($mixedCasePath);
             @unlink($phtmlPath);
+            @rmdir($directoryTrapPath);
             @rmdir($tempDir);
         }
     }


### PR DESCRIPTION
  Several low-blast-radius corrections for the XOOPS 2.7.0 RC lane.
  Each change is small, independently revertable, and scoped to bug
  and compatibility fixes — no new detection features, config
  options, schema changes, or dependencies.

  - PHP 8 compatibility fix in cookie cleanup path
  - More defensive handling of an admin-configurable pattern setting
  - Tightened response path for blocked queries
  - Tightened filter-file loading to require explicit extensions and resolved-path containment under the enabled-filters directory
  - Refined request-metadata scanning to limit inputs to server-process-intrinsic values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened plugin/filter loader: stricter filename checks, case-insensitive .php handling, realpath resolution and containment to prevent escapes.
  * Blocked responses now set HTTP 403 and return generic "Forbidden" on SQLi detection.
  * Fixed cookie-domain detection by quoting the constant name.
  * dblayertrap now scans a restricted server-key allowlist instead of raw $_SERVER.
  * Unified regex delimiter and added runtime validation for request/DOS patterns.

* **Tests**
  * Added regression tests covering all above behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->