### PR TITLE
fix(system): defensive fallback when theme_set config rows are missing

### DIFF
--- a/htdocs/include/xoops.js
+++ b/htdocs/include/xoops.js
@@ -193,7 +193,13 @@ function showImgSelected(imgId, selectId, imgDir, extra, xoopsUrl) {
     imgDom = xoopsGetElementById(imgId);
     selectDom = xoopsGetElementById(selectId);
     if (selectDom.options[selectDom.selectedIndex].value != "") {
-        imgDom.src = xoopsUrl + "/" + imgDir + "/" + selectDom.options[selectDom.selectedIndex].value + extra;
+        // encodeURIComponent on the selected value: the theme-switch
+        // selector now allows spaces and non-ASCII directory names, and
+        // avatar / rank / smiley selectors can also legitimately contain
+        // characters that need URL-encoding. encodeURIComponent is a
+        // no-op for [A-Za-z0-9_.-~] (RFC 3986 unreserved), so it does
+        // not change the URL for callers using ASCII-only filenames.
+        imgDom.src = xoopsUrl + "/" + imgDir + "/" + encodeURIComponent(selectDom.options[selectDom.selectedIndex].value) + extra;
     } else {
         imgDom.src = xoopsUrl + "/images/blank.gif";
     }

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -671,12 +671,27 @@ function b_system_themes_show($options)
     }
 
     // Defensive: if the xoops_config rows for theme_set / theme_set_allowed
-    // are missing or unreadable, neither this block nor the theme rendering
-    // chain that triggered it should fatal. Fall back to the current theme
-    // (or 'default') as a single-entry allowed list so the block renders
+    // are missing, unreadable, or contain unexpected values, neither this
+    // block nor the theme rendering chain that triggered it should fatal.
+    // Normalise each theme name to the filesystem-safe character set used
+    // for actual theme directories ([A-Za-z0-9_-]); anything else is
+    // treated as corruption and dropped. After normalisation, fall back to
+    // 'default' / [$currentTheme] as needed so the block always renders
     // something useful instead of producing a PHP warning + blank output.
-    $currentTheme  = (string) ($xoopsConfig['theme_set'] ?? 'default');
-    $allowedThemes = (array)  ($xoopsConfig['theme_set_allowed'] ?? []);
+    $normalizeTheme = static fn(string $name): string => (string) preg_replace('/[^A-Za-z0-9_-]/', '', $name);
+
+    $currentTheme = $normalizeTheme((string) ($xoopsConfig['theme_set'] ?? 'default'));
+    if ('' === $currentTheme) {
+        $currentTheme = 'default';
+    }
+
+    $allowedThemes = array_values(array_filter(
+        array_map(
+            static fn($name): string => $normalizeTheme((string) $name),
+            (array) ($xoopsConfig['theme_set_allowed'] ?? [])
+        ),
+        static fn(string $name): bool => '' !== $name
+    ));
     if ([] === $allowedThemes) {
         $allowedThemes = [$currentTheme];
     }
@@ -688,8 +703,17 @@ function b_system_themes_show($options)
     }
 
     if ($options[0] == 1) {
+        // Belt-and-suspenders: $currentTheme is already normalised to
+        // [A-Za-z0-9_-] above, so rawurlencode() is a no-op for valid
+        // input. The encode + htmlspecialchars stays correct even if
+        // the validator above is ever loosened.
+        $themeShotUrl = htmlspecialchars(
+            XOOPS_THEME_URL . '/' . rawurlencode($currentTheme) . '/shot.gif',
+            ENT_QUOTES | ENT_SUBSTITUTE,
+            'UTF-8'
+        );
         $themeSelect = '<img vspace="2" id="xoops_theme_img" src="'
-            . XOOPS_THEME_URL . '/' . $currentTheme . '/shot.gif" '
+            . $themeShotUrl . '" '
             . ' alt="screenshot" width="' . (int)$options[1] . '" />'
             . '<br>';
         $select->setExtra(' onchange="showImgSelected(\'xoops_theme_img\', \'xoops_theme_select\', \'themes\', \'/shot.gif\', '
@@ -712,7 +736,7 @@ function b_system_themes_show($options)
     }
 
     $block['theme_select'] = $themeSelect . '<br>(' . sprintf(_MB_SYSTEM_NUMTHEME, '<strong>'
-            . count($xoopsConfig['theme_set_allowed']) . '</strong>') . ')<br>';
+            . count($allowedThemes) . '</strong>') . ')<br>';
     // Note: the rendered `xoops_theme_redirect` hidden field is intentionally
     // emitted with an empty value="" by the templates. Do NOT add a server-side
     // seed here from REQUEST_URI — when bcachetime > 0 the cache-warming

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -657,13 +657,20 @@ function b_system_info_edit($options)
 }
 
 /**
- * Validate a theme directory name against the safe character set XOOPS
- * uses for theme directories — letters, digits, underscore, hyphen, dot.
- * Reject names with path separators, null bytes, any `..` sequence
- * (anywhere in the name, not just as a path segment, so e.g. `my..theme`
- * is also rejected), or a leading dot (hidden files). Names that fail
- * validation return ''. Surviving names are trimmed but otherwise not
- * rewritten, so a valid `my.theme` directory keeps its dot.
+ * Validate a theme directory name for *path safety* only.
+ *
+ * XOOPS theme discovery (XoopsLists::getDirListAsArray) and the theme
+ * factory accept arbitrary directory names — including spaces, non-ASCII
+ * characters, etc. This validator therefore enforces the minimum needed
+ * to prevent path traversal: reject empty names, leading dot (hidden
+ * files), path separators, null bytes, and `..` appearing as a path
+ * segment. Output safety (HTML / URL contexts) is the caller's job —
+ * see the option-label escape and rawurlencode/htmlspecialchars on the
+ * screenshot URL below.
+ *
+ * Names that fail validation return ''. Surviving names are trimmed but
+ * otherwise not rewritten, so an existing theme directory like
+ * `My Theme` (space) or a non-ASCII name keeps its original form.
  *
  * @internal Used by b_system_themes_show.
  */
