### PR TITLE
fix(protector): tighten admin output and module entry-point checks

### DIFF
--- a/htdocs/modules/protector/admin/stats.php
+++ b/htdocs/modules/protector/admin/stats.php
@@ -10,7 +10,9 @@
  * @package    gwiki
  */
 
-include __DIR__ . '/../../../mainfile.php';
+require __DIR__ . '/../../../mainfile.php';
+defined('XOOPS_TRUST_PATH') || exit('set XOOPS_TRUST_PATH in mainfile.php');
+
 $mydirname = basename(dirname(__DIR__)) ;
 $mydirpath = dirname(__DIR__) ;
 require $mydirpath . '/mytrustdirname.php' ; // set $mytrustdirname
@@ -18,20 +20,6 @@ require $mydirpath . '/mytrustdirname.php' ; // set $mytrustdirname
 require XOOPS_TRUST_PATH . '/modules/' . $mytrustdirname . '/admin/admin_header.php';
 
 xoops_cp_header();
-
-function dumpArray($array, $wrap = null)
-{
-    $firstTime = true;
-    $string = '[';
-    foreach ($array as $value) {
-        $string .= (!$firstTime) ? ', ' : '';
-        $firstTime = false;
-        $wrap ??= (is_int($value)) ? '' : '\'';
-        $string .= $wrap . $value . $wrap;
-    }
-    $string .= ']';
-    return $string;
-}
 
 $queryFormat = "SELECT `type`, '%s' as age, COUNT(*) as count FROM `" . $xoopsDB->prefix($mydirname . "_log")
     . "` WHERE `timestamp` > NOW() - INTERVAL %d SECOND GROUP BY `type`, 2 ";
@@ -45,7 +33,7 @@ $sql .= sprintf($queryFormat, 'day', 24 * 60 * 60);
 $sql .= 'UNION ALL ';
 $sql .= sprintf($queryFormat, 'hour', 60 * 60);
 $result = $xoopsDB->query($sql);
