### PR TITLE
fix(xbootstrap5): load runtime scripts in the right order

### DIFF
--- a/htdocs/themes/xbootstrap5/js/js.js
+++ b/htdocs/themes/xbootstrap5/js/js.js
@@ -3,8 +3,8 @@
 function initBootstrapCarousels(options) {
 	jQuery(function ($) {
 		$('.carousel').each(function () {
-			if (window.bootstrap && window.bootstrap.Carousel) {
-				window.bootstrap.Carousel.getOrCreateInstance(this, options);
+			if (globalThis.bootstrap?.Carousel) {
+				globalThis.bootstrap.Carousel.getOrCreateInstance(this, options);
 			} else if (typeof $.fn.carousel === 'function') {
 				$(this).carousel(options);
 			} else {
@@ -66,8 +66,8 @@ function initSlider() {
 }
 
 // Load when browser is idle
-if ('requestIdleCallback' in window) {
-	requestIdleCallback(initSlider);
+if ('requestIdleCallback' in globalThis) {
+	globalThis.requestIdleCallback(initSlider);
 } else {
 	setTimeout(initSlider, 200); // fallback
 }

--- a/htdocs/themes/xbootstrap5/js/js.js
+++ b/htdocs/themes/xbootstrap5/js/js.js
@@ -1,5 +1,19 @@
 // JavaScript Document
 
+function initBootstrapCarousels(options) {
+	jQuery(function ($) {
+		$('.carousel').each(function () {
+			if (window.bootstrap && window.bootstrap.Carousel) {
+				window.bootstrap.Carousel.getOrCreateInstance(this, options);
+			} else if (typeof $.fn.carousel === 'function') {
+				$(this).carousel(options);
+			} else {
+				console.warn('Bootstrap carousel API not available.');
+			}
+		});
+	});
+}
+
 /* Scroll Top */
 jQuery(function ($) {
 	if (typeof $.scrollUp === 'function') {
@@ -20,12 +34,10 @@ jQuery(function ($) {
 });
 
 /* Bootstrap Carousel */
-jQuery(function ($) {
-	$('.carousel').carousel({
-		interval: 5000,
-		pause: 'hover',
-		wrap: true
-	});
+initBootstrapCarousels({
+	interval: 5000,
+	pause: 'hover',
+	wrap: true
 });
 
 /* Masonry Grid */
@@ -47,11 +59,9 @@ jQuery(function ($) {
 
 /* Slider init */
 function initSlider() {
-	jQuery(function ($) {
-		$('.carousel').carousel({
-			interval: 5000,
-			ride: 'carousel'
-		});
+	initBootstrapCarousels({
+		interval: 5000,
+		wrap: true
 	});
 }
 

--- a/htdocs/themes/xbootstrap5/js/js.js
+++ b/htdocs/themes/xbootstrap5/js/js.js
@@ -10,7 +10,7 @@ function initBootstrapCarousels($, options) {
 		return;
 	}
 
-	if (root.bootstrap?.Carousel) {
+	if (root.bootstrap && root.bootstrap.Carousel) {
 		$carousels.each(function () {
 			root.bootstrap.Carousel.getOrCreateInstance(this, options);
 		});

--- a/htdocs/themes/xbootstrap5/js/js.js
+++ b/htdocs/themes/xbootstrap5/js/js.js
@@ -1,17 +1,27 @@
 // JavaScript Document
 
-function initBootstrapCarousels(options) {
-	jQuery(function ($) {
-		$('.carousel').each(function () {
-			if (globalThis.bootstrap?.Carousel) {
-				globalThis.bootstrap.Carousel.getOrCreateInstance(this, options);
-			} else if (typeof $.fn.carousel === 'function') {
-				$(this).carousel(options);
-			} else {
-				console.warn('Bootstrap carousel API not available.');
-			}
+function initBootstrapCarousels($, options) {
+	var $carousels = $('.carousel');
+
+	if (!$carousels.length) {
+		return;
+	}
+
+	if (globalThis.bootstrap?.Carousel) {
+		$carousels.each(function () {
+			globalThis.bootstrap.Carousel.getOrCreateInstance(this, options);
 		});
-	});
+
+		return;
+	}
+
+	if (typeof $.fn.carousel === 'function') {
+		$carousels.carousel(options);
+
+		return;
+	}
+
+	console.warn('Bootstrap carousel API not available.');
 }
 
 /* Scroll Top */
@@ -34,10 +44,12 @@ jQuery(function ($) {
 });
 
 /* Bootstrap Carousel */
-initBootstrapCarousels({
-	interval: 5000,
-	pause: 'hover',
-	wrap: true
+jQuery(function ($) {
+	initBootstrapCarousels($, {
+		interval: 5000,
+		pause: 'hover',
+		wrap: true
+	});
 });
 
 /* Masonry Grid */
@@ -56,18 +68,3 @@ jQuery(function ($) {
 	$(".newbb-links").find('span').removeClass('forum_icon forum_button');
 	$('.newbb-thread-attachment').find('br, hr').remove();
 });
-
-/* Slider init */
-function initSlider() {
-	initBootstrapCarousels({
-		interval: 5000,
-		wrap: true
-	});
-}
-
-// Load when browser is idle
-if ('requestIdleCallback' in globalThis) {
-	globalThis.requestIdleCallback(initSlider);
-} else {
-	setTimeout(initSlider, 200); // fallback
-}

--- a/htdocs/themes/xbootstrap5/js/js.js
+++ b/htdocs/themes/xbootstrap5/js/js.js
@@ -1,15 +1,18 @@
 // JavaScript Document
 
 function initBootstrapCarousels($, options) {
-	var $carousels = $('.carousel');
+	const root = typeof globalThis !== 'undefined'
+		? globalThis
+		: (typeof window !== 'undefined' ? window : (typeof self !== 'undefined' ? self : {}));
+	const $carousels = $('.carousel');
 
 	if (!$carousels.length) {
 		return;
 	}
 
-	if (globalThis.bootstrap?.Carousel) {
+	if (root.bootstrap?.Carousel) {
 		$carousels.each(function () {
-			globalThis.bootstrap.Carousel.getOrCreateInstance(this, options);
+			root.bootstrap.Carousel.getOrCreateInstance(this, options);
 		});
 
 		return;
@@ -54,7 +57,7 @@ jQuery(function ($) {
 
 /* Masonry Grid */
 jQuery(function ($) {
-	var $container = $('#xoopsgrid').masonry();
+	const $container = $('#xoopsgrid').masonry();
 	$container.imagesLoaded(function () {
 		$container.masonry();
 	});

--- a/htdocs/themes/xbootstrap5/theme.tpl
+++ b/htdocs/themes/xbootstrap5/theme.tpl
@@ -45,7 +45,7 @@
 
     <link rel="alternate" type="application/rss+xml" title="" href="<{xoAppUrl 'backend.php'}>">
 
-    <title><{if isset($xoops_dirname) && $xoops_dirname == "system"}><{$xoops_sitename}><{if !empty($xoops_pagetitle)}> - <{$xoops_pagetitle}><{/if}><{else}><{if !empty($xoops_pagetitle)}><{$xoops_pagetitle}> - <{$xoops_sitename}><{/if}><{/if}></title>
+    <title><{if isset($xoops_dirname) && $xoops_dirname == "system"}><{$xoops_sitename}><{if !empty($xoops_pagetitle)}> - <{$xoops_pagetitle}><{/if}><{elseif !empty($xoops_pagetitle)}><{$xoops_pagetitle}> - <{$xoops_sitename}><{else}><{$xoops_sitename}><{/if}></title>
 
     <script src="<{$xoops_url}>/browse.php?Frameworks/jquery/jquery.js"></script>
     <script src="<{xoImgUrl}>js/bootstrap.bundle.min.js"></script>

--- a/htdocs/themes/xbootstrap5/theme.tpl
+++ b/htdocs/themes/xbootstrap5/theme.tpl
@@ -48,14 +48,15 @@
 
     <title><{if isset($xoops_dirname) && $xoops_dirname == "system"}><{$xoops_sitename}><{if !empty($xoops_pagetitle)}> - <{$xoops_pagetitle}><{/if}><{else}><{if !empty($xoops_pagetitle)}><{$xoops_pagetitle}> - <{$xoops_sitename}><{/if}><{/if}></title>
 
+    <script src="<{$xoops_url}>/browse.php?Frameworks/jquery/jquery.js"></script>
+    <script src="<{xoImgUrl}>js/bootstrap.bundle.min.js"></script>
+
     <{include file="$theme_name/tpl/shareaholic-script.tpl"}>
 
     <{$xoops_module_header}>
 
 
 </head>
-<body>
-
 <body id="<{$xoops_dirname}>">
 
 <{include file="$theme_name/tpl/nav-menu.tpl"}>
@@ -128,30 +129,19 @@
 
 <{*=============================  JS   ==================================*}>
 
-<!-- 1. jQuery must be first -->
-<script src="<{$xoops_url}>/browse.php?Frameworks/jquery/jquery.js"></script>
-
-<!-- 2. Bootstrap (if using Bootstrap JS) -->
-<{*<script src="<{xoImgUrl}>js/bootstrap.bundle.min.js"></script>*}>
-
-<!-- 3. Plugins that require jQuery -->
+<!-- 1. Plugins that require jQuery -->
 <script src="<{xoImgUrl}>js/jquery.scrollUp.min.js"></script>
 <script src="<{xoImgUrl}>js/masonry.pkgd.min.js"></script>
 <script src="<{xoImgUrl}>js/imagesloaded.pkgd.min.js"></script>
 <script src="<{xoImgUrl}>js/headhesive.min.js"></script>
 
 
-<!-- 4. Your custom scripts (js.js etc.) -->
-
-<script src="<{xoImgUrl}>js/bootstrap.bundle.min.js"></script>
+<!-- 2. Your custom scripts (js.js etc.) -->
 
 <script src="<{xoImgUrl}>js/theme-toggle.js"></script>
 <script src="<{xoImgUrl}>js/js.js"></script>
 
-<!-- 5. XOOPS module header (injects module-specific JS if needed) -->
-<{$xoops_module_header}>
-
-<!-- 6. Inline scripts (AFTER all libraries) -->
+<!-- 3. Inline scripts (AFTER all libraries) -->
 <script>
     // Set options
     var options = {

--- a/htdocs/themes/xbootstrap5/theme.tpl
+++ b/htdocs/themes/xbootstrap5/theme.tpl
@@ -11,7 +11,6 @@
     <meta name="rating" content="<{$xoops_meta_rating}>">
     <meta name="author" content="<{$xoops_meta_author}>">
     <meta name="generator" content="XOOPS">
-    <title><{$xoops_sitename}> - <{$xoops_pagetitle}></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Owl Carousel Assets -->
     <link href="<{xoImgUrl}>js/owl/assets/owl.carousel.css" rel="stylesheet">


### PR DESCRIPTION
Move jQuery and bootstrap.bundle into the head so module inline scripts can safely use them, remove the duplicate body tag and duplicate module header injection, and initialize carousels through the Bootstrap 5 API with a jQuery fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced carousel initialization with improved fallback handling to ensure consistent performance across different browser environments.
  * Optimized the loading order of core JavaScript libraries for improved page load performance.
  * Refined initialization and callback scheduling for more efficient resource handling and execution timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->