### PR TITLE
fix(system): drop deprecated by-reference form on uploader error fetches

### DIFF
--- a/htdocs/modules/system/admin/avatars/main.php
+++ b/htdocs/modules/system/admin/avatars/main.php
@@ -203,7 +203,7 @@ switch ($op) {
             if ($uploader->fetchMedia('avatar_file')) {
                 $uploader->setPrefix('savt');
                 if (!$uploader->upload()) {
-                    $err[] = & $uploader->getErrors();
+                    $err[] = $uploader->getErrors();
                 } else {
                     $avatar->setVar('avatar_name', Request::getString('avatar_name', '', 'POST'));
                     $avatar->setVar('avatar_display', Request::getBool('avatar_display', false, 'POST'));

--- a/htdocs/modules/system/admin/images/main.php
+++ b/htdocs/modules/system/admin/images/main.php
@@ -439,7 +439,7 @@ switch ($op) {
         for ($i = 0; $i < $ucount; ++$i) {
             if ($uploader->fetchMedia($xoops_upload_file[$i])) {
                 if (!$uploader->upload()) {
-                    $err[] = & $uploader->getErrors();
+                    $err[] = $uploader->getErrors();
                 } else {
                     $image_handler = xoops_getHandler('image');
                     $image         = $image_handler->create();

--- a/htdocs/modules/system/admin/smilies/main.php
+++ b/htdocs/modules/system/admin/smilies/main.php
@@ -171,7 +171,7 @@ switch ($op) {
                 $uploader_smilies_img->setPrefix('smil');
                 $uploader_smilies_img->fetchMedia('smile_url');
                 if (!$uploader_smilies_img->upload()) {
-                    $err[] = & $uploader_smilies_img->getErrors();
+                    $err[] = $uploader_smilies_img->getErrors();
                 } else {
                     $obj->setVar('smile_url', 'smilies/' . $uploader_smilies_img->getSavedFileName());
                     if (!$smilies_Handler->insert($obj)) {

--- a/htdocs/modules/system/admin/userrank/main.php
+++ b/htdocs/modules/system/admin/userrank/main.php
@@ -163,7 +163,7 @@ switch ($op) {
                 $uploader_rank_img->setPrefix('rank');
                 $uploader_rank_img->fetchMedia('rank_image');
                 if (!$uploader_rank_img->upload()) {
-                    $err[] = & $uploader_rank_img->getErrors();
+                    $err[] = $uploader_rank_img->getErrors();
                 } else {
                     $obj->setVar('rank_image', 'ranks/' . $uploader_rank_img->getSavedFileName());
                     if (!$userrank_Handler->insert($obj)) {


### PR DESCRIPTION
  Proposed commit / PR body:
  PHP 8 deprecation cleanup in four System admin upload handlers.

  system/admin/{avatars,images,smilies,userrank}/main.php:
    Each file's upload-failure branch wrote
        $err[] = & $uploader->getErrors();
    i.e. assign-by-reference to the array result of a method call.
    This idiom has been a deprecation notice since PHP 7.4 and is
    an outright error in current PHP 8.x runs, so every failed
    upload was emitting a deprecation warning into admin output.
    getErrors() returns an array by value; the assignment is
    always copy semantics anyway, so the `& ` is removed.