### PR TITLE
fix(locale): cast $number to float before passing to PHP's number_for…

### DIFF
--- a/htdocs/language/english/locale.php
+++ b/htdocs/language/english/locale.php
@@ -55,14 +55,22 @@ class XoopsLocal extends XoopsLocalAbstract
      *
      * The @param annotation accepts string for backward compatibility with
      * callers that still pass numeric strings, but PHP's number_format()
-     * requires float, so we cast at the boundary.
+     * requires float. Cast at the boundary ONLY when the input is a
+     * numeric string — otherwise pass through unchanged so PHP's
+     * number_format() raises its own TypeError on genuinely invalid
+     * input (arrays, objects, non-numeric strings) instead of silently
+     * coercing them to 0 / 1 and returning a misleading formatted zero.
      *
      * @param  int|float|string $number
      * @return string
      */
     public function number_format($number)
     {
-        return number_format((float) $number, self::CURRENCY['decimals'], self::CURRENCY['decSep'], self::CURRENCY['thouSep']);
+        if (is_string($number) && is_numeric($number)) {
+            $number = (float) $number;
+        }
+
+        return number_format($number, self::CURRENCY['decimals'], self::CURRENCY['decSep'], self::CURRENCY['thouSep']);
     }
 
     /**

--- a/htdocs/language/english/locale.php
+++ b/htdocs/language/english/locale.php
@@ -63,6 +63,8 @@ class XoopsLocal extends XoopsLocalAbstract
      *
      * @param  int|float|string $number
      * @return string
+     *
+     * @throws \TypeError when $number is not int, float, or a numeric string
      */
     public function number_format($number)
     {
@@ -91,7 +93,15 @@ class XoopsLocal extends XoopsLocalAbstract
             if (null === $fmt) {
                 $fmt = new \NumberFormatter($c['locale'], \NumberFormatter::CURRENCY);
             }
-            $result = $fmt->formatCurrency((float) $number, $c['code']);
+            // Match number_format()'s selective-cast behaviour above:
+            // accept numeric strings for BC, pass other types through so
+            // formatCurrency() raises its own TypeError on genuinely
+            // invalid input rather than silently rendering "$0.00". The
+            // intl and fallback paths now agree on what counts as valid.
+            if (is_string($number) && is_numeric($number)) {
+                $number = (float) $number;
+            }
+            $result = $fmt->formatCurrency($number, $c['code']);
             if ($result !== false) {
                 return $result;
             }

--- a/htdocs/language/english/locale.php
+++ b/htdocs/language/english/locale.php
@@ -53,12 +53,16 @@ class XoopsLocal extends XoopsLocalAbstract
     /**
      * Number Formats
      *
+     * The @param annotation accepts string for backward compatibility with
+     * callers that still pass numeric strings, but PHP's number_format()
+     * requires float, so we cast at the boundary.
+     *
      * @param  int|float|string $number
      * @return string
      */
     public function number_format($number)
     {
-        return number_format($number, self::CURRENCY['decimals'], self::CURRENCY['decSep'], self::CURRENCY['thouSep']);
+        return number_format((float) $number, self::CURRENCY['decimals'], self::CURRENCY['decSep'], self::CURRENCY['thouSep']);
     }
 
     /**


### PR DESCRIPTION
…mat()

  language/english/locale.php (XoopsLocal::number_format):
    The function's @param annotation declares int|float|string for
    backward compatibility with callers that pass numeric strings,
    but PHP's built-in number_format() expects float for its first
    argument and Scrutinizer flagged this as a type mismatch. Add
    an explicit (float) cast at the call site so the public API
    stays permissive while the underlying PHP call gets the right
    type. Comment added next to @param documents the boundary cast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved number and currency formatting so numeric-string inputs are handled consistently across formatters.
  * Non-numeric or invalid inputs no longer produce misleading formatted values; they now surface an error instead of silently coercing.
  * Ensures consistent behavior between different formatting paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->