-if (!$xoopsDB->isResultSet($result)) {
+if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
     throw new \RuntimeException(
         \sprintf(_DB_QUERY_ERROR, $sql) . $xoopsDB->error(),
         E_USER_ERROR,
@@ -79,28 +67,34 @@ $height = (count($keys) + 1) * 24;
 
 //
 // http://gionkunz.github.io/chartist-js/examples.html#example-bar-horizontal
-$script = "new Chartist.Bar('.ct-chart', {\n";
-$script .= '  labels: ' . dumpArray(array_keys($stats)) . ",\n";
-$script .= '  series: ';
-$allSets = [];
+$seriesData = [];
 for ($i = 0; $i < 4; ++$i) {
     $newSet = [];
     foreach ($stats as $set) {
         $newSet[] = $set[$i] - (($i < 3) ? $set[$i + 1] : 0);
     }
-    $allSets[] = dumpArray($newSet);
+    $seriesData[] = $newSet;
 }
-$series = dumpArray(array_reverse($allSets), '') . "\n";
-$script .= $series;
-//Xmf\Debug::dump($stats, $series);
 
-$script .= <<<EOS
+// Build the inline JS payload via json_encode so any value embedded in
+// the chart script is well-formed JS regardless of label content. The
+// JSON_HEX_* flags keep the payload safe inside an HTML <script> block.
+$jsonFlags  = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
+$labelsJson = json_encode(array_keys($stats), $jsonFlags);
+$seriesJson = json_encode(array_reverse($seriesData), $jsonFlags);
+$heightJson = json_encode($height, $jsonFlags);
+
+$script = <<<EOS
+new Chartist.Bar('.ct-chart', {
+  labels: {$labelsJson},
+  series: {$seriesJson}
+
 }, {
   seriesBarDistance: 10,
   reverseData: true,
   horizontalBars: true,
   stackBars: true,
-  height: $height,
+  height: {$heightJson},
   axisY: {
         offset: 120
   },

--- a/htdocs/modules/protector/admin/stats.php
+++ b/htdocs/modules/protector/admin/stats.php
@@ -33,7 +33,7 @@ $sql .= sprintf($queryFormat, 'day', 24 * 60 * 60);
 $sql .= 'UNION ALL ';
 $sql .= sprintf($queryFormat, 'hour', 60 * 60);
 // Initialise $rawStats up-front so a failed query degrades gracefully
-// to an empty chart rather than fataling out of the admin page.
+// to an empty chart rather than causing a fatal error in the admin page.
 $rawStats = [
     '' => ['month' => 0, 'week' => 0, 'day' => 0, 'hour' => 0],
 ];
@@ -79,8 +79,8 @@ for ($i = 0; $i < 4; ++$i) {
 // JSON_HEX_* flags keep the payload safe inside an HTML <script> block;
 // JSON_THROW_ON_ERROR converts any encoding failure (e.g. invalid UTF-8
 // in a label) into a catchable \JsonException. On failure we degrade
-// gracefully to an empty chart and log a warning rather than fataling
-// the entire admin stats page.
+// gracefully to an empty chart and log a warning rather than causing
+// a fatal error in the admin stats page.
 $jsonFlags = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_THROW_ON_ERROR;
 try {
     $labelsJson = json_encode(array_keys($stats), $jsonFlags);

--- a/htdocs/modules/protector/admin/stats.php
+++ b/htdocs/modules/protector/admin/stats.php
@@ -32,21 +32,22 @@ $sql .= 'UNION ALL ';
 $sql .= sprintf($queryFormat, 'day', 24 * 60 * 60);
 $sql .= 'UNION ALL ';
 $sql .= sprintf($queryFormat, 'hour', 60 * 60);
-$result = $xoopsDB->query($sql);
-if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
-    throw new \RuntimeException(
-        \sprintf(_DB_QUERY_ERROR, $sql) . $xoopsDB->error(),
-        E_USER_ERROR,
-    );
-}
+// Initialise $rawStats up-front so a failed query degrades gracefully
+// to an empty chart rather than fataling out of the admin page. The
+// concrete result-set type is left to XoopsDatabase / isResultSet()
+// because Protector supports XOOPS_DB_ALTERNATIVE (see preloads/core.php),
+// which can return non-mysqli result objects.
+$rawStats = [
+    '' => ['month' => 0, 'week' => 0, 'day' => 0, 'hour' => 0],
+];
 
-$rawStats = [];
-$rawStats['']['month'] = 0;
-$rawStats['']['week'] = 0;
-$rawStats['']['day'] = 0;
-$rawStats['']['hour'] = 0;
-while (false !== ($row = $xoopsDB->fetchArray($result))) {
-    $rawStats[$row['type']][$row['age']] = $row['count'];
+$result = $xoopsDB->query($sql);
+if (!$xoopsDB->isResultSet($result)) {
+    trigger_error(\sprintf(_DB_QUERY_ERROR, $sql) . $xoopsDB->error(), E_USER_WARNING);
+} else {
+    while (false !== ($row = $xoopsDB->fetchArray($result))) {
+        $rawStats[$row['type']][$row['age']] = $row['count'];
+    }
 }
 $ages = ['month', 'week', 'day', 'hour'];
 $stats = [];
@@ -80,16 +81,19 @@ for ($i = 0; $i < 4; ++$i) {
 // the chart script is well-formed JS regardless of label content. The
 // JSON_HEX_* flags keep the payload safe inside an HTML <script> block;
 // JSON_THROW_ON_ERROR converts any encoding failure (e.g. invalid UTF-8
-// in a label) into a \JsonException, which we rewrap with a clear
-// message so the page surfaces a meaningful error instead of silently
-// emitting broken JS.
+// in a label) into a catchable \JsonException. On failure we degrade
+// gracefully to an empty chart and log a warning rather than fataling
+// the entire admin stats page.
 $jsonFlags = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_THROW_ON_ERROR;
 try {
     $labelsJson = json_encode(array_keys($stats), $jsonFlags);
     $seriesJson = json_encode(array_reverse($seriesData), $jsonFlags);
     $heightJson = json_encode($height, $jsonFlags);
 } catch (\JsonException $e) {
-    throw new \RuntimeException('Unable to encode Protector stats chart data.', 0, $e);
+    trigger_error('Unable to encode Protector stats chart data: ' . $e->getMessage(), E_USER_WARNING);
+    $labelsJson = '[]';
+    $seriesJson = '[]';
+    $heightJson = '24';
 }
 
 $script = <<<EOS

--- a/htdocs/modules/protector/admin/stats.php
+++ b/htdocs/modules/protector/admin/stats.php
@@ -34,9 +34,7 @@ $sql .= 'UNION ALL ';
 $sql .= sprintf($queryFormat, 'hour', 60 * 60);
 // Initialise $rawStats up-front so a failed query degrades gracefully
 // to an empty chart rather than causing a fatal error in the admin page.
-$rawStats = [
-    '' => ['month' => 0, 'week' => 0, 'day' => 0, 'hour' => 0],
-];
+$rawStats = [];
 
 $result = $xoopsDB->query($sql);
 if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
@@ -65,13 +63,18 @@ $height = (count($keys) + 1) * 24;
 
 //
 // http://gionkunz.github.io/chartist-js/examples.html#example-bar-horizontal
+// When $stats is empty we leave $seriesData empty as well, so the
+// payload is `labels: [], series: []` — a genuinely empty chart
+// rather than a chart with empty labels but four [[],[],[],[]] series.
 $seriesData = [];
-for ($i = 0; $i < 4; ++$i) {
-    $newSet = [];
-    foreach ($stats as $set) {
-        $newSet[] = $set[$i] - (($i < 3) ? $set[$i + 1] : 0);
+if (!empty($stats)) {
+    for ($i = 0; $i < 4; ++$i) {
+        $newSet = [];
+        foreach ($stats as $set) {
+            $newSet[] = $set[$i] - (($i < 3) ? $set[$i + 1] : 0);
+        }
+        $seriesData[] = $newSet;
     }
-    $seriesData[] = $newSet;
 }
 
 // Build the inline JS payload via json_encode so any value embedded in

--- a/htdocs/modules/protector/admin/stats.php
+++ b/htdocs/modules/protector/admin/stats.php
@@ -33,16 +33,13 @@ $sql .= sprintf($queryFormat, 'day', 24 * 60 * 60);
 $sql .= 'UNION ALL ';
 $sql .= sprintf($queryFormat, 'hour', 60 * 60);
 // Initialise $rawStats up-front so a failed query degrades gracefully
-// to an empty chart rather than fataling out of the admin page. The
-// concrete result-set type is left to XoopsDatabase / isResultSet()
-// because Protector supports XOOPS_DB_ALTERNATIVE (see preloads/core.php),
-// which can return non-mysqli result objects.
+// to an empty chart rather than fataling out of the admin page.
 $rawStats = [
     '' => ['month' => 0, 'week' => 0, 'day' => 0, 'hour' => 0],
 ];
 
 $result = $xoopsDB->query($sql);
-if (!$xoopsDB->isResultSet($result)) {
+if (!$xoopsDB->isResultSet($result) || !($result instanceof \mysqli_result)) {
     trigger_error(\sprintf(_DB_QUERY_ERROR, $sql) . $xoopsDB->error(), E_USER_WARNING);
 } else {
     while (false !== ($row = $xoopsDB->fetchArray($result))) {

--- a/htdocs/modules/protector/admin/stats.php
+++ b/htdocs/modules/protector/admin/stats.php
@@ -10,7 +10,7 @@
  * @package    gwiki
  */
 
-require __DIR__ . '/../../../mainfile.php';
+require_once dirname(__DIR__, 3) . '/mainfile.php';
 defined('XOOPS_TRUST_PATH') || exit('set XOOPS_TRUST_PATH in mainfile.php');
 
 $mydirname = basename(dirname(__DIR__)) ;
@@ -78,11 +78,19 @@ for ($i = 0; $i < 4; ++$i) {
 
 // Build the inline JS payload via json_encode so any value embedded in
 // the chart script is well-formed JS regardless of label content. The
-// JSON_HEX_* flags keep the payload safe inside an HTML <script> block.
-$jsonFlags  = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
-$labelsJson = json_encode(array_keys($stats), $jsonFlags);
-$seriesJson = json_encode(array_reverse($seriesData), $jsonFlags);
-$heightJson = json_encode($height, $jsonFlags);
+// JSON_HEX_* flags keep the payload safe inside an HTML <script> block;
+// JSON_THROW_ON_ERROR converts any encoding failure (e.g. invalid UTF-8
+// in a label) into a \JsonException, which we rewrap with a clear
+// message so the page surfaces a meaningful error instead of silently
+// emitting broken JS.
+$jsonFlags = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_THROW_ON_ERROR;
+try {
+    $labelsJson = json_encode(array_keys($stats), $jsonFlags);
+    $seriesJson = json_encode(array_reverse($seriesData), $jsonFlags);
+    $heightJson = json_encode($height, $jsonFlags);
+} catch (\JsonException $e) {
+    throw new \RuntimeException('Unable to encode Protector stats chart data.', 0, $e);
+}
 
 $script = <<<EOS
 new Chartist.Bar('.ct-chart', {

--- a/htdocs/modules/protector/blocks/blocks.php
+++ b/htdocs/modules/protector/blocks/blocks.php
@@ -1,5 +1,6 @@
 <?php
 
+defined('XOOPS_ROOT_PATH') || exit('Restricted access');
 defined('XOOPS_TRUST_PATH') || exit('set XOOPS_TRUST_PATH in mainfile.php');
 
 $mydirname = basename(dirname(__DIR__));

--- a/htdocs/modules/protector/docs/changelog.txt
+++ b/htdocs/modules/protector/docs/changelog.txt
@@ -1,5 +1,8 @@
 = CHANGES =
 
+3.63-dev (2026/05/04)
+- General hardening pass on admin output and module entry-point checks (mamba)
+
 3.63 (2025/01/19)
 - updated HTML Purifier to 4.18.0 (mamba)
 - moved HTML Purifier to /xoops_lib/vendor/ (ezyang/htmlpurifier)  (mamba)

--- a/htdocs/modules/protector/preloads/core.php
+++ b/htdocs/modules/protector/preloads/core.php
@@ -1,7 +1,4 @@
 <?php
-
-defined('XOOPS_ROOT_PATH') || exit('Restricted access');
-defined('XOOPS_TRUST_PATH') || exit('set XOOPS_TRUST_PATH in mainfile.php');
 /**
  * Protector
  *
@@ -18,6 +15,9 @@ defined('XOOPS_TRUST_PATH') || exit('set XOOPS_TRUST_PATH in mainfile.php');
  * @since               2.4.0
  * @author              trabis <lusopoemas@gmail.com>
  */
+
+defined('XOOPS_ROOT_PATH') || exit('Restricted access');
+defined('XOOPS_TRUST_PATH') || exit('set XOOPS_TRUST_PATH in mainfile.php');
 
 /**
  * Protector core preloads

--- a/htdocs/modules/protector/preloads/core.php
+++ b/htdocs/modules/protector/preloads/core.php
@@ -1,4 +1,7 @@
 <?php
+
+defined('XOOPS_ROOT_PATH') || exit('Restricted access');
+defined('XOOPS_TRUST_PATH') || exit('set XOOPS_TRUST_PATH in mainfile.php');
 /**
  * Protector
  *
@@ -15,10 +18,6 @@
  * @since               2.4.0
  * @author              trabis <lusopoemas@gmail.com>
  */
-
-//if (!defined('XOOPS_ROOT_PATH')) {
-//    throw new \RuntimeException('XOOPS root path not defined');
-//}
 
 /**
  * Protector core preloads


### PR DESCRIPTION
  Proposed commit / PR body:
  General hardening pass on the Protector module.

  admin/stats.php:
    - Switch the bootstrap include to require, and add an explicit XOOPS_TRUST_PATH guard at the top so the script fails fast when the trust path is missing.
    - Replace the local dumpArray() helper (manual string-concat of array values into a JS literal) with json_encode() using the JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT flag set, which is the appropriate encoding for values that are inlined into an HTML <script> block.
    - Tighten the result-set guard before the chart-stats fetch to the canonical two-part form (isResultSet && instanceof \mysqli_result), matching the project-wide rule.

  blocks/blocks.php, preloads/core.php:
    Add explicit `defined('XOOPS_ROOT_PATH')` guards to the front
    of these public entry-point files. The existing TRUST_PATH
    guard remains; the ROOT_PATH guard is the first defence and
    matches the convention used elsewhere in core.

  docs/changelog.txt:
    One-line 3.63-dev entry covering the above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust stats query handling with graceful fallbacks and warning on invalid results
  * Improved chart data encoding and runtime fallback to avoid chart rendering failures

* **Security**
  * Added entry-point access checks to prevent direct module access

* **Chores**
  * Updated changelog with new development version note
<!-- end of auto-generated comment: release notes by coderabbit.ai -->