### PR TITLE
non-expand section System in the menu

### DIFF
--- a/htdocs/modules/system/themes/modern/css/fixes.css
+++ b/htdocs/modules/system/themes/modern/css/fixes.css
@@ -349,3 +349,111 @@ body.dark-mode #buttontop_mod td a:hover {
     background-color: rgba(59, 130, 246, 0.15) !important;
 }
 
+/* Breadcrumb in Admin area */
+/* Container */
+#xo-breadcrumb {
+    background-image: none !important;
+    background-color: var(--primary-light);
+    height: 60px !important;
+    display: flex !important;
+    align-items: center;
+    gap: 4px;
+    list-style: none;
+    padding: 8px 12px;
+    margin: 0 0 20px 0 !important;
+    border-radius: 6px;
+}
+/* List items */
+#xo-breadcrumb li {
+    display: flex !important;
+    align-items: center;
+    color: white;
+    line-height: 30px;
+    font-weight: bold !important;
+}
+#xo-breadcrumb li:not(:has(a)) {
+    margin-left: 0;
+}
+/* Links */
+#xo-breadcrumb a {
+    padding: 0 10px !important;
+    background-image: none !important;
+    color: white !important;
+    font-weight: bold !important;
+}
+#xo-breadcrumb a {
+    display: inline-flex !important;
+    align-items: center;
+    text-decoration: none;
+    padding: 4px 6px;
+    border-radius: 4px;
+    transition: background 0.2s ease, color 0.2s ease;
+    font-weight: bold !important;
+}
+#xo-breadcrumb a:hover {
+    background-image: none !important;
+    background-color: var(--primary-dark) !important;
+}
+/* Separator */
+#xo-breadcrumb li:not(.xo-help):not(:has(+ .xo-help))::after {
+    content: "›";
+    margin: 0 6px;
+    color: white;
+}
+/* nicer Home Icon */
+#xo-breadcrumb img.home {
+    width: 16px;
+    height: 16px;
+    display: block;
+}
+/* put Help image to right */
+#xo-breadcrumb .xo-help {
+    margin-left: auto;
+    margin-right:10px;
+}
+/* Help Icons */
+#xo-breadcrumb .xo-help img {
+    width: 18px;
+    height: 18px;
+    opacity: 0.7;
+    transition: opacity 0.2s ease;
+    margin-top:5px;
+}
+#xo-breadcrumb .xo-help a:hover img {
+    opacity: 1;
+}
+
+#xo-breadcrumb .xo-help a.hidden {
+    display: none !important;
+    visibility: hidden !important;
+    opacity: 0 !important;
+    pointer-events: none;
+}
+
+/* Buttons and Links */
+.xo-buttons button,
+.xo-buttons a,
+button.btn.btn-default,
+button.btn.btn-primary,
+input[type="reset"],
+input.formbutton[type="reset"] {
+    padding: 6px 16px !important;
+    margin: 2px 2px 10px 0 !important;
+    background: var(--primary) !important;
+    color: white !important;
+    border: none !important;
+    border-radius: var(--radius-sm) !important;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.xo-buttons button:hover,
+.xo-buttons a:hover,
+button.btn.btn-default:hover,
+button.btn.btn-primary:hover,
+input[type="reset"]:hover,
+input.formbutton[type="reset"]:hover {
+    background: var(--primary-dark) !important;
+    transform: translateY(-1px);
+    box-shadow: var(--shadow);
+}

--- a/htdocs/modules/system/themes/modern/css/fixes.css
+++ b/htdocs/modules/system/themes/modern/css/fixes.css
@@ -354,7 +354,7 @@ body.dark-mode #buttontop_mod td a:hover {
 #xo-breadcrumb {
     background-image: none !important;
     background-color: var(--primary-light);
-    height: 60px !important;
+    min-height: 60px !important;
     display: flex !important;
     align-items: center;
     gap: 4px;

--- a/htdocs/modules/system/themes/modern/css/fixes.css
+++ b/htdocs/modules/system/themes/modern/css/fixes.css
@@ -380,15 +380,11 @@ body.dark-mode #buttontop_mod td a:hover {
     background-image: none !important;
     color: white !important;
     font-weight: bold !important;
-}
-#xo-breadcrumb a {
     display: inline-flex !important;
     align-items: center;
     text-decoration: none;
-    padding: 4px 6px;
-    border-radius: 4px;
+    border-radius: var(--radius-sm) !important;
     transition: background 0.2s ease, color 0.2s ease;