@@ -676,8 +683,7 @@ function systemValidateThemeName(string $name): string
         || str_contains($name, '/')
         || str_contains($name, '\\')
         || str_contains($name, "\0")
-        || str_contains($name, '..')
-        || !preg_match('/^[A-Za-z0-9_.-]+$/', $name)
+        || preg_match('~(?:^|[\\\\/])\.\.(?:[\\\\/]|$)~', $name)
     ) {
         return '';
     }
@@ -769,16 +775,21 @@ function b_system_themes_show($options)
     $selectSize = ($options[0] == 1) ? 1 : (int) $options[2];
     $select = new XoopsFormSelect('', 'xoops_theme_select', $currentTheme, $selectSize);
     foreach ($allowedThemes as $theme) {
-        $select->addOption($theme, $theme);
+        // XoopsFormSelect escapes option *values* but not option *labels*;
+        // since the validator only enforces path safety, a legitimate
+        // theme directory may still contain HTML-significant characters
+        // (e.g. an `&` in the directory name). Escape the label here so
+        // it's safe in HTML body context.
+        $select->addOption($theme, htmlspecialchars($theme, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
     }
 
     if ($options[0] == 1) {
-        // Belt-and-suspenders: $currentTheme has already passed the
-        // validator above (letters, digits, underscore, hyphen, dot —
-        // all in RFC 3986 unreserved set), so rawurlencode() preserves
-        // it as-is and htmlspecialchars() has nothing to escape. The
-        // explicit encode + escape stays correct if the validator is
-        // ever loosened.
+        // Encode + escape the screenshot URL. $currentTheme has passed
+        // the path-safety validator above, but the validator deliberately
+        // allows any character XOOPS theme discovery would accept —
+        // including spaces and non-ASCII — so rawurlencode is needed to
+        // produce a valid URL component, and htmlspecialchars is needed
+        // to make the result safe inside the src="..." attribute.
         $themeShotUrl = htmlspecialchars(
             XOOPS_THEME_URL . '/' . rawurlencode($currentTheme) . '/shot.gif',
             ENT_QUOTES | ENT_SUBSTITUTE,

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -697,7 +697,12 @@ function b_system_themes_show($options)
         return $name;
     };
 
-    $currentTheme = $normalizeTheme((string) ($xoopsConfig['theme_set'] ?? 'default'));
+    // Same defence as the allowed-themes loop below: avoid casting a
+    // non-string (e.g. an object or array left in xoops_config by a
+    // corrupted override) directly to string, which would TypeError on
+    // an object without __toString or render an array as "Array".
+    $rawCurrentTheme = $xoopsConfig['theme_set'] ?? 'default';
+    $currentTheme    = is_string($rawCurrentTheme) ? $normalizeTheme($rawCurrentTheme) : '';
     if ('' === $currentTheme) {
         $currentTheme = 'default';
     }
@@ -719,7 +724,10 @@ function b_system_themes_show($options)
     }
     $allowedThemes = array_values(array_filter(
         array_map(
-            static fn($name): string => $normalizeTheme((string) $name),
+            // Skip non-scalar entries (objects without __toString, resources,
+            // arrays, null) without casting — `(string)` on those would
+            // raise a TypeError on PHP 8.
+            static fn($name): string => is_scalar($name) ? $normalizeTheme((string) $name) : '',
             $rawAllowedThemes
         ),
         static fn(string $name): bool => '' !== $name

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -685,16 +685,34 @@ function b_system_themes_show($options)
         $currentTheme = 'default';
     }
 
+    // theme_set_allowed is normally a PHP array (xoops_config 'array' type
+    // decodes via unserialize). Defend against direct overrides in
+    // mainfile.php / xoopsconfig.php that may set it as a pipe-separated
+    // string; anything else falls through to an empty list.
+    $rawAllowedThemes = $xoopsConfig['theme_set_allowed'] ?? [];
+    if (is_string($rawAllowedThemes)) {
+        $rawAllowedThemes = array_filter(array_map('trim', explode('|', $rawAllowedThemes)));
+    } elseif (!is_array($rawAllowedThemes)) {
+        $rawAllowedThemes = [];
+    }
     $allowedThemes = array_values(array_filter(
         array_map(
             static fn($name): string => $normalizeTheme((string) $name),
-            (array) ($xoopsConfig['theme_set_allowed'] ?? [])
+            $rawAllowedThemes
         ),
         static fn(string $name): bool => '' !== $name
     ));
     if ([] === $allowedThemes) {
         $allowedThemes = [$currentTheme];
     }
+    // Keep the selected option and screenshot aligned: if the allowed
+    // list does not include the active theme (partial / corrupted
+    // config), prepend it so the rendered <select> has an option that
+    // matches its `selected` value.
+    if (!in_array($currentTheme, $allowedThemes, true)) {
+        array_unshift($allowedThemes, $currentTheme);
+    }
+    $allowedThemes = array_values(array_unique($allowedThemes));
 
     $selectSize = ($options[0] == 1) ? 1 : (int) $options[2];
     $select = new XoopsFormSelect('', 'xoops_theme_select', $currentTheme, $selectSize);

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -673,13 +673,13 @@ function b_system_themes_show($options)
     // Defensive: if the xoops_config rows for theme_set / theme_set_allowed
     // are missing, unreadable, or contain unexpected values, neither this
     // block nor the theme rendering chain that triggered it should fatal.
-    // Validate (do NOT rewrite) each theme name against the directory-safe
-    // character set XOOPS theme directories actually use — letters, digits,
-    // underscore, hyphen, and dot — and reject names with path separators,
-    // null bytes, '..' segments, or a leading dot (hidden files). Names
-    // that fail validation are returned as '' and dropped by the
-    // array_filter below; anything that survives is the original name
-    // unmodified, so a valid `my.theme` directory keeps its dot.
+    // Validate each theme name against the directory-safe character set
+    // XOOPS theme directories actually use — letters, digits, underscore,
+    // hyphen, and dot — and reject names with path separators, null
+    // bytes, '..' segments, or a leading dot (hidden files). Names that
+    // fail validation are returned as '' and dropped by the array_filter
+    // below. Surviving names are returned trimmed but otherwise not
+    // rewritten — a valid `my.theme` directory keeps its dot.
     $normalizeTheme = static function (string $name): string {
         $name = trim($name);
         if (
@@ -708,7 +708,12 @@ function b_system_themes_show($options)
     // string; anything else falls through to an empty list.
     $rawAllowedThemes = $xoopsConfig['theme_set_allowed'] ?? [];
     if (is_string($rawAllowedThemes)) {
-        $rawAllowedThemes = array_filter(array_map('trim', explode('|', $rawAllowedThemes)));
+        // Filter on empty-string explicitly — a default array_filter() drops
+        // any falsy entry, including a theme directory literally named "0".
+        $rawAllowedThemes = array_filter(
+            array_map('trim', explode('|', $rawAllowedThemes)),
+            static fn(string $theme): bool => '' !== $theme
+        );
     } elseif (!is_array($rawAllowedThemes)) {
         $rawAllowedThemes = [];
     }

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -661,60 +661,68 @@ function b_system_info_edit($options)
  *
  * @return array
  */
-function b_system_themes_show($options)
+/**
+ * Validate a theme directory name against the safe character set XOOPS
+ * uses for theme directories — letters, digits, underscore, hyphen, dot.
+ * Reject names with path separators, null bytes, '..' segments, or a
+ * leading dot (hidden files). Names that fail validation return ''.
+ * Surviving names are trimmed but otherwise not rewritten, so a valid
+ * `my.theme` directory keeps its dot.
+ *
+ * @internal Used by b_system_themes_show.
+ */
+function _b_system_themes_normalize_name(string $name): string
 {
-    global $xoopsConfig;
-    $block = [];
-
-    if (!isset($options[2])) {
-        $options[2] = 6; // default visible theme rows
+    $name = trim($name);
+    if (
+        '' === $name
+        || str_starts_with($name, '.')
+        || str_contains($name, '/')
+        || str_contains($name, '\\')
+        || str_contains($name, "\0")
+        || str_contains($name, '..')
+        || !preg_match('/^[A-Za-z0-9_.-]+$/', $name)
+    ) {
+        return '';
     }
 
-    // Defensive: if the xoops_config rows for theme_set / theme_set_allowed
-    // are missing, unreadable, or contain unexpected values, neither this
-    // block nor the theme rendering chain that triggered it should fatal.
-    // Validate each theme name against the directory-safe character set
-    // XOOPS theme directories actually use — letters, digits, underscore,
-    // hyphen, and dot — and reject names with path separators, null
-    // bytes, '..' segments, or a leading dot (hidden files). Names that
-    // fail validation are returned as '' and dropped by the array_filter
-    // below. Surviving names are returned trimmed but otherwise not
-    // rewritten — a valid `my.theme` directory keeps its dot.
-    $normalizeTheme = static function (string $name): string {
-        $name = trim($name);
-        if (
-            '' === $name
-            || str_starts_with($name, '.')
-            || str_contains($name, '/')
-            || str_contains($name, '\\')
-            || str_contains($name, "\0")
-            || str_contains($name, '..')
-            || !preg_match('/^[A-Za-z0-9_.-]+$/', $name)
-        ) {
-            return '';
-        }
+    return $name;
+}
 
-        return $name;
-    };
-
-    // Same defence as the allowed-themes loop below: avoid casting a
-    // non-string (e.g. an object or array left in xoops_config by a
-    // corrupted override) directly to string, which would TypeError on
-    // an object without __toString or render an array as "Array".
+/**
+ * Resolve the (current, allowed) theme pair from $xoopsConfig defensively.
+ *
+ * - Casts and validates each value through _b_system_themes_normalize_name.
+ * - Treats a string `theme_set_allowed` as pipe-separated (defends against
+ *   manual overrides in mainfile.php / xoopsconfig.php).
+ * - Skips non-scalar entries (object/array/null/resource) without casting,
+ *   so a corrupted xoops_config row cannot trigger an Error or a
+ *   string-conversion Warning.
+ * - Falls back to 'default' if no usable current theme survived.
+ * - Falls back to [$currentTheme] if no usable allowed theme survived.
+ * - Ensures $currentTheme is in the allowed list (otherwise the rendered
+ *   <select> would be selected on a value that is not one of its options).
+ *
+ * @return array{0: string, 1: list<string>} [$currentTheme, $allowedThemes]
+ *
+ * @internal Used by b_system_themes_show.
+ */
+function _b_system_themes_resolve_config(array $xoopsConfig): array
+{
     $rawCurrentTheme = $xoopsConfig['theme_set'] ?? 'default';
-    $currentTheme    = is_string($rawCurrentTheme) ? $normalizeTheme($rawCurrentTheme) : '';
+    $currentTheme    = is_string($rawCurrentTheme) ? _b_system_themes_normalize_name($rawCurrentTheme) : '';
     if ('' === $currentTheme) {
         $currentTheme = 'default';
     }
 
-    // theme_set_allowed is normally a PHP array (xoops_config 'array' type
-    // decodes via unserialize). Defend against direct overrides in
-    // mainfile.php / xoopsconfig.php that may set it as a pipe-separated
-    // string; anything else falls through to an empty list.
+    // theme_set_allowed is normally a PHP array (xoops_config 'array'
+    // type decodes via unserialize). Defend against direct overrides
+    // setting it as a pipe-separated string; anything else falls
+    // through to an empty list.
     $rawAllowedThemes = $xoopsConfig['theme_set_allowed'] ?? [];
     if (is_string($rawAllowedThemes)) {
-        // Filter on empty-string explicitly — a default array_filter() drops
-        // any falsy entry, including a theme directory literally named "0".
+        // Filter on empty-string explicitly — default array_filter()
+        // drops any falsy entry, including a theme literally named "0".
         $rawAllowedThemes = array_filter(
             array_map('trim', explode('|', $rawAllowedThemes)),
             static fn(string $theme): bool => '' !== $theme
@@ -724,10 +732,7 @@ function b_system_themes_show($options)
     }
     $allowedThemes = array_values(array_filter(
         array_map(
-            // Skip non-scalar entries (objects without __toString, resources,
-            // arrays, null) without casting — `(string)` on those would
-            // raise a TypeError on PHP 8.
-            static fn($name): string => is_scalar($name) ? $normalizeTheme((string) $name) : '',
+            static fn($name): string => is_scalar($name) ? _b_system_themes_normalize_name((string) $name) : '',
             $rawAllowedThemes
         ),
         static fn(string $name): bool => '' !== $name
@@ -735,14 +740,35 @@ function b_system_themes_show($options)
     if ([] === $allowedThemes) {
         $allowedThemes = [$currentTheme];
     }
-    // Keep the selected option and screenshot aligned: if the allowed
-    // list does not include the active theme (partial / corrupted
-    // config), prepend it so the rendered <select> has an option that
-    // matches its `selected` value.
     if (!in_array($currentTheme, $allowedThemes, true)) {
         array_unshift($allowedThemes, $currentTheme);
     }
     $allowedThemes = array_values(array_unique($allowedThemes));
+
+    return [$currentTheme, $allowedThemes];
+}
+
+/**
+ * @param $options
+ *
+ * @return array
+ */
+function b_system_themes_show($options)
+{
+    global $xoopsConfig;
+    $block = [];
+
+    if (!isset($options[2])) {
+        $options[2] = 6; // default visible theme rows
+    }
+
+    // Defensive: if xoops_config rows for theme_set / theme_set_allowed
+    // are missing, unreadable, or contain unexpected values, neither
+    // this block nor the theme rendering chain that triggered it
+    // should fatal. The helper returns safe (current, allowed) locals
+    // so the rest of this function can render a usable select even
+    // when the config is partially corrupted.
+    [$currentTheme, $allowedThemes] = _b_system_themes_resolve_config($xoopsConfig);
 
     $selectSize = ($options[0] == 1) ? 1 : (int) $options[2];
     $select = new XoopsFormSelect('', 'xoops_theme_select', $currentTheme, $selectSize);

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -667,7 +667,7 @@ function b_system_info_edit($options)
  *
  * @internal Used by b_system_themes_show.
  */
-function systemNormalizeThemeName(string $name): string
+function systemValidateThemeName(string $name): string
 {
     $name = trim($name);
     if (
@@ -688,7 +688,7 @@ function systemNormalizeThemeName(string $name): string
 /**
  * Resolve the (current, allowed) theme pair from $xoopsConfig defensively.
  *
- * - Casts and validates each value through systemNormalizeThemeName.
+ * - Casts and validates each value through systemValidateThemeName.
  * - Treats a string `theme_set_allowed` as pipe-separated (defends against
  *   manual overrides in mainfile.php / xoopsconfig.php).
  * - Skips non-scalar entries (object/array/null/resource) without casting,
@@ -706,7 +706,7 @@ function systemNormalizeThemeName(string $name): string
 function systemThemesResolveConfig(array $xoopsConfig): array
 {
     $rawCurrentTheme = $xoopsConfig['theme_set'] ?? 'default';
-    $currentTheme    = is_string($rawCurrentTheme) ? systemNormalizeThemeName($rawCurrentTheme) : '';
+    $currentTheme    = is_string($rawCurrentTheme) ? systemValidateThemeName($rawCurrentTheme) : '';
     if ('' === $currentTheme) {
         $currentTheme = 'default';
     }
@@ -728,7 +728,7 @@ function systemThemesResolveConfig(array $xoopsConfig): array
     }
     $allowedThemes = array_values(array_filter(
         array_map(
-            static fn($name): string => is_scalar($name) ? systemNormalizeThemeName((string) $name) : '',
+            static fn($name): string => is_scalar($name) ? systemValidateThemeName((string) $name) : '',
             $rawAllowedThemes
         ),
         static fn(string $name): bool => '' !== $name

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -659,10 +659,11 @@ function b_system_info_edit($options)
 /**
  * Validate a theme directory name against the safe character set XOOPS
  * uses for theme directories — letters, digits, underscore, hyphen, dot.
- * Reject names with path separators, null bytes, '..' segments, or a
- * leading dot (hidden files). Names that fail validation return ''.
- * Surviving names are trimmed but otherwise not rewritten, so a valid
- * `my.theme` directory keeps its dot.
+ * Reject names with path separators, null bytes, any `..` sequence
+ * (anywhere in the name, not just as a path segment, so e.g. `my..theme`
+ * is also rejected), or a leading dot (hidden files). Names that fail
+ * validation return ''. Surviving names are trimmed but otherwise not
+ * rewritten, so a valid `my.theme` directory keeps its dot.
  *
  * @internal Used by b_system_themes_show.
  */

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -669,15 +669,27 @@ function b_system_themes_show($options)
     if (!isset($options[2])) {
         $options[2] = 6; // default visible theme rows
     }
+
+    // Defensive: if the xoops_config rows for theme_set / theme_set_allowed
+    // are missing or unreadable, neither this block nor the theme rendering
+    // chain that triggered it should fatal. Fall back to the current theme
+    // (or 'default') as a single-entry allowed list so the block renders
+    // something useful instead of producing a PHP warning + blank output.
+    $currentTheme  = (string) ($xoopsConfig['theme_set'] ?? 'default');
+    $allowedThemes = (array)  ($xoopsConfig['theme_set_allowed'] ?? []);
+    if ([] === $allowedThemes) {
+        $allowedThemes = [$currentTheme];
+    }
+
     $selectSize = ($options[0] == 1) ? 1 : (int) $options[2];
-    $select = new XoopsFormSelect('', 'xoops_theme_select', $xoopsConfig['theme_set'], $selectSize);
-    foreach ($xoopsConfig['theme_set_allowed'] as $theme) {
+    $select = new XoopsFormSelect('', 'xoops_theme_select', $currentTheme, $selectSize);
+    foreach ($allowedThemes as $theme) {
         $select->addOption($theme, $theme);
     }
 
     if ($options[0] == 1) {
         $themeSelect = '<img vspace="2" id="xoops_theme_img" src="'
-            . XOOPS_THEME_URL . '/' . $xoopsConfig['theme_set'] . '/shot.gif" '
+            . XOOPS_THEME_URL . '/' . $currentTheme . '/shot.gif" '
             . ' alt="screenshot" width="' . (int)$options[1] . '" />'
             . '<br>';
         $select->setExtra(' onchange="showImgSelected(\'xoops_theme_img\', \'xoops_theme_select\', \'themes\', \'/shot.gif\', '

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -657,11 +657,6 @@ function b_system_info_edit($options)
 }
 
 /**
- * @param $options
- *
- * @return array
- */
-/**
  * Validate a theme directory name against the safe character set XOOPS
  * uses for theme directories — letters, digits, underscore, hyphen, dot.
  * Reject names with path separators, null bytes, '..' segments, or a
@@ -671,7 +666,7 @@ function b_system_info_edit($options)
  *
  * @internal Used by b_system_themes_show.
  */
-function _b_system_themes_normalize_name(string $name): string
+function systemNormalizeThemeName(string $name): string
 {
     $name = trim($name);
     if (
@@ -692,7 +687,7 @@ function _b_system_themes_normalize_name(string $name): string
 /**
  * Resolve the (current, allowed) theme pair from $xoopsConfig defensively.
  *
- * - Casts and validates each value through _b_system_themes_normalize_name.
+ * - Casts and validates each value through systemNormalizeThemeName.
  * - Treats a string `theme_set_allowed` as pipe-separated (defends against
  *   manual overrides in mainfile.php / xoopsconfig.php).
  * - Skips non-scalar entries (object/array/null/resource) without casting,
@@ -707,10 +702,10 @@ function _b_system_themes_normalize_name(string $name): string
  *
  * @internal Used by b_system_themes_show.
  */
-function _b_system_themes_resolve_config(array $xoopsConfig): array
+function systemThemesResolveConfig(array $xoopsConfig): array
 {
     $rawCurrentTheme = $xoopsConfig['theme_set'] ?? 'default';
-    $currentTheme    = is_string($rawCurrentTheme) ? _b_system_themes_normalize_name($rawCurrentTheme) : '';
+    $currentTheme    = is_string($rawCurrentTheme) ? systemNormalizeThemeName($rawCurrentTheme) : '';
     if ('' === $currentTheme) {
         $currentTheme = 'default';
     }
@@ -732,7 +727,7 @@ function _b_system_themes_resolve_config(array $xoopsConfig): array
     }
     $allowedThemes = array_values(array_filter(
         array_map(
-            static fn($name): string => is_scalar($name) ? _b_system_themes_normalize_name((string) $name) : '',
+            static fn($name): string => is_scalar($name) ? systemNormalizeThemeName((string) $name) : '',
             $rawAllowedThemes
         ),
         static fn(string $name): bool => '' !== $name
@@ -768,7 +763,7 @@ function b_system_themes_show($options)
     // should fatal. The helper returns safe (current, allowed) locals
     // so the rest of this function can render a usable select even
     // when the config is partially corrupted.
-    [$currentTheme, $allowedThemes] = _b_system_themes_resolve_config($xoopsConfig);
+    [$currentTheme, $allowedThemes] = systemThemesResolveConfig($xoopsConfig);
 
     $selectSize = ($options[0] == 1) ? 1 : (int) $options[2];
     $select = new XoopsFormSelect('', 'xoops_theme_select', $currentTheme, $selectSize);

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -657,112 +657,6 @@ function b_system_info_edit($options)
 }
 
 /**
- * Validate a theme directory name for path AND HTML safety.
- *
- * XOOPS theme discovery (XoopsLists::getDirListAsArray) and the theme
- * factory accept arbitrary directory names — including spaces and
- * non-ASCII characters. This validator therefore intentionally does
- * NOT enforce the conservative `[A-Za-z0-9_.-]` alphabet that an
- * earlier revision used (which would have silently dropped legitimate
- * `My Theme` or `テーマ` directories). It enforces two safety classes
- * instead:
- *
- *  - Path safety: reject empty names, leading dot (hidden files),
- *    path separators, null bytes, and `..` appearing as a path
- *    segment.
- *  - HTML safety: reject the five HTML metacharacters (< > & " ').
- *    No legitimate theme directory contains those, and rejecting
- *    them at the boundary lets the option label and screenshot URL
- *    be embedded without per-renderer escaping logic. (XoopsFormSelect
- *    renderers diverge on whether they escape labels: Bootstrap3/4/5
- *    + Legacy render labels raw, while Tailwind escapes them — pre-
- *    escaping in the caller would correctly handle the first four
- *    but cause double-escape under Tailwind.)
- *
- * Names that fail validation return ''. Surviving names are trimmed
- * but otherwise not rewritten — `My Theme` (space) and non-ASCII names
- * keep their original form.
- *
- * @internal Used by b_system_themes_show.
- */
-function systemValidateThemeName(string $name): string
-{
-    $name = trim($name);
-    if (
-        '' === $name
-        || str_starts_with($name, '.')
-        || str_contains($name, '/')
-        || str_contains($name, '\\')
-        || str_contains($name, "\0")
-        || preg_match('~(?:^|[\\\\/])\.\.(?:[\\\\/]|$)~', $name)
-        || preg_match('/[<>"\'&]/', $name)
-    ) {
-        return '';
-    }
-
-    return $name;
-}
-
-/**
- * Resolve the (current, allowed) theme pair from $xoopsConfig defensively.
- *
- * - Casts and validates each value through systemValidateThemeName.
- * - Treats a string `theme_set_allowed` as pipe-separated (defends against
- *   manual overrides in mainfile.php / xoopsconfig.php).
- * - Skips non-scalar entries (object/array/null/resource) without casting,
- *   so a corrupted xoops_config row cannot trigger an Error or a
- *   string-conversion Warning.
- * - Falls back to 'default' if no usable current theme survived.
- * - Falls back to [$currentTheme] if no usable allowed theme survived.
- * - Ensures $currentTheme is in the allowed list (otherwise the rendered
- *   <select> would be selected on a value that is not one of its options).
- *
- * @return array{0: string, 1: list<string>} [$currentTheme, $allowedThemes]
- *
- * @internal Used by b_system_themes_show.
- */
-function systemThemesResolveConfig(array $xoopsConfig): array
-{
-    $rawCurrentTheme = $xoopsConfig['theme_set'] ?? 'default';
-    $currentTheme    = is_string($rawCurrentTheme) ? systemValidateThemeName($rawCurrentTheme) : '';
-    if ('' === $currentTheme) {
-        $currentTheme = 'default';
-    }
-
-    // theme_set_allowed is normally a PHP array (xoops_config 'array'
-    // type decodes via unserialize). Defend against direct overrides
-    // setting it as a pipe-separated string; anything else falls
-    // through to an empty list.
-    $rawAllowedThemes = $xoopsConfig['theme_set_allowed'] ?? [];
-    if (is_string($rawAllowedThemes)) {
-        // Filter on empty-string explicitly — default array_filter()
-        // drops any falsy entry, including a theme literally named "0".
-        $rawAllowedThemes = array_filter(
-            array_map('trim', explode('|', $rawAllowedThemes)),
-            static fn(string $theme): bool => '' !== $theme
-        );
-    } elseif (!is_array($rawAllowedThemes)) {
-        $rawAllowedThemes = [];
-    }
-    $allowedThemes = array_values(array_filter(
-        array_map(
-            static fn($name): string => is_scalar($name) ? systemValidateThemeName((string) $name) : '',
-            $rawAllowedThemes
-        ),
-        static fn(string $name): bool => '' !== $name
-    ));
-    if ([] === $allowedThemes) {
-        $allowedThemes = [$currentTheme];
-    }
-    if (!in_array($currentTheme, $allowedThemes, true)) {
-        array_unshift($allowedThemes, $currentTheme);
-    }
-    $allowedThemes = array_values(array_unique($allowedThemes));
-
-    return [$currentTheme, $allowedThemes];
-}
-
-/**
  * @param $options
  *
  * @return array
@@ -779,10 +673,102 @@ function b_system_themes_show($options)
     // Defensive: if xoops_config rows for theme_set / theme_set_allowed
     // are missing, unreadable, or contain unexpected values, neither
     // this block nor the theme rendering chain that triggered it
-    // should fatal. The helper returns safe (current, allowed) locals
-    // so the rest of this function can render a usable select even
-    // when the config is partially corrupted.
-    [$currentTheme, $allowedThemes] = systemThemesResolveConfig($xoopsConfig);
+    // should fatal. The two helpers below are defined as local closures
+    // so they don't pollute the global namespace (the previous extraction
+    // to top-level system* functions risked collisions in a codebase that
+    // already uses several `system_*` and `system*` helper names) while
+    // still keeping the per-function cognitive complexity low (Sonar
+    // treats closures as separate units, so their bodies don't bubble
+    // back into the parent's complexity score).
+
+    // Validate a theme directory name for path AND HTML safety.
+    //
+    // XOOPS theme discovery (XoopsLists::getDirListAsArray) and the theme
+    // factory accept arbitrary directory names — including spaces and
+    // non-ASCII characters. The validator therefore intentionally does
+    // NOT enforce a conservative `[A-Za-z0-9_.-]` alphabet (which would
+    // silently drop legitimate `My Theme` / `テーマ` directories) and
+    // enforces two safety classes instead:
+    //
+    //  - Path safety: reject empty, leading dot, path separators (/, \),
+    //    null bytes, and `..` appearing as a path segment.
+    //  - HTML safety: reject the five HTML metacharacters (< > & " ').
+    //    No legitimate theme directory contains those, and rejecting
+    //    them at the boundary lets the option label and screenshot URL
+    //    be embedded without per-renderer escaping logic (XoopsFormSelect
+    //    renderers diverge: Bootstrap3/4/5 + Legacy render labels raw,
+    //    Tailwind escapes them — pre-escaping in the caller would
+    //    double-escape under Tailwind).
+    //
+    // Names that fail validation return ''. Surviving names are trimmed
+    // but otherwise not rewritten — `My Theme` and non-ASCII names keep
+    // their original form.
+    $validateThemeName = static function (string $name): string {
+        $name = trim($name);
+        if (
+            '' === $name
+            || str_starts_with($name, '.')
+            || str_contains($name, '/')
+            || str_contains($name, '\\')
+            || str_contains($name, "\0")
+            || preg_match('~(?:^|[\\\\/])\.\.(?:[\\\\/]|$)~', $name)
+            || preg_match('/[<>"\'&]/', $name)
+        ) {
+            return '';
+        }
+
+        return $name;
+    };
+
+    // Resolve the safe (current, allowed) theme pair from $xoopsConfig.
+    //
+    // - Casts and validates each value through $validateThemeName.
+    // - Treats a string theme_set_allowed as pipe-separated (defends
+    //   against direct overrides in mainfile.php / xoopsconfig.php).
+    // - Skips non-scalar entries (object / array / null / resource)
+    //   without casting, so a corrupted xoops_config row cannot trigger
+    //   an Error or string-conversion Warning.
+    // - Falls back to 'default' if no usable current theme survived.
+    // - Falls back to [$currentTheme] if no usable allowed theme survived.
+    // - Ensures $currentTheme is in the allowed list (otherwise the
+    //   rendered <select>'s `selected` value would not match any of
+    //   its <option>s).
+    $resolveConfig = static function (array $xoopsConfig) use ($validateThemeName): array {
+        $rawCurrentTheme = $xoopsConfig['theme_set'] ?? 'default';
+        $currentTheme    = is_string($rawCurrentTheme) ? $validateThemeName($rawCurrentTheme) : '';
+        if ('' === $currentTheme) {
+            $currentTheme = 'default';
+        }
+
+        $rawAllowedThemes = $xoopsConfig['theme_set_allowed'] ?? [];
+        if (is_string($rawAllowedThemes)) {
+            // Filter on empty-string explicitly — default array_filter()
+            // drops any falsy entry, including a theme literally named "0".
+            $rawAllowedThemes = array_filter(
+                array_map('trim', explode('|', $rawAllowedThemes)),
+                static fn(string $theme): bool => '' !== $theme
+            );
+        } elseif (!is_array($rawAllowedThemes)) {
+            $rawAllowedThemes = [];
+        }
+        $allowedThemes = array_values(array_filter(
+            array_map(
+                static fn($name): string => is_scalar($name) ? $validateThemeName((string) $name) : '',
+                $rawAllowedThemes
+            ),
+            static fn(string $name): bool => '' !== $name
+        ));
+        if ([] === $allowedThemes) {
+            $allowedThemes = [$currentTheme];
+        }
+        if (!in_array($currentTheme, $allowedThemes, true)) {
+            array_unshift($allowedThemes, $currentTheme);
+        }
+
+        return [$currentTheme, array_values(array_unique($allowedThemes))];
+    };
+
+    [$currentTheme, $allowedThemes] = $resolveConfig($xoopsConfig);
 
     $selectSize = ($options[0] == 1) ? 1 : (int) $options[2];
     $select = new XoopsFormSelect('', 'xoops_theme_select', $currentTheme, $selectSize);

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -673,12 +673,29 @@ function b_system_themes_show($options)
     // Defensive: if the xoops_config rows for theme_set / theme_set_allowed
     // are missing, unreadable, or contain unexpected values, neither this
     // block nor the theme rendering chain that triggered it should fatal.
-    // Normalise each theme name to the filesystem-safe character set used
-    // for actual theme directories ([A-Za-z0-9_-]); anything else is
-    // treated as corruption and dropped. After normalisation, fall back to
-    // 'default' / [$currentTheme] as needed so the block always renders
-    // something useful instead of producing a PHP warning + blank output.
-    $normalizeTheme = static fn(string $name): string => (string) preg_replace('/[^A-Za-z0-9_-]/', '', $name);
+    // Validate (do NOT rewrite) each theme name against the directory-safe
+    // character set XOOPS theme directories actually use — letters, digits,
+    // underscore, hyphen, and dot — and reject names with path separators,
+    // null bytes, '..' segments, or a leading dot (hidden files). Names
+    // that fail validation are returned as '' and dropped by the
+    // array_filter below; anything that survives is the original name
+    // unmodified, so a valid `my.theme` directory keeps its dot.
+    $normalizeTheme = static function (string $name): string {
+        $name = trim($name);
+        if (
+            '' === $name
+            || str_starts_with($name, '.')
+            || str_contains($name, '/')
+            || str_contains($name, '\\')
+            || str_contains($name, "\0")
+            || str_contains($name, '..')
+            || !preg_match('/^[A-Za-z0-9_.-]+$/', $name)
+        ) {
+            return '';
+        }
+
+        return $name;
+    };
 
     $currentTheme = $normalizeTheme((string) ($xoopsConfig['theme_set'] ?? 'default'));
     if ('' === $currentTheme) {
@@ -721,10 +738,12 @@ function b_system_themes_show($options)
     }
 
     if ($options[0] == 1) {
-        // Belt-and-suspenders: $currentTheme is already normalised to
-        // [A-Za-z0-9_-] above, so rawurlencode() is a no-op for valid
-        // input. The encode + htmlspecialchars stays correct even if
-        // the validator above is ever loosened.
+        // Belt-and-suspenders: $currentTheme has already passed the
+        // validator above (letters, digits, underscore, hyphen, dot —
+        // all in RFC 3986 unreserved set), so rawurlencode() preserves
+        // it as-is and htmlspecialchars() has nothing to escape. The
+        // explicit encode + escape stays correct if the validator is
+        // ever loosened.
         $themeShotUrl = htmlspecialchars(
             XOOPS_THEME_URL . '/' . rawurlencode($currentTheme) . '/shot.gif',
             ENT_QUOTES | ENT_SUBSTITUTE,

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -657,20 +657,31 @@ function b_system_info_edit($options)
 }
 
 /**
- * Validate a theme directory name for *path safety* only.
+ * Validate a theme directory name for path AND HTML safety.
  *
  * XOOPS theme discovery (XoopsLists::getDirListAsArray) and the theme
- * factory accept arbitrary directory names — including spaces, non-ASCII
- * characters, etc. This validator therefore enforces the minimum needed
- * to prevent path traversal: reject empty names, leading dot (hidden
- * files), path separators, null bytes, and `..` appearing as a path
- * segment. Output safety (HTML / URL contexts) is the caller's job —
- * see the option-label escape and rawurlencode/htmlspecialchars on the
- * screenshot URL below.
+ * factory accept arbitrary directory names — including spaces and
+ * non-ASCII characters. This validator therefore intentionally does
+ * NOT enforce the conservative `[A-Za-z0-9_.-]` alphabet that an
+ * earlier revision used (which would have silently dropped legitimate
+ * `My Theme` or `テーマ` directories). It enforces two safety classes
+ * instead:
  *
- * Names that fail validation return ''. Surviving names are trimmed but
- * otherwise not rewritten, so an existing theme directory like
- * `My Theme` (space) or a non-ASCII name keeps its original form.
+ *  - Path safety: reject empty names, leading dot (hidden files),
+ *    path separators, null bytes, and `..` appearing as a path
+ *    segment.
+ *  - HTML safety: reject the five HTML metacharacters (< > & " ').
+ *    No legitimate theme directory contains those, and rejecting
+ *    them at the boundary lets the option label and screenshot URL
+ *    be embedded without per-renderer escaping logic. (XoopsFormSelect
+ *    renderers diverge on whether they escape labels: Bootstrap3/4/5
+ *    + Legacy render labels raw, while Tailwind escapes them — pre-
+ *    escaping in the caller would correctly handle the first four
+ *    but cause double-escape under Tailwind.)
+ *
+ * Names that fail validation return ''. Surviving names are trimmed
+ * but otherwise not rewritten — `My Theme` (space) and non-ASCII names
+ * keep their original form.
  *
  * @internal Used by b_system_themes_show.
  */
@@ -684,6 +695,7 @@ function systemValidateThemeName(string $name): string
         || str_contains($name, '\\')
         || str_contains($name, "\0")
         || preg_match('~(?:^|[\\\\/])\.\.(?:[\\\\/]|$)~', $name)
+        || preg_match('/[<>"\'&]/', $name)
     ) {
         return '';
     }
@@ -775,12 +787,13 @@ function b_system_themes_show($options)
     $selectSize = ($options[0] == 1) ? 1 : (int) $options[2];
     $select = new XoopsFormSelect('', 'xoops_theme_select', $currentTheme, $selectSize);
     foreach ($allowedThemes as $theme) {
-        // XoopsFormSelect escapes option *values* but not option *labels*;
-        // since the validator only enforces path safety, a legitimate
-        // theme directory may still contain HTML-significant characters
-        // (e.g. an `&` in the directory name). Escape the label here so
-        // it's safe in HTML body context.
-        $select->addOption($theme, htmlspecialchars($theme, ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+        // The validator above rejects any theme name containing the five
+        // HTML metacharacters, so $theme is safe to embed as both option
+        // value and label without further per-call escaping. This
+        // sidesteps the divergent renderer behaviour: Bootstrap3/4/5 +
+        // Legacy render labels raw, while Tailwind escapes them — passing
+        // a value that needs no escaping at all works under both.
+        $select->addOption($theme, $theme);
     }
 
     if ($options[0] == 1) {


### PR DESCRIPTION
  Add a graceful-degradation path to the System theme-switch block.

  system/blocks/system_blocks.php (b_system_themes_show):
    Two `xoops_config` rows are required for this block to render —
    `theme_set` (the active theme) and `theme_set_allowed` (the list
    of permitted themes). If either is missing or unreadable —
    e.g. mid-upgrade state, corrupted config row, custom installer
    glitch — the previous code emitted PHP "Undefined index"
    warnings and produced an empty select element, which in turn
    blanked the page wherever the block was placed.

    Capture both values up-front with sensible defaults
    (`'default'` for the active theme, `[]` for the allowed list)
    and, if the allowed list ends up empty, fall back to a
    single-entry list containing the active theme. The block now
    renders a usable single-option select rather than nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validates and normalizes theme names, rejecting empty, hidden, or path-like values and filtering unsafe characters.
  * Accepts allowed-theme settings as arrays or pipe-separated strings, deduplicates and falls back to the current theme if none remain.
  * Ensures the selected theme, its preview image, and the displayed theme count reflect the validated list.
  * Encodes theme names when building preview URLs so spaces and non-ASCII characters display correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->