### PR TITLE
fix(profile): handler-based avatar save with rollback; null guards; strip_tags cast

### DIFF
--- a/htdocs/modules/profile/edituser.php
+++ b/htdocs/modules/profile/edituser.php
@@ -193,7 +193,14 @@ if ($op === 'avatarupload') {
                         }
                     }
                     $sql = sprintf('UPDATE %s SET user_avatar = %s WHERE uid = %u', $GLOBALS['xoopsDB']->prefix('users'), $GLOBALS['xoopsDB']->quote('avatars/' . $uploader->getSavedFileName()), $GLOBALS['xoopsUser']->getVar('uid'));
-                    $GLOBALS['xoopsDB']->exec($sql);
+                    if (false === $GLOBALS['xoopsDB']->exec($sql)) {
+                        // Avatar UPDATE failed — abort before
+                        // addUser/redirect, otherwise the user gets a
+                        // "profile updated" confirmation while the
+                        // users.user_avatar column is left stale.
+                        @unlink($uploader->getSavedDestination());
+                        redirect_header('edituser.php?op=avatarform', 3, _PROFILE_MA_ERRORDURINGSAVE);
+                    }
                     $avt_handler->addUser($avatar->getVar('avatar_id'), $GLOBALS['xoopsUser']->getVar('uid'));
                     redirect_header('userinfo.php?t=' . time() . '&amp;uid=' . $GLOBALS['xoopsUser']->getVar('uid'), 3, _US_PROFUPDATED);
                 }