-    font-weight: bold !important;
 }
 #xo-breadcrumb a:hover {
     background-image: none !important;

--- a/htdocs/modules/system/themes/modern/modern.php
+++ b/htdocs/modules/system/themes/modern/modern.php
@@ -397,9 +397,12 @@ class XoopsGuiModern extends XoopsSystemGui
         $basePath   = rtrim((string) parse_url(XOOPS_URL, PHP_URL_PATH), '/'); // '' on root, '/xoops27' on WAMP
 
         $isSystemAdmin      = ($pathUri === $basePath . '/modules/system/admin.php');
-        $isRefererSystem    = ($pathReferer === $basePath . '/modules/system/admin.php');
         $isControlPanelHome = ($pathUri === $basePath . '/admin.php');
-        $tpl->assign('showSystemServices', ($isSystemAdmin && $isRefererSystem) || $isControlPanelHome);
+        $fct = \Xmf\Request::getString('fct', '', 'GET');
+        $op  = \Xmf\Request::getString('op', '', 'GET');
+        $mod = \Xmf\Request::getInt('mod', 0, 'GET');
+        $isModulePreferenceEdit = $isSystemAdmin && $fct === 'preferences' && $op === 'showmod' && $mod > 0;
+        $tpl->assign('showSystemServices', $isControlPanelHome || ($isSystemAdmin && !$isModulePreferenceEdit));
 
         // assign vars
         $tpl->assign('sys_options', $system_services);

--- a/htdocs/modules/system/themes/modern/modern.php
+++ b/htdocs/modules/system/themes/modern/modern.php
@@ -390,13 +390,16 @@ class XoopsGuiModern extends XoopsSystemGui
         }
 
         // Detect whether system panel should be opened
-        $requestUri = \Xmf\Request::getString('REQUEST_URI', '', 'SERVER');
-        $path       = (string) parse_url($requestUri, PHP_URL_PATH);          // strip query string
+        $requestUri  = \Xmf\Request::getString('REQUEST_URI', '', 'SERVER');
+        $pathUri     = (string) parse_url($requestUri, PHP_URL_PATH);          // strip query string
+        $httpReferer = \Xmf\Request::getString('HTTP_REFERER', '', 'SERVER');
+        $pathReferer = (string) parse_url($httpReferer, PHP_URL_PATH);
         $basePath   = rtrim((string) parse_url(XOOPS_URL, PHP_URL_PATH), '/'); // '' on root, '/xoops27' on WAMP
 
-        $isSystemAdmin      = ($path === $basePath . '/modules/system/admin.php');
-        $isControlPanelHome = ($path === $basePath . '/admin.php');
-        $tpl->assign('showSystemServices', $isSystemAdmin || $isControlPanelHome);
+        $isSystemAdmin      = ($pathUri === $basePath . '/modules/system/admin.php');
+        $isRefererSystem    = ($pathReferer === $basePath . '/modules/system/admin.php');
+        $isControlPanelHome = ($pathUri === $basePath . '/admin.php');
+        $tpl->assign('showSystemServices', ($isSystemAdmin && $isRefererSystem) || $isControlPanelHome);
 
         // assign vars
         $tpl->assign('sys_options', $system_services);

--- a/htdocs/modules/system/themes/modern/modern.php
+++ b/htdocs/modules/system/themes/modern/modern.php
@@ -392,8 +392,6 @@ class XoopsGuiModern extends XoopsSystemGui
         // Detect whether system panel should be opened
         $requestUri  = \Xmf\Request::getString('REQUEST_URI', '', 'SERVER');
         $pathUri     = (string) parse_url($requestUri, PHP_URL_PATH);          // strip query string
-        $httpReferer = \Xmf\Request::getString('HTTP_REFERER', '', 'SERVER');
-        $pathReferer = (string) parse_url($httpReferer, PHP_URL_PATH);
         $basePath   = rtrim((string) parse_url(XOOPS_URL, PHP_URL_PATH), '/'); // '' on root, '/xoops27' on WAMP
 
         $isSystemAdmin      = ($pathUri === $basePath . '/modules/system/admin.php');


### PR DESCRIPTION
the section "System" should not expand if only the preferences of a specific module are edited

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Menu logic improved so system service links appear appropriately on control panel and admin pages while being suppressed during specific preference-edit flows.
* **Style**
  * Admin breadcrumb and action button styles updated for clearer layout, consistent colors, separators between segments, refined help icon behavior, and unified button/link appearance and hover effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->