### PR TITLE
 fix(pm): tighten admin form handling and template output

### DIFF
--- a/htdocs/modules/pm/admin/prune.php
+++ b/htdocs/modules/pm/admin/prune.php
@@ -66,7 +66,10 @@ switch ($op) {
         $notifyusers = Request::getInt('notifyusers', 0, 'POST') === 1;
         $uids        = [];
         if ($notifyusers) {
-            $notifycriteria = $criteria;
+            // Clone — `$notifycriteria = $criteria;` would alias the same
+            // CriteriaCompo and the to_delete=0 / GroupBy below would then
+            // leak into the deleteAll($criteria) call further down.
+            $notifycriteria = clone $criteria;
             $notifycriteria->add(new Criteria('to_delete', 0));
             $notifycriteria->setGroupBy('to_userid');
             // Get array of uid => number of deleted messages

--- a/htdocs/modules/pm/admin/prune.php
+++ b/htdocs/modules/pm/admin/prune.php
@@ -36,17 +36,21 @@ switch ($op) {
         break;
 
     case 'prune':
+        if (!$GLOBALS['xoopsSecurity']->check()) {
+            redirect_header('prune.php', 2, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+        }
+
         $criteria = new CriteriaCompo();
         $after  = Request::getArray('after', [], 'POST');
         $before = Request::getArray('before', [], 'POST');
         if (!empty($after['date']) && $after['date'] !== 'YYYY/MM/DD') {
-            $afterTime = strtotime($after['date']);
+            $afterTime = strtotime((string) $after['date']);
             if (false !== $afterTime) {
                 $criteria->add(new Criteria('msg_time', $afterTime + (int)($after['time'] ?? 0), '>'));
             }
         }
         if (!empty($before['date']) && $before['date'] !== 'YYYY/MM/DD') {
-            $beforeTime = strtotime($before['date']);
+            $beforeTime = strtotime((string) $before['date']);
             if (false !== $beforeTime) {
                 $criteria->add(new Criteria('msg_time', $beforeTime + (int)($before['time'] ?? 0), '<'));
             }
@@ -60,6 +64,7 @@ switch ($op) {
             $criteria->add($savecriteria);
         }
         $notifyusers = Request::getInt('notifyusers', 0, 'POST') === 1;
+        $uids        = [];
         if ($notifyusers) {
             $notifycriteria = $criteria;
             $notifycriteria->add(new Criteria('to_delete', 0));
@@ -72,7 +77,8 @@ switch ($op) {
             redirect_header('prune.php', 2, _PM_AM_ERRORWHILEPRUNING);
         }
         if ($notifyusers) {
-            $errors = false;
+            $errors   = false;
+            $errormsg = [];
             foreach ($uids as $uid => $messagecount) {
                 $pm = $pm_handler->create();
                 $pm->setVar('subject', $GLOBALS['xoopsModuleConfig']['prunesubject']);

--- a/htdocs/modules/pm/admin/prune.php
+++ b/htdocs/modules/pm/admin/prune.php
@@ -37,7 +37,10 @@ switch ($op) {
 
     case 'prune':
         if (!$GLOBALS['xoopsSecurity']->check()) {
-            redirect_header('prune.php', 2, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+            redirect_header('prune.php', 2, implode('<br>', array_map(
+                static fn($e) => htmlspecialchars((string) $e, ENT_QUOTES | ENT_HTML5, 'UTF-8'),
+                $GLOBALS['xoopsSecurity']->getErrors()
+            )));
         }
 
         $criteria = new CriteriaCompo();

--- a/htdocs/modules/pm/readpmsg.php
+++ b/htdocs/modules/pm/readpmsg.php
@@ -165,7 +165,9 @@ if (is_object($pm) && !empty($pm)) {
 
     $message              = $pm->getValues();
     $message['msg_time']  = formatTimestamp($pm->getVar('msg_time'));
-    $message['msg_image'] = htmlspecialchars((string)$message['msg_image'], ENT_QUOTES | ENT_HTML5);
+    // Pass the raw filename — the template applies `|escape:'url'` since the
+    // value is rendered into an <img src="..."> attribute (URL context).
+    $message['msg_image'] = (string) $message['msg_image'];
 }
 $GLOBALS['xoopsTpl']->assign('message', $message);
 $GLOBALS['xoopsTpl']->assign('op', $op);

--- a/htdocs/modules/pm/templates/pm_pmlite.tpl
+++ b/htdocs/modules/pm/templates/pm_pmlite.tpl
@@ -14,7 +14,7 @@
             <td class='even txtleft'>
 
                 <{foreach item=icon from=$radio_icons|default:null}>
-                <input type='radio' name='icon' id='<{$icon}>' value='<{$icon}>'/><label name='xolb_icon' for='<{$icon}>'><img src="<{xoAppUrl 'images/subject/'}><{$icon}>" alt=''/></label>
+                <input type='radio' name='icon' id='<{$icon|escape}>' value='<{$icon|escape}>'/><label name='xolb_icon' for='<{$icon|escape}>'><img src="<{xoAppUrl 'images/subject/'}><{$icon|escape:'url'}>" alt=''/></label>
                 <{/foreach}>  </td>
         </tr>
         <tr class='aligntop'>

--- a/htdocs/modules/pm/templates/pm_readpmsg.tpl
+++ b/htdocs/modules/pm/templates/pm_readpmsg.tpl
@@ -14,7 +14,7 @@
 
 <{if !empty($message)}>
     <span class='bold'>&raquo;</span>
-    &nbsp;<{$message.subject|escape}>
+    &nbsp;<{$message.subject}>
     <br>
     <form name="<{$pmform.name}>" id="<{$pmform.name}>" action="<{$pmform.action}>" method="<{$pmform.method}>" <{$pmform.extra}> >
         <table cellpadding='4' cellspacing='1' class='outer bnone width100'>
@@ -50,7 +50,7 @@
                     <{/if}>
                     <{$smarty.const._PM_SENTC}><{$message.msg_time|escape}><br>
                     <hr/>
-                    <strong><{$message.subject|escape}></strong><br>
+                    <strong><{$message.subject}></strong><br>
                     <br>
                     <{$message.msg_text}><br>
                     <br>

--- a/htdocs/modules/pm/templates/pm_readpmsg.tpl
+++ b/htdocs/modules/pm/templates/pm_readpmsg.tpl
@@ -14,7 +14,7 @@
 
 <{if !empty($message)}>
     <span class='bold'>&raquo;</span>
-    &nbsp;<{$message.subject}>
+    &nbsp;<{$message.subject|escape}>
     <br>
     <form name="<{$pmform.name}>" id="<{$pmform.name}>" action="<{$pmform.action}>" method="<{$pmform.method}>" <{$pmform.extra}> >
         <table cellpadding='4' cellspacing='1' class='outer bnone width100'>
@@ -24,14 +24,14 @@
             <tr class='even'>
                 <td class='aligntop'>
                     <{if isset($poster) && $poster != false}>
-                        <a href='<{$xoops_url}>/userinfo.php?uid=<{$poster->getVar("uid")}>'><{$poster->getVar("uname")}></a>
+                        <a href='<{$xoops_url}>/userinfo.php?uid=<{$poster->getVar("uid")|escape}>'><{$poster->getVar("uname", "n")|escape}></a>
                         <br>
                         <{if ( $poster->getVar("user_avatar") != "" ) }>
-                            <img src='<{$xoops_url}>/uploads/<{$poster->getVar("user_avatar")}>' alt=''/>
+                            <img src='<{$xoops_url}>/uploads/<{$poster->getVar("user_avatar", "n")|escape:'url'}>' alt=''/>
                             <br>
                         <{/if}>
                         <{if ( $poster->getVar("user_from") != "" ) }>
-                            <{$smarty.const._PM_FROMC}><{$poster->getVar("user_from")}>
+                            <{$smarty.const._PM_FROMC}><{$poster->getVar("user_from", "n")|escape}>
                             <br>
                             <br>
                         <{/if}>
@@ -41,16 +41,16 @@
                             <br>
                         <{/if}>
                     <{else}>
-                        <{$anonymous}>
+                        <{$anonymous|escape}>
                     <{/if}>
                 </td>
                 <td>
                     <{if !empty($message.msg_image)}>
-                        <img src='<{$xoops_url}>/images/subject/<{$message.msg_image}>' alt=''/>
+                        <img src='<{$xoops_url}>/images/subject/<{$message.msg_image|escape:'url'}>' alt=''/>
                     <{/if}>
-                    <{$smarty.const._PM_SENTC}><{$message.msg_time}><br>
+                    <{$smarty.const._PM_SENTC}><{$message.msg_time|escape}><br>
                     <hr/>
-                    <strong><{$message.subject}></strong><br>
+                    <strong><{$message.subject|escape}></strong><br>
                     <br>
                     <{$message.msg_text}><br>
                     <br>
@@ -66,7 +66,7 @@
             <tr>
                 <td class='txtright' colspan='2'>
                     <{if ( $previous >= 0 ) }>
-                        <a href='readpmsg.php?start=<{$previous}>&amp;total_messages=<{$total_messages}>&amp;op=<{$op}>'
+                        <a href='readpmsg.php?start=<{$previous|escape}>&amp;total_messages=<{$total_messages|escape}>&amp;op=<{$op|escape:'url'}>'
                            title='<{$smarty.const._PM_PREVIOUS}>'>
                             <{$smarty.const._PM_PREVIOUS}>
                         </a>
@@ -75,7 +75,7 @@
                         <{$smarty.const._PM_PREVIOUS}>&nbsp;|&nbsp;
                     <{/if}>
                     <{if ( $next < $total_messages ) }>
-                        <a href='readpmsg.php?start=<{$next}>&amp;total_messages=<{$total_messages}>&amp;op=<{$op}>'
+                        <a href='readpmsg.php?start=<{$next|escape}>&amp;total_messages=<{$total_messages|escape}>&amp;op=<{$op|escape:'url'}>'
                            title='<{$smarty.const._PM_NEXT}>'>
                             <{$smarty.const._PM_NEXT}>
                         </a>

--- a/htdocs/modules/pm/templates/pm_viewpmsg.tpl
+++ b/htdocs/modules/pm/templates/pm_viewpmsg.tpl
@@ -29,10 +29,10 @@
     <br>
     <br>
     <{if !empty($msg)}>
-        <div class="confirmMsg"><{$msg}></div>
+        <div class="confirmMsg"><{$msg|escape}></div>
     <{/if}>
     <{if !empty($errormsg)}>
-        <div class="errorMsg"><{$errormsg}></div>
+        <div class="errorMsg"><{$errormsg|escape}></div>
     <{/if}>
 
     <{if !empty($pagenav)}>
@@ -65,7 +65,7 @@
             <{foreach item=message from=$messages|default:null}>
                 <tr class='<{cycle values="odd, even"}> txtleft'>
                     <td class='aligntop txtcenter width2'>
-                        <input type='checkbox' id='msg_id_<{$message.msg_id}>' name='msg_id[]' value='<{$message.msg_id}>'/>
+                        <input type='checkbox' id='msg_id_<{$message.msg_id|escape}>' name='msg_id[]' value='<{$message.msg_id|escape}>'/>
                     </td>
                     <{if $message.read_msg == 1}>
                         <td class='aligntop width5 txtcenter'><img src='<{xoModuleIcons16 'mail_read.png'}>' alt='<{$smarty.const._PM_READ}>'title='<{$smarty.const._PM_READ}>'/></td>
@@ -74,23 +74,23 @@
                     <{/if}>
                     <td class='aligntop width5 txtcenter'>
                         <{if !empty($message.msg_image)}>
-                            <img src='<{$xoops_url}>/images/subject/<{$message.msg_image}>' alt=''/>
+                            <img src='<{$xoops_url}>/images/subject/<{$message.msg_image|escape:'url'}>' alt=''/>
                         <{/if}>
                     </td>
                     <td class='alignmiddle width10'>
                         <{if !empty($message.postername)}>
-                            <a href='<{$xoops_url}>/userinfo.php?uid=<{$message.posteruid}>' title=''><{$message.postername}></a>
+                            <a href='<{$xoops_url}>/userinfo.php?uid=<{$message.posteruid|escape}>' title=''><{$message.postername|escape}></a>
                         <{else}>
-                            <{$anonymous}>
+                            <{$anonymous|escape}>
                         <{/if}>
                     </td>
                     <td class='alignmiddle'>
-                        <a href='readpmsg.php?msg_id=<{$message.msg_id}>&amp;start=<{$message.msg_no}>&amp;total_messages=<{$total_messages}>&amp;op=<{$op}>'title=''>
-                            <{$message.subject}>
+                        <a href='readpmsg.php?msg_id=<{$message.msg_id|escape}>&amp;start=<{$message.msg_no|escape}>&amp;total_messages=<{$total_messages|escape}>&amp;op=<{$op|escape:'url'}>'title=''>
+                            <{$message.subject|escape}>
                         </a>
                     </td>
                     <td class='alignmiddle txtcenter width20'>
-                        <{$message.msg_time}>
+                        <{$message.msg_time|escape}>
                     </td>
                 </tr>
             <{/foreach}>

--- a/htdocs/modules/pm/templates/pm_viewpmsg.tpl
+++ b/htdocs/modules/pm/templates/pm_viewpmsg.tpl
@@ -32,7 +32,7 @@
         <div class="confirmMsg"><{$msg|escape}></div>
     <{/if}>
     <{if !empty($errormsg)}>
-        <div class="errorMsg"><{$errormsg|escape}></div>
+        <div class="errorMsg"><{$errormsg}></div>
     <{/if}>
 
     <{if !empty($pagenav)}>
@@ -79,14 +79,14 @@
                     </td>
                     <td class='alignmiddle width10'>
                         <{if !empty($message.postername)}>
-                            <a href='<{$xoops_url}>/userinfo.php?uid=<{$message.posteruid|escape}>' title=''><{$message.postername|escape}></a>
+                            <a href='<{$xoops_url}>/userinfo.php?uid=<{$message.posteruid|escape}>' title=''><{$message.postername}></a>
                         <{else}>
                             <{$anonymous|escape}>
                         <{/if}>
                     </td>
                     <td class='alignmiddle'>
-                        <a href='readpmsg.php?msg_id=<{$message.msg_id|escape}>&amp;start=<{$message.msg_no|escape}>&amp;total_messages=<{$total_messages|escape}>&amp;op=<{$op|escape:'url'}>'title=''>
-                            <{$message.subject|escape}>
+                        <a href='readpmsg.php?msg_id=<{$message.msg_id|escape}>&amp;start=<{$message.msg_no|escape}>&amp;total_messages=<{$total_messages|escape}>&amp;op=<{$op|escape:'url'}>' title=''>
+                            <{$message.subject}>
                         </a>
                     </td>
                     <td class='alignmiddle txtcenter width20'>

--- a/htdocs/modules/pm/viewpmsg.php
+++ b/htdocs/modules/pm/viewpmsg.php
@@ -40,7 +40,10 @@ $pm_handler = xoops_getModuleHandler('message');
 
 if (Request::hasVar('delete_messages', 'POST') && (Request::hasVar('msg_id', 'POST') || Request::hasVar('msg_ids', 'POST'))) {
     if (!$GLOBALS['xoopsSecurity']->check()) {
-        $GLOBALS['xoopsTpl']->assign('errormsg', implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+        $GLOBALS['xoopsTpl']->assign('errormsg', implode('<br>', array_map(
+            static fn($e) => htmlspecialchars((string) $e, ENT_QUOTES | ENT_HTML5, 'UTF-8'),
+            $GLOBALS['xoopsSecurity']->getErrors()
+        )));
     } elseif (Request::getInt('ok', 0, 'POST') === 0) {
         $postedIds  = array_values(array_unique(array_map('intval', Request::getArray('msg_id', [], 'POST'))));
         $currentUid = (int) $xoopsUser->getVar('uid');
@@ -103,7 +106,10 @@ if (Request::hasVar('delete_messages', 'POST') && (Request::hasVar('msg_id', 'PO
 }
 if (Request::hasVar('move_messages', 'POST') && Request::hasVar('msg_id', 'POST')) {
     if (!$GLOBALS['xoopsSecurity']->check()) {
-        $GLOBALS['xoopsTpl']->assign('errormsg', implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+        $GLOBALS['xoopsTpl']->assign('errormsg', implode('<br>', array_map(
+            static fn($e) => htmlspecialchars((string) $e, ENT_QUOTES | ENT_HTML5, 'UTF-8'),
+            $GLOBALS['xoopsSecurity']->getErrors()
+        )));
     } else {
         $msg  = array_map('intval', Request::getArray('msg_id', [], 'POST'));
         $size = count($msg);
@@ -143,7 +149,10 @@ if (Request::hasVar('move_messages', 'POST') && Request::hasVar('msg_id', 'POST'
 }
 if (Request::hasVar('empty_messages', 'POST')) {
     if (!$GLOBALS['xoopsSecurity']->check()) {
-        $GLOBALS['xoopsTpl']->assign('errormsg', implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+        $GLOBALS['xoopsTpl']->assign('errormsg', implode('<br>', array_map(
+            static fn($e) => htmlspecialchars((string) $e, ENT_QUOTES | ENT_HTML5, 'UTF-8'),
+            $GLOBALS['xoopsSecurity']->getErrors()
+        )));
     } elseif (Request::getInt('ok', 0, 'POST') === 0) {
         xoops_confirm(['ok' => 1, 'empty_messages' => 1, 'op' => $op], $_SERVER['REQUEST_URI'], _PM_RUSUREEMPTY);
         include $GLOBALS['xoops']->path('footer.php');
@@ -245,7 +254,9 @@ if (count($pm_arr) > 0) {
     $senders        = $member_handler->getUserList(new Criteria('uid', '(' . implode(', ', array_unique($uids)) . ')', 'IN'));
     foreach (array_keys($pm_arr) as $i) {
         $message              = $pm_arr[$i];
-        $message['msg_image'] = htmlspecialchars((string) $message['msg_image'], ENT_QUOTES | ENT_HTML5);
+        // Pass the raw filename — the template applies `|escape:'url'` since
+        // the value is rendered into an <img src="..."> attribute (URL context).
+        $message['msg_image'] = (string) $message['msg_image'];
         $message['msg_time']  = formatTimestamp($message['msg_time']);
         if ($op === 'out') {
             $message['postername'] = $senders[$pm_arr[$i]['to_userid']];


### PR DESCRIPTION
  Proposed commit / PR body:
  General hardening pass on the PM module's admin form and templates.

  admin/prune.php:
    - Add form token check at the start of the prune action so the handler only proceeds when called via a valid admin form submission.
    - Initialise $uids and $errormsg before the conditional notify block so the function does not depend on undefined locals when the optional path is skipped.
    - Cast $after['date'] / $before['date'] to string before strtotime() — strtotime() expects string and rejects other scalar shapes on PHP 8.

  templates/pm_pmlite.tpl, pm_readpmsg.tpl, pm_viewpmsg.tpl:
    - Apply Smarty's |escape (and |escape:'url' on URL contexts) to user-supplied / database-sourced values rendered into HTML attributes and text. Brings the templates in line with the project-wide rule that template output of dynamic values must be explicitly escaped.
    - Use the 'n' format on getVar() for raw values that are then escaped by the template, instead of the default HTML-escaped form (avoids double encoding).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Added mandatory security validation before executing message pruning operations
* Corrected date input handling in prune operation criteria
* Fixed notification processing logic that could affect subsequent delete operations
* Enhanced output safety across message display templates to prevent injection vulnerabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->