### PR TITLE
 fix(system): module update preserves mid + catid; users.php exec/isResultSet bug

### DIFF
--- a/docs/lang_diff.txt
+++ b/docs/lang_diff.txt
@@ -10,6 +10,9 @@ Below are language differences from a version to next version.
 - added define('_AM_SYSTEM_MENUS', 'Menus');
 - added define('_AM_SYSTEM_MENUS_DESC', 'Manage site navigation menus');
 
+/htdocs/modules/system/language/english/admin/modulesadmin.php
+- added define('_AM_SYSTEM_MODULES_CONFIG_DATA_INVALID', ' ERROR: Skipped malformed config entry %s. ');
+
 /htdocs/modules/system/language/english/modinfo.php
 - added define('_MI_SYSTEM_MENUS_ACTIVE', 'Enable Menu System');
 - added define('_MI_SYSTEM_MENUS_ACTIVE_DESC', 'Enable the built-in menu management system for site navigation');

--- a/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
+++ b/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
@@ -22,6 +22,43 @@ if ( !is_object($xoopsUser) || !is_object($xoopsModule) || !$xoopsUser->isAdmin(
 */
 
 /**
+ * Validate a single module config-entry definition.
+ *
+ * On a malformed entry (non-array, or missing one of the required keys
+ * name/title/formtype/valuetype) appends a single visible error row to
+ * $msgs and returns false. On a valid entry returns true with $msgs
+ * untouched. Used by both install and update paths to skip bad entries
+ * rather than fataling on array_keys() or spraying N undefined-key
+ * warnings per entry.
+ *
+ * @param mixed             $config Entry from $module->getInfo('config').
+ * @param array<int,string> $msgs   Admin log buffer (appended to on failure).
+ *
+ * @return bool True when $config is a usable array of config metadata.
+ */
+function xoops_module_validate_config_entry($config, array &$msgs): bool
+{
+    if (!is_array($config)) {
+        $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">'
+            . sprintf(_AM_SYSTEM_MODULES_CONFIG_DATA_INVALID, '<strong>?</strong> (non-array entry)')
+            . '</span>';
+        return false;
+    }
+    $missing = array_diff(['name', 'title', 'formtype', 'valuetype'], array_keys($config));
+    if ([] !== $missing) {
+        $name = htmlspecialchars((string) ($config['name'] ?? '?'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">'
+            . sprintf(
+                _AM_SYSTEM_MODULES_CONFIG_DATA_INVALID,
+                '<strong>' . $name . '</strong> (missing required keys: ' . implode(', ', $missing) . ')'
+            )
+            . '</span>';
+        return false;
+    }
+    return true;
+}
+
+/**
  * @param $dirname
  *
  * @return string
@@ -424,25 +461,7 @@ function xoops_module_install($dirname)
                     $config_handler = xoops_getHandler('config');
                     $order          = 0;
                     foreach ($configs as $config) {
-                        // A malformed config entry (non-array, or missing one of the four
-                        // required keys) is unrecoverable — emit a single visible warning
-                        // row and continue, rather than fataling on array_keys() or spraying
-                        // four "Undefined array key" warnings per entry.
-                        if (!is_array($config)) {
-                            $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">'
-                                . sprintf(_AM_SYSTEM_MODULES_CONFIG_DATA_ADD_ERROR, '<strong>?</strong>')
-                                . ' (invalid config entry type)</span>';
-                            continue;
-                        }
-                        $missing = array_diff(['name', 'title', 'formtype', 'valuetype'], array_keys($config));
-                        if ([] !== $missing) {
-                            $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">'
-                                . sprintf(
-                                    _AM_SYSTEM_MODULES_CONFIG_DATA_ADD_ERROR,
-                                    '<strong>' . htmlspecialchars((string) ($config['name'] ?? '?'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</strong>'
-                                    . ' (missing: ' . implode(', ', $missing) . ')'
-                                )
-                                . '</span>';
+                        if (!xoops_module_validate_config_entry($config, $msgs)) {
                             continue;
                         }
                         $confobj = $config_handler->createConfig();
@@ -1349,24 +1368,7 @@ function xoops_module_update($dirname)
             $config_handler = xoops_getHandler('config');
             $order          = 0;
             foreach ($configs as $config) {
-                // Same defense as the install path: skip malformed entries
-                // (non-array, or missing required keys) with one visible row
-                // instead of fataling on array_keys() or N undefined-key warnings.
-                if (!is_array($config)) {
-                    $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">'
-                        . sprintf(_AM_SYSTEM_MODULES_CONFIG_DATA_ADD_ERROR, '<strong>?</strong>')
-                        . ' (invalid config entry type)</span>';
-                    continue;
-                }
-                $missing = array_diff(['name', 'title', 'formtype', 'valuetype'], array_keys($config));
-                if ([] !== $missing) {
-                    $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">'
-                        . sprintf(
-                            _AM_SYSTEM_MODULES_CONFIG_DATA_ADD_ERROR,
-                            '<strong>' . htmlspecialchars((string) ($config['name'] ?? '?'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</strong>'
-                            . ' (missing: ' . implode(', ', $missing) . ')'
-                        )
-                        . '</span>';
+                if (!xoops_module_validate_config_entry($config, $msgs)) {
                     continue;
                 }
                 // only insert ones that have been deleted previously with success

--- a/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
+++ b/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
@@ -350,6 +350,16 @@ function xoops_module_install($dirname)
                     unset($blocks);
                 }
                 $configs = $module->getInfo('config');
+                // The validation helper guards individual entries; the top-level
+                // container also needs a type guard so a malformed manifest
+                // (e.g. config: "invalid") cannot TypeError on the array_push /
+                // [] writes below.
+                if (false !== $configs && !is_array($configs)) {
+                    $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">'
+                        . sprintf(_AM_SYSTEM_MODULES_CONFIG_DATA_INVALID, '<strong>?</strong> (config section is not an array)')
+                        . '</span>';
+                    $configs = [];
+                }
                 if ($configs !== false) {
                     if ($module->getVar('hascomments') != 0) {
                         include_once XOOPS_ROOT_PATH . '/include/comment_constants.php';
@@ -1257,6 +1267,14 @@ function xoops_module_update($dirname)
 
         // now reinsert them with the new settings
         $configs = $module->getInfo('config');
+        // Same top-level guard as the install path — protect array_push /
+        // [] writes below from a non-array, non-false manifest value.
+        if (false !== $configs && !is_array($configs)) {
+            $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">'
+                . sprintf(_AM_SYSTEM_MODULES_CONFIG_DATA_INVALID, '<strong>?</strong> (config section is not an array)')
+                . '</span>';
+            $configs = [];
+        }
         if ($configs !== false) {
             if ($module->getVar('hascomments') != 0) {
                 include_once XOOPS_ROOT_PATH . '/include/comment_constants.php';

--- a/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
+++ b/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
@@ -424,9 +424,16 @@ function xoops_module_install($dirname)
                     $config_handler = xoops_getHandler('config');
                     $order          = 0;
                     foreach ($configs as $config) {
-                        // A malformed config entry (missing one of the four required keys)
-                        // is unrecoverable — emit a single visible warning row and continue,
-                        // rather than spraying four "Undefined array key" warnings per entry.
+                        // A malformed config entry (non-array, or missing one of the four
+                        // required keys) is unrecoverable — emit a single visible warning
+                        // row and continue, rather than fataling on array_keys() or spraying
+                        // four "Undefined array key" warnings per entry.
+                        if (!is_array($config)) {
+                            $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">'
+                                . sprintf(_AM_SYSTEM_MODULES_CONFIG_DATA_ADD_ERROR, '<strong>?</strong>')
+                                . ' (invalid config entry type)</span>';
+                            continue;
+                        }
                         $missing = array_diff(['name', 'title', 'formtype', 'valuetype'], array_keys($config));
                         if ([] !== $missing) {
                             $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">'
@@ -852,13 +859,16 @@ function xoops_module_update($dirname)
     $module         = $module_handler->getByDirname($dirname);
 
     // ============================================================
-    // SAFETY GUARDS — protect xoops_config from "writes to modid=0".
+    // SAFETY GUARDS — protect xoops_config from writes against the
+    // wrong mid.
     //
-    // Capture the mid ONCE here. $module->loadInfoAsVar() below
-    // overwrites the module's vars from xoops_version.php (which does
-    // NOT declare 'mid', because mid is a DB-assigned identity), so
-    // without an explicit restore every config row gets re-inserted
-    // at conf_modid=0, corrupting xoops_config across the whole site.
+    // Capture the persisted mid once and keep it as the update identity.
+    // loadInfoAsVar() below refreshes manifest-backed fields (name,
+    // version, dirname, has*) but the DB-assigned mid must remain the
+    // single source of truth for module, block, template, and config
+    // writes. Refuse to proceed if the module is missing or has an
+    // invalid mid — the alternative is a `WHERE conf_modid = 0` write
+    // that would corrupt xoops_config across the whole site.
     // ============================================================
     if (!is_object($module) || !($module instanceof XoopsModule)) {
         return '<p style="color:#ff0000;">Could not find module "'
@@ -887,7 +897,9 @@ function xoops_module_update($dirname)
     $temp_name = $module->getVar('name');
     $module->loadInfoAsVar($dirname);
     $module->setVar('name', $temp_name);
-    // Re-assert mid AFTER loadInfoAsVar() — see safety-guard comment above.
+    // Defensive restore: loadInfoAsVar() does not currently touch mid
+    // or the new-record flag, but re-asserting them keeps this code
+    // resilient against subclass overrides or future kernel changes.
     $module->setVar('mid', $targetMid);
     $module->unsetNew();
     $module->setVar('last_update', time());
@@ -1338,7 +1350,14 @@ function xoops_module_update($dirname)
             $order          = 0;
             foreach ($configs as $config) {
                 // Same defense as the install path: skip malformed entries
-                // with one visible row instead of N undefined-key warnings.
+                // (non-array, or missing required keys) with one visible row
+                // instead of fataling on array_keys() or N undefined-key warnings.
+                if (!is_array($config)) {
+                    $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">'
+                        . sprintf(_AM_SYSTEM_MODULES_CONFIG_DATA_ADD_ERROR, '<strong>?</strong>')
+                        . ' (invalid config entry type)</span>';
+                    continue;
+                }
                 $missing = array_diff(['name', 'title', 'formtype', 'valuetype'], array_keys($config));
                 if ([] !== $missing) {
                     $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">'

--- a/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
+++ b/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
@@ -28,7 +28,7 @@ if ( !is_object($xoopsUser) || !is_object($xoopsModule) || !$xoopsUser->isAdmin(
  * name/title/formtype/valuetype) appends a single visible error row to
  * $msgs and returns false. On a valid entry returns true with $msgs
  * untouched. Used by both install and update paths to skip bad entries
- * rather than fataling on array_keys() or spraying N undefined-key
+ * rather than failing on array_keys() or spraying N undefined-key
  * warnings per entry.
  *
  * @param mixed             $config Entry from $module->getInfo('config').
@@ -938,8 +938,15 @@ function xoops_module_update($dirname)
 
         */
     if (!$module_handler->insert($module)) {
-        echo '<p>Could not update ' . $module->getVar('name') . '</p>';
-        echo "<br><div class='center'><a href='admin.php?fct=modulesadmin'>" . _AM_SYSTEM_MODULES_BTOMADMIN . '</a></div>';
+        // Return early so the trailing implode($msgs) below does not fire on
+        // an undefined variable. The success branch is the only path that
+        // initialises $msgs; on failure we hand the caller a self-contained
+        // error string (matching the early-return pattern used by the
+        // safety-guard checks at the top of this function).
+        return '<p style="color:#ff0000;">Could not update '
+            . htmlspecialchars((string) $module->getVar('name'), ENT_QUOTES | ENT_HTML5, 'UTF-8')
+            . '</p>'
+            . "<div class='center'><a href='admin.php?fct=modulesadmin'>" . _AM_SYSTEM_MODULES_BTOMADMIN . '</a></div>';
     } else {
         // $newmid is the captured $targetMid — never re-derived from
         // $module->getVar('mid'), to keep DELETE and INSERT in sync.

--- a/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
+++ b/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
@@ -424,6 +424,20 @@ function xoops_module_install($dirname)
                     $config_handler = xoops_getHandler('config');
                     $order          = 0;
                     foreach ($configs as $config) {
+                        // A malformed config entry (missing one of the four required keys)
+                        // is unrecoverable — emit a single visible warning row and continue,
+                        // rather than spraying four "Undefined array key" warnings per entry.
+                        $missing = array_diff(['name', 'title', 'formtype', 'valuetype'], array_keys($config));
+                        if ([] !== $missing) {
+                            $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">'
+                                . sprintf(
+                                    _AM_SYSTEM_MODULES_CONFIG_DATA_ADD_ERROR,
+                                    '<strong>' . htmlspecialchars((string) ($config['name'] ?? '?'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</strong>'
+                                    . ' (missing: ' . implode(', ', $missing) . ')'
+                                )
+                                . '</span>';
+                            continue;
+                        }
                         $confobj = $config_handler->createConfig();
                         $confobj->setVar('conf_modid', $newmid);
                         $confobj->setVar('conf_catid', 0);
@@ -432,7 +446,9 @@ function xoops_module_install($dirname)
                         $confobj->setVar('conf_desc', $config['description'] ?? '', true);
                         $confobj->setVar('conf_formtype', $config['formtype']);
                         $confobj->setVar('conf_valuetype', $config['valuetype']);
-                        $confobj->setConfValueForInput($config['default'], true);
+                        // setConfValueForInput() takes its first arg by reference, so a `??` expression cannot be passed inline.
+                        $defaultValue = $config['default'] ?? '';
+                        $confobj->setConfValueForInput($defaultValue, true);
                         $confobj->setVar('conf_order', $order);
                         $confop_msgs = '';
                         if (isset($config['options']) && \is_array($config['options'])) {
@@ -834,6 +850,34 @@ function xoops_module_update($dirname)
     /** @var XoopsModuleHandler $module_handler */
     $module_handler = xoops_getHandler('module');
     $module         = $module_handler->getByDirname($dirname);
+
+    // ============================================================
+    // SAFETY GUARDS — protect xoops_config from "writes to modid=0".
+    //
+    // Capture the mid ONCE here. $module->loadInfoAsVar() below
+    // overwrites the module's vars from xoops_version.php (which does
+    // NOT declare 'mid', because mid is a DB-assigned identity), so
+    // without an explicit restore every config row gets re-inserted
+    // at conf_modid=0, corrupting xoops_config across the whole site.
+    // ============================================================
+    if (!is_object($module) || !($module instanceof XoopsModule)) {
+        return '<p style="color:#ff0000;">Could not find module "'
+            . htmlspecialchars($dirname, ENT_QUOTES | ENT_HTML5, 'UTF-8')
+            . '" — update aborted.</p>'
+            . '<div class="center"><a href="admin.php?fct=modulesadmin">' . _AM_SYSTEM_MODULES_BTOMADMIN . '</a></div>';
+    }
+    $targetMid = (int) $module->getVar('mid');
+    if ($targetMid <= 0) {
+        trigger_error(
+            sprintf('modulesadmin: refusing to update "%s" with mid=%d (would corrupt xoops_config)', $dirname, $targetMid),
+            E_USER_WARNING
+        );
+        return '<p style="color:#ff0000;">Module "'
+            . htmlspecialchars($dirname, ENT_QUOTES | ENT_HTML5, 'UTF-8')
+            . '" has invalid mid=' . $targetMid . '; update aborted to protect xoops_config.</p>'
+            . '<div class="center"><a href="admin.php?fct=modulesadmin">' . _AM_SYSTEM_MODULES_BTOMADMIN . '</a></div>';
+    }
+
     // Save current version for use in the update function
     $prev_version = $module->getVar('version');
     $clearTpl     = new XoopsTpl();
@@ -843,6 +887,9 @@ function xoops_module_update($dirname)
     $temp_name = $module->getVar('name');
     $module->loadInfoAsVar($dirname);
     $module->setVar('name', $temp_name);
+    // Re-assert mid AFTER loadInfoAsVar() — see safety-guard comment above.
+    $module->setVar('mid', $targetMid);
+    $module->unsetNew();
     $module->setVar('last_update', time());
     /*
         // Call Header
@@ -863,7 +910,9 @@ function xoops_module_update($dirname)
         echo '<p>Could not update ' . $module->getVar('name') . '</p>';
         echo "<br><div class='center'><a href='admin.php?fct=modulesadmin'>" . _AM_SYSTEM_MODULES_BTOMADMIN . '</a></div>';
     } else {
-        $newmid = $module->getVar('mid');
+        // $newmid is the captured $targetMid — never re-derived from
+        // $module->getVar('mid'), to keep DELETE and INSERT in sync.
+        $newmid = $targetMid;
         $msgs   = [];
         $msgs[] = '<div id="xo-module-log"><div class="header">';
         $msgs[] = $errs[] = '<h4>' . _AM_SYSTEM_MODULES_UPDATING . $module->getInfo('name', 's') . '</h4>';
@@ -1138,24 +1187,32 @@ function xoops_module_update($dirname)
         //        $GLOBALS['xoopsTpl']->setCompileId();
         //        $xoopsTpl->setCompileId();
 
-        // first delete all config entries
+        // first delete all config entries — using the captured $newmid (= $targetMid)
         /** @var XoopsConfigHandler $config_handler */
         $config_handler = xoops_getHandler('config');
-        $configs        = $config_handler->getConfigs(new Criteria('conf_modid', $module->getVar('mid')));
+        $configs        = $config_handler->getConfigs(new Criteria('conf_modid', $newmid));
         $confcount      = count($configs);
         $config_delng   = [];
+        $config_old     = [];
         if ($confcount > 0) {
             $msgs[] = _AM_SYSTEM_MODULES_MODULE_DATA_DELETE;
             for ($i = 0; $i < $confcount; $i++) {
                 if (!$config_handler->deleteConfig($configs[$i])) {
-                    $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">' . _AM_SYSTEM_MODULES_CONFIG_DATA_DELETE_ERROR . sprintf(_AM_SYSTEM_MODULES_GONFIG_ID, '<strong>' . $configs[$i]->getvar('conf_id') . '</strong>') . '</span>';
+                    $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">' . _AM_SYSTEM_MODULES_CONFIG_DATA_DELETE_ERROR . sprintf(_AM_SYSTEM_MODULES_GONFIG_ID, '<strong>' . $configs[$i]->getVar('conf_id') . '</strong>') . '</span>';
                     // save the name of config failed to delete for later use
-                    $config_delng[] = $configs[$i]->getvar('conf_name');
+                    $config_delng[] = $configs[$i]->getVar('conf_name');
                 } else {
-                    $config_old[$configs[$i]->getvar('conf_name')]['value']     = $configs[$i]->getvar('conf_value', 'N');
-                    $config_old[$configs[$i]->getvar('conf_name')]['formtype']  = $configs[$i]->getvar('conf_formtype');
-                    $config_old[$configs[$i]->getvar('conf_name')]['valuetype'] = $configs[$i]->getvar('conf_valuetype');
-                    $msgs[]                                                     = '&nbsp;&nbsp;' . _AM_SYSTEM_MODULES_GONFIG_DATA_DELETE . sprintf(_AM_SYSTEM_MODULES_GONFIG_ID, '<strong>' . $configs[$i]->getVar('conf_id') . '</strong>');
+                    // Capture old value AND old catid. Preserving catid lets a
+                    // System-module update keep its general/mailer/censor groupings;
+                    // hardcoding catid=0 below moved every system config row out of
+                    // its category and made getConfigsByCat(XOOPS_CONF) return empty.
+                    $config_old[$configs[$i]->getVar('conf_name')] = [
+                        'value'     => $configs[$i]->getVar('conf_value', 'N'),
+                        'formtype'  => $configs[$i]->getVar('conf_formtype'),
+                        'valuetype' => $configs[$i]->getVar('conf_valuetype'),
+                        'catid'     => (int) $configs[$i]->getVar('conf_catid'),
+                    ];
+                    $msgs[] = '&nbsp;&nbsp;' . _AM_SYSTEM_MODULES_GONFIG_DATA_DELETE . sprintf(_AM_SYSTEM_MODULES_GONFIG_ID, '<strong>' . $configs[$i]->getVar('conf_id') . '</strong>');
                 }
             }
         }
@@ -1280,26 +1337,56 @@ function xoops_module_update($dirname)
             $config_handler = xoops_getHandler('config');
             $order          = 0;
             foreach ($configs as $config) {
+                // Same defense as the install path: skip malformed entries
+                // with one visible row instead of N undefined-key warnings.
+                $missing = array_diff(['name', 'title', 'formtype', 'valuetype'], array_keys($config));
+                if ([] !== $missing) {
+                    $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">'
+                        . sprintf(
+                            _AM_SYSTEM_MODULES_CONFIG_DATA_ADD_ERROR,
+                            '<strong>' . htmlspecialchars((string) ($config['name'] ?? '?'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</strong>'
+                            . ' (missing: ' . implode(', ', $missing) . ')'
+                        )
+                        . '</span>';
+                    continue;
+                }
                 // only insert ones that have been deleted previously with success
                 if (!in_array($config['name'], $config_delng)) {
+                    // Resolve catid:
+                    //   1. manifest-declared 'category' or 'catid', if > 0
+                    //   2. else preserve the catid from the row we just deleted
+                    //      (system general settings = 1, mailer = 2, censor = 3, ...)
+                    //   3. else 0 (historical module behaviour)
+                    $catid = 0;
+                    if (isset($config['category']) && (int) $config['category'] > 0) {
+                        $catid = (int) $config['category'];
+                    } elseif (isset($config['catid']) && (int) $config['catid'] > 0) {
+                        $catid = (int) $config['catid'];
+                    } elseif (isset($config_old[$config['name']]['catid'])) {
+                        $catid = (int) $config_old[$config['name']]['catid'];
+                    }
+
                     $confobj = $config_handler->createConfig();
                     $confobj->setVar('conf_modid', $newmid);
-                    $confobj->setVar('conf_catid', 0);
+                    $confobj->setVar('conf_catid', $catid);
                     $confobj->setVar('conf_name', $config['name']);
                     $confobj->setVar('conf_title', $config['title'], true);
-                    $confobj->setVar('conf_desc', $config['description'], true);
+                    $confobj->setVar('conf_desc', $config['description'] ?? '', true);
                     $confobj->setVar('conf_formtype', $config['formtype']);
-                    if (isset($config['valuetype'])) {
-                        $confobj->setVar('conf_valuetype', $config['valuetype']);
-                    }
-                    if (isset($config_old[$config['name']]['value']) && $config_old[$config['name']]['formtype'] == $config['formtype'] && $config_old[$config['name']]['valuetype'] == $config['valuetype']) {
-                        // preserver the old value if any
-                        // form type and value type must be the same
-                        $confobj->setVar('conf_value', $config_old[$config['name']]['value'], true);
+                    $confobj->setVar('conf_valuetype', $config['valuetype']);
+                    $oldEntry = $config_old[$config['name']] ?? [];
+                    if (
+                        isset($oldEntry['value'])
+                        && ($oldEntry['formtype'] ?? null) === $config['formtype']
+                        && ($oldEntry['valuetype'] ?? null) === $config['valuetype']
+                    ) {
+                        // preserve the old value if any — form/value type must match
+                        $confobj->setVar('conf_value', $oldEntry['value'], true);
                     } else {
-                        $confobj->setConfValueForInput($config['default'], true);
-
-                        //$confobj->setVar('conf_value', $config['default'], true);
+                        // setConfValueForInput() takes its first arg by reference,
+                        // so a `??` expression cannot be passed inline.
+                        $defaultValue = $config['default'] ?? '';
+                        $confobj->setConfValueForInput($defaultValue, true);
                     }
                     $confobj->setVar('conf_order', $order);
                     $confop_msgs = '';

--- a/htdocs/modules/system/admin/users/users.php
+++ b/htdocs/modules/system/admin/users/users.php
@@ -251,6 +251,7 @@ function synchronize($uid, $type)
     switch ($type) {
         case 'user':
             $total_posts = 0;
+            $countFailed = false;
             foreach ($tables as $table) {
                 $criteria = new CriteriaCompo();
                 $criteria->add(new Criteria($table['uid_column'], $uid));
@@ -260,11 +261,20 @@ function synchronize($uid, $type)
                 $sql = 'SELECT COUNT(*) AS total FROM ' . $xoopsDB->prefix($table['table_name']) . ' ' . $criteria->renderWhere();
                 $result = $xoopsDB->query($sql);
                 if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
-                    continue;
+                    $countFailed = true;
+                    break;
                 }
-                if ($row = $xoopsDB->fetchArray($result)) {
-                    $total_posts += $row['total'];
+                $row = $xoopsDB->fetchArray($result);
+                if (!is_array($row) || !array_key_exists('total', $row)) {
+                    $countFailed = true;
+                    break;
                 }
+                $total_posts += (int) $row['total'];
+            }
+            if ($countFailed) {
+                // Refuse to overwrite users.posts with a partial total.
+                redirect_header('admin.php?fct=users', 1, _AM_SYSTEM_USERS_CNUUSER);
+                return;
             }
             $sql = 'UPDATE ' . $xoopsDB->prefix('users') . " SET posts = '" . $total_posts . "' WHERE uid = '" . $uid . "'";
             $result = $xoopsDB->exec($sql);

--- a/htdocs/modules/system/admin/users/users.php
+++ b/htdocs/modules/system/admin/users/users.php
@@ -259,15 +259,16 @@ function synchronize($uid, $type)
                 }
                 $sql = 'SELECT COUNT(*) AS total FROM ' . $xoopsDB->prefix($table['table_name']) . ' ' . $criteria->renderWhere();
                 $result = $xoopsDB->query($sql);
-                if ($xoopsDB->isResultSet($result)) {
-                    if ($row = $xoopsDB->fetchArray($result)) {
-                        $total_posts += $row['total'];
-                    }
+                if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
+                    continue;
+                }
+                if ($row = $xoopsDB->fetchArray($result)) {
+                    $total_posts += $row['total'];
                 }
             }
             $sql = 'UPDATE ' . $xoopsDB->prefix('users') . " SET posts = '" . $total_posts . "' WHERE uid = '" . $uid . "'";
             $result = $xoopsDB->exec($sql);
-            if (!$xoopsDB->isResultSet($result)) {
+            if (false === $result) {
                 redirect_header('admin.php?fct=users', 1, _AM_SYSTEM_USERS_CNUUSER);
             }
             break;
@@ -275,7 +276,7 @@ function synchronize($uid, $type)
         case 'all users':
             $sql = 'SELECT uid FROM ' . $xoopsDB->prefix('users') . '';
             $result = $xoopsDB->query($sql);
-            if (!$xoopsDB->isResultSet($result)) {
+            if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
                 redirect_header('admin.php?fct=users', 1, sprintf(_AM_SYSTEM_USERS_CNGUSERID, $uid));
             }
 

--- a/htdocs/modules/system/admin/users/users.php
+++ b/htdocs/modules/system/admin/users/users.php
@@ -288,6 +288,7 @@ function synchronize($uid, $type)
             $result = $xoopsDB->query($sql);
             if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
                 redirect_header('admin.php?fct=users', 1, sprintf(_AM_SYSTEM_USERS_CNGUSERID, $uid));
+                return;
             }
 
             while (false !== ($data = $xoopsDB->fetchArray($result))) {

--- a/htdocs/modules/system/admin/users/users.php
+++ b/htdocs/modules/system/admin/users/users.php
@@ -220,8 +220,17 @@ function form_user($add_or_edit, $user = '')
 }
 
 /**
- * @param $uid
- * @param $type
+ * Synchronize one user (or all users) — recompute posts count.
+ *
+ * Returns false on failure (followed by a redirect_header to the admin
+ * users page) so callers iterating in 'all users' mode can stop short
+ * instead of looping past a redirect that does not actually halt
+ * execution.
+ *
+ * @param int|string $uid  User id (ignored when $type === 'all users').
+ * @param string     $type 'user' | 'all users'
+ *
+ * @return bool True on success, false on any failure.
  */
 function synchronize($uid, $type)
 {
@@ -274,12 +283,13 @@ function synchronize($uid, $type)
             if ($countFailed) {
                 // Refuse to overwrite users.posts with a partial total.
                 redirect_header('admin.php?fct=users', 1, _AM_SYSTEM_USERS_CNUUSER);
-                return;
+                return false;
             }
             $sql = 'UPDATE ' . $xoopsDB->prefix('users') . " SET posts = '" . $total_posts . "' WHERE uid = '" . $uid . "'";
             $result = $xoopsDB->exec($sql);
             if (false === $result) {
                 redirect_header('admin.php?fct=users', 1, _AM_SYSTEM_USERS_CNUUSER);
+                return false;
             }
             break;
 
@@ -288,14 +298,18 @@ function synchronize($uid, $type)
             $result = $xoopsDB->query($sql);
             if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
                 redirect_header('admin.php?fct=users', 1, sprintf(_AM_SYSTEM_USERS_CNGUSERID, $uid));
-                return;
+                return false;
             }
 
             while (false !== ($data = $xoopsDB->fetchArray($result))) {
-                synchronize($data['uid'], 'user');
+                if (false === synchronize($data['uid'], 'user')) {
+                    // Stop the bulk sync — synchronize() already issued its
+                    // own redirect_header for this user's failure.
+                    return false;
+                }
             }
             break;
     }
 
-    // exit();
+    return true;
 }

--- a/htdocs/modules/system/admin/users/users.php
+++ b/htdocs/modules/system/admin/users/users.php
@@ -222,15 +222,14 @@ function form_user($add_or_edit, $user = '')
 /**
  * Synchronize one user (or all users) — recompute posts count.
  *
- * Returns false on failure (followed by a redirect_header to the admin
- * users page) so callers iterating in 'all users' mode can stop short
- * instead of looping past a redirect that does not actually halt
- * execution.
+ * Failure paths invoke redirect_header(), which terminates the request
+ * via exit(); control does not return to the caller on failure. The
+ * trailing `return;` statements after each redirect are kept as
+ * defensive markers in case a custom preload handler ever short-circuits
+ * the redirect.
  *
  * @param int|string $uid  User id (ignored when $type === 'all users').
  * @param string     $type 'user' | 'all users'
- *
- * @return bool True on success, false on any failure.
  */
 function synchronize($uid, $type)
 {
@@ -283,13 +282,13 @@ function synchronize($uid, $type)
             if ($countFailed) {
                 // Refuse to overwrite users.posts with a partial total.
                 redirect_header('admin.php?fct=users', 1, _AM_SYSTEM_USERS_CNUUSER);
-                return false;
+                return;
             }
             $sql = 'UPDATE ' . $xoopsDB->prefix('users') . " SET posts = '" . $total_posts . "' WHERE uid = '" . $uid . "'";
             $result = $xoopsDB->exec($sql);
             if (false === $result) {
                 redirect_header('admin.php?fct=users', 1, _AM_SYSTEM_USERS_CNUUSER);
-                return false;
+                return;
             }
             break;
 
@@ -298,18 +297,14 @@ function synchronize($uid, $type)
             $result = $xoopsDB->query($sql);
             if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
                 redirect_header('admin.php?fct=users', 1, sprintf(_AM_SYSTEM_USERS_CNGUSERID, $uid));
-                return false;
+                return;
             }
 
             while (false !== ($data = $xoopsDB->fetchArray($result))) {
-                if (false === synchronize($data['uid'], 'user')) {
-                    // Stop the bulk sync — synchronize() already issued its
-                    // own redirect_header for this user's failure.
-                    return false;
-                }
+                // synchronize() either succeeds or terminates the request via
+                // redirect_header()->exit(); no per-call return-value check needed.
+                synchronize($data['uid'], 'user');
             }
             break;
     }
-
-    return true;
 }

--- a/htdocs/modules/system/language/english/admin/modulesadmin.php
+++ b/htdocs/modules/system/language/english/admin/modulesadmin.php
@@ -127,6 +127,7 @@ define('_AM_SYSTEM_MODULES_MODULE_DATA_UPDATE', 'Module data updated.');
 define('_AM_SYSTEM_MODULES_CONFIG_ADD', ' Config option added');
 define('_AM_SYSTEM_MODULES_CONFIG_DATA_ADD', ' Config %s added to the database');
 define('_AM_SYSTEM_MODULES_CONFIG_DATA_ADD_ERROR', ' ERROR: Could not insert config %s to the database. ');
+define('_AM_SYSTEM_MODULES_CONFIG_DATA_INVALID', ' ERROR: Skipped malformed config entry %s. ');
 define('_AM_SYSTEM_MODULES_GONFIG_DATA_DELETE', 'Config data deleted from the database. ');
 define('_AM_SYSTEM_MODULES_CONFIG_DATA_DELETE_ERROR', 'ERROR: Could not delete config data from the database');
 // Access


### PR DESCRIPTION
  Critical correctness fixes for two long-standing bugs in the System module
  admin code, plus by-ref + malformed-config defenses.

  users.php (synchronize-user case):
  - exec() returns int|false, not a result set. The legacy `if (!$xoopsDB->isResultSet($result))` check on the post-update return was structurally wrong - isResultSet(int) is always false, so a successful forum-post recount always triggered the failure redirect with _AM_SYSTEM_USERS_CNUUSER. Replaced with `if (false === $result)`.
  - Added the two-part fetch guard with explicit parentheses around `instanceof` (PHP precedence: `!` binds tighter than `instanceof`) on both SELECT result paths, matching the project-wide rule.

  modulesadmin.php (xoops_module_update):
  - $module->loadInfoAsVar() reloads vars from xoops_version.php, which does not declare 'mid' (DB-assigned). Without an explicit restore, every config row got re-inserted at conf_modid=0, corrupting xoops_config across the whole site. Capture mid into $targetMid before loadInfoAsVar(), refuse to proceed if invalid, restore after with setVar('mid', $targetMid) + unsetNew(), and anchor $newmid to the captured value as the single source of truth for delete and insert.
  - Preserve conf_catid on update: capture each row's catid during the delete sweep, then on re-insert resolve catid from the manifest ('category' or 'catid') first, falling back to the captured old catid. The legacy hardcoded 0 moved every system config row out of its category, making getConfigsByCat(XOOPS_CONF) return empty.
  - setConfValueForInput() takes its first arg by reference; PHP rejects passing a `??` rvalue. Extract `$config['default'] ?? ''` to a local $defaultValue first (both install and update paths).
  - Malformed config entries (missing one of name/title/formtype/ valuetype) now produce a single visible error row instead of four "Undefined array key" warnings each.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Module install/update now validates config entries and skips malformed items to prevent corrupted configuration; update path aborts on invalid modules and returns formatted errors on failure.
  * User synchronization now performs stricter database-result validation to avoid overwriting post counts on query anomalies.

* **Documentation**
  * Changelog and admin language updated with a new message for skipped malformed config entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->