--- a/htdocs/modules/profile/edituser.php
+++ b/htdocs/modules/profile/edituser.php
@@ -184,17 +184,25 @@ if ($op === 'avatarupload') {
                 if (!$avt_handler->insert($avatar)) {
                     @unlink($uploader->getSavedDestination());
                 } else {
-                    // Order matters: write the users.user_avatar column FIRST,
-                    // then clean up the previous custom avatar only after the
-                    // UPDATE has succeeded. The earlier flow deleted the old
-                    // avatar (DB row + file) before the UPDATE, so a failing
-                    // UPDATE would leave the user pointing at a deleted file.
-                    $sql = sprintf('UPDATE %s SET user_avatar = %s WHERE uid = %u', $GLOBALS['xoopsDB']->prefix('users'), $GLOBALS['xoopsDB']->quote('avatars/' . $uploader->getSavedFileName()), $GLOBALS['xoopsUser']->getVar('uid'));
-                    if (false === $GLOBALS['xoopsDB']->exec($sql)) {
-                        // Roll back: drop the just-inserted avatar row and
-                        // remove the uploaded file. The previous custom
-                        // avatar is still intact because we no longer
-                        // delete it before the UPDATE.
+                    // Order matters: persist the user's new avatar via the
+                    // member handler FIRST, then clean up the previous
+                    // custom avatar only after that save has succeeded.
+                    // Mirrors the canonical pattern used by the
+                    // avatarchoose op below (member_handler->insertUser),
+                    // and avoids hand-rolled SQL for the same column write.
+                    $oldavatar = $GLOBALS['xoopsUser']->getVar('user_avatar', 'n');
+                    $newAvatar = 'avatars/' . $uploader->getSavedFileName();
+                    $GLOBALS['xoopsUser']->setVar('user_avatar', $newAvatar);
+
+                    /** @var XoopsMemberHandler $member_handler */
+                    $member_handler = xoops_getHandler('member');
+                    if (!$member_handler->insertUser($GLOBALS['xoopsUser'])) {
+                        // Roll back: drop the just-inserted avatar row,
+                        // restore the prior user_avatar value on the user
+                        // object, and remove the uploaded file. The
+                        // previous custom avatar (DB + file) is untouched
+                        // because cleanup is deferred to the success path.
+                        $GLOBALS['xoopsUser']->setVar('user_avatar', $oldavatar);
                         $avt_handler->delete($avatar);
                         @unlink($uploader->getSavedDestination());
                         redirect_header($avatarFormUrl, 3, _PROFILE_MA_ERRORDURINGSAVE);
@@ -206,9 +214,8 @@ if ($op === 'avatarupload') {
                         exit;
                     }
 
-                    // UPDATE succeeded — safe to clean up the previous
+                    // Save succeeded — safe to clean up the previous
                     // custom avatar (record + file).
-                    $oldavatar = $GLOBALS['xoopsUser']->getVar('user_avatar');
                     if (!empty($oldavatar) && false !== strpos(strtolower($oldavatar), 'cavt')) {
                         $avatars = $avt_handler->getObjects(new Criteria('avatar_file', $oldavatar));
                         if (!empty($avatars) && count($avatars) == 1 && is_object($avatars[0])) {

--- a/htdocs/modules/profile/edituser.php
+++ b/htdocs/modules/profile/edituser.php
@@ -156,7 +156,10 @@ if ($op === 'avatarupload') {
     }
     if ($GLOBALS['xoopsConfigUser']['avatar_allow_upload'] == 1 && $GLOBALS['xoopsUser']->getVar('posts') >= $GLOBALS['xoopsConfigUser']['avatar_minposts']) {
         include_once $GLOBALS['xoops']->path('class/uploader.php');
-        $uploader = new XoopsMediaUploader(XOOPS_UPLOAD_PATH . '/avatars', [
+        // Sonar S1192: this redirect target was duplicated three times
+        // in the avatar-upload flow; capture once.
+        $avatarFormUrl = 'edituser.php?op=avatarform';
+        $uploader      = new XoopsMediaUploader(XOOPS_UPLOAD_PATH . '/avatars', [
             'image/gif',
             'image/jpeg',
             'image/pjpeg',
@@ -165,7 +168,7 @@ if ($op === 'avatarupload') {
         ], $GLOBALS['xoopsConfigUser']['avatar_maxsize'], $GLOBALS['xoopsConfigUser']['avatar_width'], $GLOBALS['xoopsConfigUser']['avatar_height']);
         $uploadField = $xoops_upload_file[0] ?? '';
         if ($uploadField === '') {
-            redirect_header('edituser.php?op=avatarform', 3, _ER_UP_FILENOTFOUND);
+            redirect_header($avatarFormUrl, 3, _ER_UP_FILENOTFOUND);
         }
         if ($uploader->fetchMedia($uploadField)) {
             $uploader->setPrefix('cavt');
@@ -181,6 +184,30 @@ if ($op === 'avatarupload') {
                 if (!$avt_handler->insert($avatar)) {
                     @unlink($uploader->getSavedDestination());
                 } else {
+                    // Order matters: write the users.user_avatar column FIRST,
+                    // then clean up the previous custom avatar only after the
+                    // UPDATE has succeeded. The earlier flow deleted the old
+                    // avatar (DB row + file) before the UPDATE, so a failing
+                    // UPDATE would leave the user pointing at a deleted file.
+                    $sql = sprintf('UPDATE %s SET user_avatar = %s WHERE uid = %u', $GLOBALS['xoopsDB']->prefix('users'), $GLOBALS['xoopsDB']->quote('avatars/' . $uploader->getSavedFileName()), $GLOBALS['xoopsUser']->getVar('uid'));
+                    if (false === $GLOBALS['xoopsDB']->exec($sql)) {
+                        // Roll back: drop the just-inserted avatar row and
+                        // remove the uploaded file. The previous custom
+                        // avatar is still intact because we no longer
+                        // delete it before the UPDATE.
+                        $avt_handler->delete($avatar);
+                        @unlink($uploader->getSavedDestination());
+                        redirect_header($avatarFormUrl, 3, _PROFILE_MA_ERRORDURINGSAVE);
+                        // redirect_header() calls exit() internally, but a
+                        // custom preload could intercept it; the explicit
+                        // exit is defensive belt-and-suspenders so the
+                        // success-path cleanup below cannot run on the
+                        // failure branch.
+                        exit;
+                    }
+
+                    // UPDATE succeeded — safe to clean up the previous
+                    // custom avatar (record + file).
                     $oldavatar = $GLOBALS['xoopsUser']->getVar('user_avatar');
                     if (!empty($oldavatar) && false !== strpos(strtolower($oldavatar), 'cavt')) {
                         $avatars = $avt_handler->getObjects(new Criteria('avatar_file', $oldavatar));
@@ -192,21 +219,13 @@ if ($op === 'avatarupload') {
                             }
                         }
                     }
-                    $sql = sprintf('UPDATE %s SET user_avatar = %s WHERE uid = %u', $GLOBALS['xoopsDB']->prefix('users'), $GLOBALS['xoopsDB']->quote('avatars/' . $uploader->getSavedFileName()), $GLOBALS['xoopsUser']->getVar('uid'));
-                    if (false === $GLOBALS['xoopsDB']->exec($sql)) {
-                        // Avatar UPDATE failed — abort before
-                        // addUser/redirect, otherwise the user gets a
-                        // "profile updated" confirmation while the
-                        // users.user_avatar column is left stale.
-                        @unlink($uploader->getSavedDestination());
-                        redirect_header('edituser.php?op=avatarform', 3, _PROFILE_MA_ERRORDURINGSAVE);
-                    }
+
                     $avt_handler->addUser($avatar->getVar('avatar_id'), $GLOBALS['xoopsUser']->getVar('uid'));
                     redirect_header('userinfo.php?t=' . time() . '&amp;uid=' . $GLOBALS['xoopsUser']->getVar('uid'), 3, _US_PROFUPDATED);
                 }
             }
         }
-        redirect_header('edituser.php?op=avatarform', 3, $uploader->getErrors());
+        redirect_header($avatarFormUrl, 3, $uploader->getErrors());
     }
 }
 

--- a/htdocs/modules/profile/edituser.php
+++ b/htdocs/modules/profile/edituser.php
@@ -193,7 +193,7 @@ if ($op === 'avatarupload') {
                         }
                     }
                     $sql = sprintf('UPDATE %s SET user_avatar = %s WHERE uid = %u', $GLOBALS['xoopsDB']->prefix('users'), $GLOBALS['xoopsDB']->quote('avatars/' . $uploader->getSavedFileName()), $GLOBALS['xoopsUser']->getVar('uid'));
-                    $GLOBALS['xoopsDB']->query($sql);
+                    $GLOBALS['xoopsDB']->exec($sql);
                     $avt_handler->addUser($avatar->getVar('avatar_id'), $GLOBALS['xoopsUser']->getVar('uid'));
                     redirect_header('userinfo.php?t=' . time() . '&amp;uid=' . $GLOBALS['xoopsUser']->getVar('uid'), 3, _US_PROFUPDATED);
                 }

--- a/htdocs/modules/profile/include/forms.php
+++ b/htdocs/modules/profile/include/forms.php
@@ -176,9 +176,10 @@ function profile_getFieldForm(ProfileField $field, $action = false)
                 //   TypeError on PHP 8+. Also reject '' explicitly so the
                 //   branch only runs when there is serialized payload.
                 $rawDefault = $field->getVar('field_default', 'n');
-                $def_value  = (null !== $rawDefault && '' !== $rawDefault)
-                    ? (unserialize($rawDefault, ['allowed_classes' => false]) ?: [])
-                    : null;
+                $def_value  = null;
+                if (null !== $rawDefault && '' !== $rawDefault) {
+                    $def_value = unserialize($rawDefault, ['allowed_classes' => false]) ?: [];
+                }
                 $element   = new XoopsFormSelect(_PROFILE_AM_DEFAULT, 'field_default', $def_value, 8, true);
                 $options   = $field->getVar('field_options');
                 asort($options);
@@ -193,11 +194,14 @@ function profile_getFieldForm(ProfileField $field, $action = false)
 
             case 'select':
             case 'radio':
-                // Same defence as the select_multi branch above: guard via
-                // the RAW ('n') value so a DB NULL doesn't become '' and
-                // then escape the !== null check.
-                $rawDefault = $field->getVar('field_default', 'n');
-                $def_value  = null !== $rawDefault ? $field->getVar('field_default') : null;
+                // Use the RAW ('n') value directly — getVar returns null
+                // for a NULL DB row, the actual string for any other value,
+                // and is the correct format for matching raw option keys
+                // in $field_options. Calling $field->getVar('field_default')
+                // again without a format would return the 's' (HTML-escaped)
+                // form, which would not match raw keys containing '&', '<',
+                // '>', or '"'.
+                $def_value = $field->getVar('field_default', 'n');
                 $element   = new XoopsFormSelect(_PROFILE_AM_DEFAULT, 'field_default', $def_value);
                 $options   = $field->getVar('field_options');
                 asort($options);
@@ -239,7 +243,15 @@ function profile_getFieldForm(ProfileField $field, $action = false)
                 break;
 
             case 'group_multi':
-                $groupDefault = unserialize($field->getVar('field_default', 'n'), ['allowed_classes' => false]) ?: [];
+                // Same null/'' guard as the checkbox/select_multi branch
+                // above — a DB NULL or empty default would otherwise feed
+                // the unserialize call below a real NULL or '', raising
+                // TypeError on PHP 8+.
+                $rawGroupDefault = $field->getVar('field_default', 'n');
+                $groupDefault    = [];
+                if (null !== $rawGroupDefault && '' !== $rawGroupDefault) {
+                    $groupDefault = unserialize($rawGroupDefault, ['allowed_classes' => false]) ?: [];
+                }
                 $form->addElement(new XoopsFormSelectGroup(_PROFILE_AM_DEFAULT, 'field_default', true, $groupDefault, 5, true));
                 break;
 

--- a/htdocs/modules/profile/include/forms.php
+++ b/htdocs/modules/profile/include/forms.php
@@ -169,7 +169,7 @@ function profile_getFieldForm(ProfileField $field, $action = false)
 
             case 'checkbox':
             case 'select_multi':
-                $def_value = $field->getVar('field_default', 'e') != null
+                $def_value = $field->getVar('field_default', 'e') !== null
                     ? (unserialize($field->getVar('field_default', 'n'), ['allowed_classes' => false]) ?: [])
                     : null;
                 $element   = new XoopsFormSelect(_PROFILE_AM_DEFAULT, 'field_default', $def_value, 8, true);
@@ -186,7 +186,7 @@ function profile_getFieldForm(ProfileField $field, $action = false)
 
             case 'select':
             case 'radio':
-                $def_value = $field->getVar('field_default', 'e') != null ? $field->getVar('field_default') : null;
+                $def_value = $field->getVar('field_default', 'e') !== null ? $field->getVar('field_default') : null;
                 $element   = new XoopsFormSelect(_PROFILE_AM_DEFAULT, 'field_default', $def_value);
                 $options   = $field->getVar('field_options');
                 asort($options);

--- a/htdocs/modules/profile/include/forms.php
+++ b/htdocs/modules/profile/include/forms.php
@@ -169,8 +169,15 @@ function profile_getFieldForm(ProfileField $field, $action = false)
 
             case 'checkbox':
             case 'select_multi':
-                $def_value = $field->getVar('field_default', 'e') !== null
-                    ? (unserialize($field->getVar('field_default', 'n'), ['allowed_classes' => false]) ?: [])
+                // Use the RAW ('n') value for the null guard:
+                //   getVar(..., 'e') for a TXTAREA returns '' when the DB
+                //   value is NULL, which would make `!== null` always true
+                //   and feed the unserialize call below a real NULL —
+                //   TypeError on PHP 8+. Also reject '' explicitly so the
+                //   branch only runs when there is serialized payload.
+                $rawDefault = $field->getVar('field_default', 'n');
+                $def_value  = (null !== $rawDefault && '' !== $rawDefault)
+                    ? (unserialize($rawDefault, ['allowed_classes' => false]) ?: [])
                     : null;
                 $element   = new XoopsFormSelect(_PROFILE_AM_DEFAULT, 'field_default', $def_value, 8, true);
                 $options   = $field->getVar('field_options');
@@ -186,7 +193,11 @@ function profile_getFieldForm(ProfileField $field, $action = false)
 
             case 'select':
             case 'radio':
-                $def_value = $field->getVar('field_default', 'e') !== null ? $field->getVar('field_default') : null;
+                // Same defence as the select_multi branch above: guard via
+                // the RAW ('n') value so a DB NULL doesn't become '' and
+                // then escape the !== null check.
+                $rawDefault = $field->getVar('field_default', 'n');
+                $def_value  = null !== $rawDefault ? $field->getVar('field_default') : null;
                 $element   = new XoopsFormSelect(_PROFILE_AM_DEFAULT, 'field_default', $def_value);
                 $options   = $field->getVar('field_options');
                 asort($options);

--- a/htdocs/modules/profile/include/install.php
+++ b/htdocs/modules/profile/include/install.php
@@ -130,8 +130,8 @@ function profile_install_addField($name, $title, $description, $category, $type,
     $obj->setVar('field_show', 1);
     $obj->setVar('field_edit', $canedit ? 1 : 0);
     $obj->setVar('field_config', 0);
-    $obj->setVar('field_title', strip_tags($title), true);
-    $obj->setVar('field_description', strip_tags($description), true);
+    $obj->setVar('field_title', strip_tags((string) $title), true);
+    $obj->setVar('field_description', strip_tags((string) $description), true);
     $obj->setVar('field_type', $type, true);
     $obj->setVar('field_valuetype', $valuetype, true);
     $obj->setVar('field_options', $options, true);


### PR DESCRIPTION
Three bug fixes in the Profile module, evolved through several review rounds.

## profile/edituser.php (avatar upload flow)

Replaced the original `$xoopsDB->query()` UPDATE — which itself was first migrated to `exec()` and ultimately to `$member_handler->insertUser($xoopsUser)` — to match the canonical pattern already used by the `avatarchoose` op in the same file.

Key behaviour change: the order of operations was reorganised so the user-record save happens **before** the previous custom avatar is cleaned up, and a save failure rolls back the just-inserted avatar row + uploaded file while leaving the previous avatar (DB row + file) intact.

- New flow: insert new avatar row → `insertUser` → cleanup old custom avatar (only on success) → `addUser` mapping → success redirect.
- Failure path: restore in-memory `user_avatar` to the prior value, `$avt_handler->delete($avatar)` to drop the new row, `unlink` the uploaded file, redirect with `_PROFILE_MA_ERRORDURINGSAVE`, then explicit `exit;` (defensive — `redirect_header()` exits internally, but the explicit halt protects against any preload that intercepts and prevents the success-path cleanup from running).
- Sonar S1192: extracted the duplicated `'edituser.php?op=avatarform'` redirect target into a single local `$avatarFormUrl`.

## profile/include/forms.php (default-value resolution)

`profile_getFieldForm()` had three branches (`checkbox/select_multi`, `select/radio`, `group_multi`) whose default-value resolution was unsafe in two ways:

- Used `getVar('field_default', 'e')` for the null guard; the `'e'` (escaped) form coerces a NULL DB value to `''`, so `!= null` / `!== null` checks fired wrong and could feed `unserialize()` a real NULL → TypeError on PHP 8+.
- Re-fetched the value via `getVar('field_default')` (no format) for the actual default, defaulting to `'s'` (HTML-escaped); option keys in `field_options` are stored raw, so a default like `A&B` would be passed as `A&amp;B` and never match its own option key.

Both branches now use the raw `'n'` form for the guard and value, with explicit empty-string checks where serialised payloads are involved. The nested `?: []` ternary was extracted into an `if`-block for readability.

## profile/include/install.php (strip_tags input safety)

Wrapped `$title` and `$description` in `(string)` casts before `strip_tags()`. PHP 8.1 deprecates passing null and 8.2 raises TypeError on non-string scalars / objects without `__toString` — the cast is the minimum defence consistent with the function's public contract (which accepts mixed input).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable avatar uploads with proper rollback on failure and consistent redirects.
  * Corrected default value handling in profile edit forms for checkboxes, multi-selects, single-selects, radio buttons, and group_multi.
  * Stronger sanitization of profile field titles and descriptions during installation to prevent malformed defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->