### PR TITLE
fix(locale): number_format() defaults now come from locale, not hardc…

### DIFF
--- a/htdocs/language/english/locale.php
+++ b/htdocs/language/english/locale.php
@@ -53,19 +53,12 @@ class XoopsLocal extends XoopsLocalAbstract
     /**
      * Number Formats
      *
-     * @param  int|float   $number
-     * @param  int|null    $decimals
-     * @param  string|null $decSep  Override decimal separator (defaults to locale)
-     * @param  string|null $thouSep Override thousands separator (defaults to locale)
+     * @param  int|float|string $number
      * @return string
      */
-    public function number_format($number, $decimals = null, $decSep = null, $thouSep = null): string
+    public function number_format($number)
     {
-        $decimals ??= self::CURRENCY['decimals'];
-        $decSep   ??= self::CURRENCY['decSep'];
-        $thouSep  ??= self::CURRENCY['thouSep'];
-
-        return number_format((float) $number, $decimals, $decSep, $thouSep);
+        return number_format($number, self::CURRENCY['decimals'], self::CURRENCY['decSep'], self::CURRENCY['thouSep']);
     }
 
     /**
@@ -92,7 +85,7 @@ class XoopsLocal extends XoopsLocalAbstract
             }
         }
 
-        $amount = number_format((float) $number, $c['decimals'], $c['decSep'], $c['thouSep']);
+        $amount = $this->number_format($number);
 
         return sprintf($c['pattern'], $amount, $c['symbol']);
     }

--- a/htdocs/language/english/locale.php
+++ b/htdocs/language/english/locale.php
@@ -47,25 +47,27 @@ if (!class_exists('XoopsLocalAbstract')) {
  */
 class XoopsLocal extends XoopsLocalAbstract
 {
-        private const CURRENCY = ['locale' => 'en_US', 'code' => 'USD', 'symbol' => '$',  'decimals' => 2, 'decSep' => '.', 'thouSep' => ',', 'pattern' => '%s%s'];
+    /** Per-locale currency formatting data. Pattern uses positional placeholders: %1$s = amount, %2$s = symbol. */
+    private const CURRENCY = ['locale' => 'en_US', 'code' => 'USD', 'symbol' => '$',  'decimals' => 2, 'decSep' => '.', 'thouSep' => ',', 'pattern' => '%2$s%1$s'];
 
     /**
      * Number Formats
      *
-     * @param int|float   $number
-     * @param int|null    $decimals
-     * @param string|null $decSep  Override decimal separator (defaults to locale)
-     * @param string|null $thouSep Override thousands separator (defaults to locale)
+     * @param  int|float   $number
+     * @param  int|null    $decimals
+     * @param  string|null $decSep  Override decimal separator (defaults to locale)
+     * @param  string|null $thouSep Override thousands separator (defaults to locale)
      * @return string
      */
-    public function number_format($number, $decimals = null, $decSep = null, $thouSep = null)
+    public function number_format($number, $decimals = null, $decSep = null, $thouSep = null): string
     {
         $decimals ??= self::CURRENCY['decimals'];
-        $decSep ??= self::CURRENCY['decSep'];
-        $thouSep ??= self::CURRENCY['thouSep'];
+        $decSep   ??= self::CURRENCY['decSep'];
+        $thouSep  ??= self::CURRENCY['thouSep'];
 
-        return number_format((float)$number, $decimals, $decSep, $thouSep);
+        return number_format((float) $number, $decimals, $decSep, $thouSep);
     }
+
     /**
      * Money Format
      *
@@ -80,8 +82,8 @@ class XoopsLocal extends XoopsLocalAbstract
         $c = self::CURRENCY;
 
         if (extension_loaded('intl')) {
-        static $fmt = null;
-        if (null === $fmt) {
+            static $fmt = null;
+            if (null === $fmt) {
                 $fmt = new \NumberFormatter($c['locale'], \NumberFormatter::CURRENCY);
             }
             $result = $fmt->formatCurrency((float) $number, $c['code']);

--- a/htdocs/language/english/locale.php
+++ b/htdocs/language/english/locale.php
@@ -47,17 +47,25 @@ if (!class_exists('XoopsLocalAbstract')) {
  */
 class XoopsLocal extends XoopsLocalAbstract
 {
+        private const CURRENCY = ['locale' => 'en_US', 'code' => 'USD', 'symbol' => '$',  'decimals' => 2, 'decSep' => '.', 'thouSep' => ',', 'pattern' => '%s%s'];
+
     /**
      * Number Formats
      *
-     * @param  unknown_type $number
-     * @return mixed
+     * @param int|float   $number
+     * @param int|null    $decimals
+     * @param string|null $decSep  Override decimal separator (defaults to locale)
+     * @param string|null $thouSep Override thousands separator (defaults to locale)
+     * @return string
      */
-    public function number_format($number)
+    public function number_format($number, $decimals = null, $decSep = null, $thouSep = null)
     {
-        return number_format($number, 2, '.', ',');
-    }
+        $decimals ??= self::CURRENCY['decimals'];
+        $decSep ??= self::CURRENCY['decSep'];
+        $thouSep ??= self::CURRENCY['thouSep'];
 
+        return number_format((float)$number, $decimals, $decSep, $thouSep);
+    }
     /**
      * Money Format
      *
@@ -69,17 +77,21 @@ class XoopsLocal extends XoopsLocalAbstract
      */
     public function money_format($format, $number)
     {
-        if (!extension_loaded('intl')) {
-            return '$' . number_format((float)$number, 2, '.', ',');
-        }
+        $c = self::CURRENCY;
 
+        if (extension_loaded('intl')) {
         static $fmt = null;
         if (null === $fmt) {
-            $fmt = new \NumberFormatter('en_US', \NumberFormatter::CURRENCY);
+                $fmt = new \NumberFormatter($c['locale'], \NumberFormatter::CURRENCY);
+            }
+            $result = $fmt->formatCurrency((float) $number, $c['code']);
+            if ($result !== false) {
+                return $result;
+            }
         }
 
-        $result = $fmt->formatCurrency((float)$number, 'USD');
+        $amount = number_format((float) $number, $c['decimals'], $c['decSep'], $c['thouSep']);
 
-        return $result !== false ? $result : '$' . number_format((float)$number, 2, '.', ',');
+        return sprintf($c['pattern'], $amount, $c['symbol']);
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,7 +12,6 @@ parameters:
             - htdocs/xoops_data/caches
             - htdocs/class/libraries/vendor/
             - tests/
-            - tests_codex2/
         analyse:
             - htdocs/class/auth/
             - htdocs/install/


### PR DESCRIPTION
…oded

  - Separators: '.', ',' → locale-specific (fixes wrong output on ~30 locales)
  - Decimals: hardcoded 2 → locale's currency minor-unit precision
  - Behavioural change for JPY/KRW/VND locales: integer-default instead of 2dp
  - Callers needing 2dp on those locales must pass $decimals = 2 explicitly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced number formatting with customizable decimal places and separators using locale-based defaults.
  * Improved currency formatting with international locale support and robust fallback handling when locale formatting is unavailable.
* **Chores**
  * Static analysis configuration updated to exclude an additional test directory from checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->