### PR TITLE
chore: add .githooks/ pre-commit + commit-msg sniffs for documented antipatterns

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,11 @@
 *.tpl text eol=lf
 *.sql text eol=lf
 
+# Git hook scripts must stay LF-only — they run under bash on every
+# platform, and a CRLF conversion on Windows would break them on Linux/macOS.
+.githooks/pre-commit text eol=lf
+.githooks/commit-msg text eol=lf
+
 # Export ignores (not included in dist packages)
 /_archive/** export-ignore
 /tests/** export-ignore
@@ -24,6 +29,7 @@
 /docs/** export-ignore
 /.ai/** export-ignore
 /.github/** export-ignore
+/.githooks/** export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .editorconfig export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -17,9 +17,9 @@
 *.sql text eol=lf
 
 # Git hook scripts must stay LF-only — they run under bash on every
-# platform, and a CRLF conversion on Windows would break them on Linux/macOS.
-.githooks/pre-commit text eol=lf
-.githooks/commit-msg text eol=lf
+# platform, and a CRLF conversion on Windows would break them on
+# Linux/macOS. Glob covers any future hook file (pre-push, post-merge, …).
+.githooks/* text eol=lf
 
 # Export ignores (not included in dist packages)
 /_archive/** export-ignore

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,9 +1,9 @@
 # Git hooks for XoopsCore27
 
-Versioned hooks that mechanize the most-violated rules from `CLAUDE.md`.
-Prose rules depend on a human (or LLM) reading and remembering them at the
-right moment; these hooks make the same checks unbypassable without
-explicit `--no-verify`.
+Versioned hooks that mechanize the project's most frequently-violated
+conventions. Prose rules depend on a human (or LLM) reading and
+remembering them at the right moment; these hooks make the same checks
+unbypassable without explicit `--no-verify`.
 
 ## Activate (one-time, per clone)
 
@@ -31,18 +31,23 @@ Sniffs staged PHP and `.tpl` changes for known-bad shapes:
 | 7 | `->queryF(` | Deprecated in 2.7 — bypassed Protector |
 | 8 | `->quoteString(` | Deprecated in 2.7 — use `quote()` |
 | 9 | `// removed` | BC-shim antipattern — delete the code instead |
-| 10 | `JSON_UNESCAPED_SLASHES` | `</script>` breakout risk in HTML — use `JSON_HEX_TAG` |
-| 11 | Standard Smarty `{$var}` in `.tpl` | XOOPS uses `<{$var}>` delimiters |
+| 10 | Standard Smarty `{$var}` in `.tpl` | XOOPS uses `<{$var}>` delimiters |
+
+The diff is scanned with `--diff-filter=ACMR` so edits inside `git mv`
+or `git cp` are also covered.
 
 ### `commit-msg`
 
 Refuses commit messages containing:
 
-- "Claude" / "Claude Code" / "Anthropic"
-- "Generated with [Claude / AI / ...]"
-- `Co-Authored-By:` lines naming an AI assistant
+- An attribution trailer at the start of a line (`Generated with ...`)
+  — vendor-agnostic, so any tool name is rejected
+- `Co-Authored-By:` trailers naming an AI assistant (matches `claude`,
+  `anthropic`, `gpt`, `copilot`, `codex`, `gemini`, `bard`)
 
-This enforces the universal CLAUDE.md privacy rule mechanically.
+The hook deliberately does **not** reject bare in-prose mentions of
+vendor or product names — that would false-fire on legitimate file or
+context references (e.g. a docs commit titled `docs: update CLAUDE.md`).
 
 ## Bypass
 
@@ -52,28 +57,31 @@ Both hooks accept `--no-verify`:
 git commit --no-verify -m "..."
 ```
 
-Only use this when the match is a genuine false positive (e.g., an
-`unserialize($cached, ['allowed_classes' => false])` that the regex
-misidentifies). Document the reason in the commit body.
+Only use this when the match is a genuine false positive. The most
+common real-world case is a multi-line `unserialize()` call where
+`allowed_classes` appears on a different added line than the call
+itself — the line-by-line sniff can't see across lines. Document the
+reason in the commit body.
 
 ## Adding a new sniff
 
 1. Edit `.githooks/pre-commit`.
-2. Each sniff is a `grep -nE` against the staged-added lines, followed by
-   a `report` call with a short label and sample output.
+2. Each sniff is a `grep -E` against the staged-added lines, followed
+   by a `report` call with a short label and sample output.
 3. The diff is filtered to *added* lines only, so legacy code does not
    false-fire — only new occurrences count.
 4. Run a test commit to confirm the new sniff fires on the bad pattern
    and stays silent on the good pattern.
 
-## Why a hook, not more CLAUDE.md prose?
+## Why a hook, not more conventions-doc prose?
 
-CLAUDE.md is read at conversation start and held in context. When code
-generation pattern-matches on a *task concept* ("DB safety guard") the
-relevant rule may be filed under a different category ("PHP precedence
-gotcha") and not fire. Mechanical sniffs run unconditionally on every
-commit, so the failure mode of "I knew the rule but didn't apply it"
-becomes structurally impossible.
+Convention docs are read once at conversation start and held in
+context. When code generation pattern-matches on a *task concept*
+(e.g. "DB safety guard") the relevant rule may be filed under a
+different category (e.g. "PHP precedence gotcha") and not fire.
+Mechanical sniffs run unconditionally on every commit, so the failure
+mode of "I knew the rule but didn't apply it" becomes structurally
+impossible.
 
 When a rule is violated post-hoc and caught by review, the canonical
 response is: **add a sniff here**, not "I will be more careful next

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -24,7 +24,7 @@ Sniffs staged PHP and `.tpl` changes for known-bad shapes:
 |---|---------|-----|
 | 1 | `!$x instanceof Y` (no parens) | PHP precedence: `!` binds tighter than `instanceof`, so the unparenthesized form is always `false` |
 | 2 | `header('HTTP/1.x ...')` | Use `http_response_code(NNN)` for SAPI portability |
-| 3 | `unserialize($x)` (no `allowed_classes`) | Object-injection risk |
+| 3 | `unserialize($x)` without `'allowed_classes' => false` | Object-injection risk; the rule requires `=> false` literally so `=> true` (allows ANY class) and ambiguous variable-options forms don't slip through |
 | 4 | `extract(` | Banned — access keys explicitly |
 | 5 | `eval(` | Banned, no exceptions |
 | 6 | `error_log(` | Use the PSR-3 logger in new code |
@@ -33,8 +33,12 @@ Sniffs staged PHP and `.tpl` changes for known-bad shapes:
 | 9 | `// removed` | BC-shim antipattern — delete the code instead |
 | 10 | Standard Smarty `{$var}` in `.tpl` | XOOPS uses `<{$var}>` delimiters |
 
-The diff is scanned with `--diff-filter=ACMR` so edits inside `git mv`
-or `git cp` are also covered.
+The diff is scanned with `--diff-filter=ACMR` so edits to renamed
+files (`git mv`) and copies that Git's copy-detection finds are also
+covered. Vendored trees (`htdocs/xoops_lib/vendor/**`,
+`htdocs/class/libraries/vendor/**`) and the `tests/**` tree are
+excluded from the scan so dependency updates and test fixtures
+containing pattern literals do not false-fire.
 
 ### `commit-msg`
 

--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,80 @@
+# Git hooks for XoopsCore27
+
+Versioned hooks that mechanize the most-violated rules from `CLAUDE.md`.
+Prose rules depend on a human (or LLM) reading and remembering them at the
+right moment; these hooks make the same checks unbypassable without
+explicit `--no-verify`.
+
+## Activate (one-time, per clone)
+
+```bash
+git config core.hooksPath .githooks
+```
+
+This change is local to your clone — it does not propagate to other
+contributors via push. Re-run after any fresh clone.
+
+## What's enforced
+
+### `pre-commit`
+
+Sniffs staged PHP and `.tpl` changes for known-bad shapes:
+
+| # | Pattern | Why |
+|---|---------|-----|
+| 1 | `!$x instanceof Y` (no parens) | PHP precedence: `!` binds tighter than `instanceof`, so the unparenthesized form is always `false` |
+| 2 | `header('HTTP/1.x ...')` | Use `http_response_code(NNN)` for SAPI portability |
+| 3 | `unserialize($x)` (no `allowed_classes`) | Object-injection risk |
+| 4 | `extract(` | Banned — access keys explicitly |
+| 5 | `eval(` | Banned, no exceptions |
+| 6 | `error_log(` | Use the PSR-3 logger in new code |
+| 7 | `->queryF(` | Deprecated in 2.7 — bypassed Protector |
+| 8 | `->quoteString(` | Deprecated in 2.7 — use `quote()` |
+| 9 | `// removed` | BC-shim antipattern — delete the code instead |
+| 10 | `JSON_UNESCAPED_SLASHES` | `</script>` breakout risk in HTML — use `JSON_HEX_TAG` |
+| 11 | Standard Smarty `{$var}` in `.tpl` | XOOPS uses `<{$var}>` delimiters |
+
+### `commit-msg`
+
+Refuses commit messages containing:
+
+- "Claude" / "Claude Code" / "Anthropic"
+- "Generated with [Claude / AI / ...]"
+- `Co-Authored-By:` lines naming an AI assistant
+
+This enforces the universal CLAUDE.md privacy rule mechanically.
+
+## Bypass
+
+Both hooks accept `--no-verify`:
+
+```bash
+git commit --no-verify -m "..."
+```
+
+Only use this when the match is a genuine false positive (e.g., an
+`unserialize($cached, ['allowed_classes' => false])` that the regex
+misidentifies). Document the reason in the commit body.
+
+## Adding a new sniff
+
+1. Edit `.githooks/pre-commit`.
+2. Each sniff is a `grep -nE` against the staged-added lines, followed by
+   a `report` call with a short label and sample output.
+3. The diff is filtered to *added* lines only, so legacy code does not
+   false-fire — only new occurrences count.
+4. Run a test commit to confirm the new sniff fires on the bad pattern
+   and stays silent on the good pattern.
+
+## Why a hook, not more CLAUDE.md prose?
+
+CLAUDE.md is read at conversation start and held in context. When code
+generation pattern-matches on a *task concept* ("DB safety guard") the
+relevant rule may be filed under a different category ("PHP precedence
+gotcha") and not fire. Mechanical sniffs run unconditionally on every
+commit, so the failure mode of "I knew the rule but didn't apply it"
+becomes structurally impossible.
+
+When a rule is violated post-hoc and caught by review, the canonical
+response is: **add a sniff here**, not "I will be more careful next
+time."

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,16 +1,23 @@
 #!/usr/bin/env bash
 # .githooks/commit-msg — XOOPS commit message hygiene
 #
-# Refuses commits whose message includes:
-#   - Mentions of Claude / Claude Code / Anthropic / "Generated with"
-#   - Co-Authored-By lines for AI assistants
+# Refuses commits whose message contains AI-authorship leak patterns:
+#   - Any "Generated with ..." trailer (vendor-agnostic)
+#   - Co-Authored-By trailers naming common AI assistants
+#
+# The earlier version of this hook also rejected any bare mention of
+# the words "Claude" or "Anthropic" anywhere in the message, which
+# false-fired on legitimate file references like
+#   docs: update CLAUDE.md
+# and forced --no-verify for normal maintenance commits. The current
+# rules target the actual leak shapes (trailers and "generated with"
+# attribution lines) instead.
 #
 # Bypass (only when explicitly intentional):
 #   git commit --no-verify
 #
-# Authorship privacy is a project-wide rule documented in CLAUDE.md
-# (~/.claude/CLAUDE.md "PR and Commit Privacy") and ~/.claude/CLAUDE.md
-# project-level XOOPS git-privacy skill. This hook makes it mechanical.
+# Authorship privacy is documented in the project's conventions doc.
+# This hook makes the trailer-shape part mechanical.
 
 set -u
 
@@ -27,17 +34,16 @@ report() {
 
 content=$(cat "$msg_file")
 
-hits=$(printf '%s\n' "$content" | grep -niE '\bclaude([[:space:]]code)?\b' || true)
-[ -n "$hits" ] && report "commit message mentions Claude — strip per CLAUDE.md privacy rule" "$hits"
+# 1. "Generated with ..." attribution line — vendor-agnostic.
+#    Catches "Generated with Claude Code", "Generated with GitHub
+#    Copilot", "Generated with ChatGPT", etc. Stripping the vendor
+#    name keeps the rule simple and future-proof.
+hits=$(printf '%s\n' "$content" | grep -niE 'generated with' || true)
+[ -n "$hits" ] && report "commit message contains a 'Generated with ...' attribution — strip per privacy convention" "$hits"
 
-hits=$(printf '%s\n' "$content" | grep -niE '\banthropic\b' || true)
-[ -n "$hits" ] && report "commit message mentions Anthropic — strip per CLAUDE.md privacy rule" "$hits"
-
-hits=$(printf '%s\n' "$content" | grep -niE 'generated with[[:space:]]*\[?(claude|ai)' || true)
-[ -n "$hits" ] && report "commit message contains 'Generated with...' tag — remove" "$hits"
-
-hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*(claude|anthropic|gpt|copilot|codex)' || true)
-[ -n "$hits" ] && report "Co-Authored-By line names an AI assistant — remove" "$hits"
+# 2. Co-Authored-By trailer naming an AI assistant.
+hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*(claude|anthropic|gpt|copilot|codex|gemini|bard)' || true)
+[ -n "$hits" ] && report "Co-Authored-By trailer names an AI assistant — remove" "$hits"
 
 if [ "$violations" -gt 0 ]; then
     printf '\n[commit-msg] %d privacy violation(s) in commit message.\n' "$violations" >&2

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -34,12 +34,13 @@ report() {
 
 content=$(cat "$msg_file")
 
-# 1. "Generated with ..." attribution line — vendor-agnostic.
-#    Catches "Generated with Claude Code", "Generated with GitHub
-#    Copilot", "Generated with ChatGPT", etc. Stripping the vendor
-#    name keeps the rule simple and future-proof.
-hits=$(printf '%s\n' "$content" | grep -niE 'generated with' || true)
-[ -n "$hits" ] && report "commit message contains a 'Generated with ...' attribution — strip per privacy convention" "$hits"
+# 1. Attribution trailer line — vendor-agnostic.
+#    Anchored to the start of a line (after optional whitespace) so a
+#    quoted mention inside body prose — e.g. a commit that documents
+#    the rule itself — does not false-fire. Real attribution trailers
+#    are virtually always alone on their own line.
+hits=$(printf '%s\n' "$content" | grep -niE '^[[:space:]]*generated with' || true)
+[ -n "$hits" ] && report "commit message contains an attribution trailer — strip per privacy convention" "$hits"
 
 # 2. Co-Authored-By trailer naming an AI assistant.
 hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*(claude|anthropic|gpt|copilot|codex|gemini|bard)' || true)

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -34,29 +34,35 @@ report() {
 
 content=$(cat "$msg_file")
 
-# 1. Attribution trailer line — vendor-agnostic, capitalised.
-#    Anchored to the start of a line and requires the next token to
-#    start with an uppercase letter (i.e. a proper-noun vendor name)
-#    so the rule fires on real attribution lines like
-#    `Generated with Claude Code` or `Generated with GitHub Copilot`
-#    while leaving lowercase prose like `Generated with care...` and
-#    quoted mentions of the rule name alone.
-#    Note: case-sensitive on purpose here (no -i) — real attribution
-#    trailers from AI tools all use proper capitalisation.
-hits=$(printf '%s\n' "$content" | grep -nE '^Generated with [A-Z]' || true)
+# Extract the trailer block — everything after the LAST blank line.
+# This is the conventional location for `Co-Authored-By:` and
+# attribution trailers; scoping the "Generated with" rule to this
+# block lets a body paragraph or list item that happens to mention
+# the phrase pass without false-firing.
+trailer_block=$(printf '%s\n' "$content" \
+    | awk '/^$/ {n=NR} {lines[NR]=$0} END {for(i=n+1;i<=NR;i++) print lines[i]}')
+
+# 1. Attribution trailer line — vendor-agnostic, scoped to the
+#    trailer block. Real attribution trailers virtually always
+#    appear there (alone on a line, after the body's final blank
+#    line); body prose mentioning the phrase no longer triggers.
+hits=$(printf '%s\n' "$trailer_block" | grep -niE '^[[:space:]]*generated with' || true)
 [ -n "$hits" ] && report "commit message contains an attribution trailer — strip per privacy convention" "$hits"
 
 # 2a. Co-Authored-By trailer with an unambiguous AI vendor / product
-#     name. These tokens have no realistic human-name overlap.
-hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*(\b(anthropic|copilot|codex)\b|chatgpt)' || true)
+#     name. These tokens have no realistic human-name overlap. `gpt`
+#     is included here (word-bounded) — `\bgpt\b` matches the exact
+#     three-letter word, not the substring of `gpts@example.com`.
+hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*(\b(anthropic|copilot|codex|gpt)\b|chatgpt)' || true)
 [ -n "$hits" ] && report "Co-Authored-By trailer names an AI assistant — remove" "$hits"
 
 # 2b. Co-Authored-By trailer with an ambiguous-with-human-names token
-#     (Claude / Bard / Gemini / GPT) followed by an AI qualifier
-#     (Code / Bot / Assistant / AI). Catches `Claude Code`,
-#     `Bard Bot`, `Gemini AI`, `GPT-4 Assistant`, etc., while leaving
-#     legitimate human authors with first names like Claude/Bard alone.
-hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*\b(claude|bard|gemini|gpt[0-9]*)([[:space:]]+|-)(code|bot|ai|assistant)\b' || true)
+#     (Claude / Bard / Gemini) followed by an AI qualifier (Code /
+#     Bot / Assistant / AI). Catches `Claude Code`, `Bard Bot`,
+#     `Gemini AI`, `GPT-4 Assistant`, etc., while leaving legitimate
+#     human authors with first names like Claude/Bard alone.
+#     `gpt(-?[0-9]*)?` covers `GPT-4`, `GPT4`, and bare `GPT`.
+hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*\b(claude|bard|gemini|gpt-?[0-9]*)([[:space:]]+|-)(code|bot|ai|assistant)\b' || true)
 [ -n "$hits" ] && report "Co-Authored-By trailer names an AI assistant — remove" "$hits"
 
 # 2c. Co-Authored-By trailer with a known AI-vendor email domain.

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -42,8 +42,11 @@ content=$(cat "$msg_file")
 hits=$(printf '%s\n' "$content" | grep -niE '^[[:space:]]*generated with' || true)
 [ -n "$hits" ] && report "commit message contains an attribution trailer — strip per privacy convention" "$hits"
 
-# 2. Co-Authored-By trailer naming an AI assistant.
-hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*(claude|anthropic|gpt|copilot|codex|gemini|bard)' || true)
+# 2. Co-Authored-By trailer naming an AI assistant. Each vendor token
+#    is wrapped in word boundaries so a real human name or email like
+#    `Claudia`, `Bardosa`, or `gpts@example.com` doesn't false-fire on
+#    a substring of the vendor list.
+hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*\b(claude|anthropic|gpt|copilot|codex|gemini|bard)\b' || true)
 [ -n "$hits" ] && report "Co-Authored-By trailer names an AI assistant — remove" "$hits"
 
 if [ "$violations" -gt 0 ]; then

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# .githooks/commit-msg — XOOPS commit message hygiene
+#
+# Refuses commits whose message includes:
+#   - Mentions of Claude / Claude Code / Anthropic / "Generated with"
+#   - Co-Authored-By lines for AI assistants
+#
+# Bypass (only when explicitly intentional):
+#   git commit --no-verify
+#
+# Authorship privacy is a project-wide rule documented in CLAUDE.md
+# (~/.claude/CLAUDE.md "PR and Commit Privacy") and ~/.claude/CLAUDE.md
+# project-level XOOPS git-privacy skill. This hook makes it mechanical.
+
+set -u
+
+msg_file="$1"
+[ -z "$msg_file" ] && exit 0
+[ ! -f "$msg_file" ] && exit 0
+
+violations=0
+report() {
+    printf '\n[commit-msg] %s\n' "$1" >&2
+    printf '%s\n' "$2" >&2
+    violations=$((violations + 1))
+}
+
+content=$(cat "$msg_file")
+
+hits=$(printf '%s\n' "$content" | grep -niE '\bclaude([[:space:]]code)?\b' || true)
+[ -n "$hits" ] && report "commit message mentions Claude — strip per CLAUDE.md privacy rule" "$hits"
+
+hits=$(printf '%s\n' "$content" | grep -niE '\banthropic\b' || true)
+[ -n "$hits" ] && report "commit message mentions Anthropic — strip per CLAUDE.md privacy rule" "$hits"
+
+hits=$(printf '%s\n' "$content" | grep -niE 'generated with[[:space:]]*\[?(claude|ai)' || true)
+[ -n "$hits" ] && report "commit message contains 'Generated with...' tag — remove" "$hits"
+
+hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*(claude|anthropic|gpt|copilot|codex)' || true)
+[ -n "$hits" ] && report "Co-Authored-By line names an AI assistant — remove" "$hits"
+
+if [ "$violations" -gt 0 ]; then
+    printf '\n[commit-msg] %d privacy violation(s) in commit message.\n' "$violations" >&2
+    printf '            Fix the message, or bypass with `git commit --no-verify` (only when intentional).\n' >&2
+    exit 1
+fi
+
+exit 0

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -46,12 +46,24 @@ content=$(cat "$msg_file")
 hits=$(printf '%s\n' "$content" | grep -nE '^Generated with [A-Z]' || true)
 [ -n "$hits" ] && report "commit message contains an attribution trailer — strip per privacy convention" "$hits"
 
-# 2. Co-Authored-By trailer naming an AI assistant. Each vendor token
-#    is wrapped in word boundaries so a real human name or email like
-#    `Claudia`, `Bardosa`, or `gpts@example.com` doesn't false-fire on
-#    a substring of the vendor list.
-hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*\b(claude|anthropic|gpt|copilot|codex|gemini|bard)\b' || true)
+# 2a. Co-Authored-By trailer with an unambiguous AI vendor / product
+#     name. These tokens have no realistic human-name overlap.
+hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*(\b(anthropic|copilot|codex)\b|chatgpt)' || true)
 [ -n "$hits" ] && report "Co-Authored-By trailer names an AI assistant — remove" "$hits"
+
+# 2b. Co-Authored-By trailer with an ambiguous-with-human-names token
+#     (Claude / Bard / Gemini / GPT) followed by an AI qualifier
+#     (Code / Bot / Assistant / AI). Catches `Claude Code`,
+#     `Bard Bot`, `Gemini AI`, `GPT-4 Assistant`, etc., while leaving
+#     legitimate human authors with first names like Claude/Bard alone.
+hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*\b(claude|bard|gemini|gpt[0-9]*)([[:space:]]+|-)(code|bot|ai|assistant)\b' || true)
+[ -n "$hits" ] && report "Co-Authored-By trailer names an AI assistant — remove" "$hits"
+
+# 2c. Co-Authored-By trailer with a known AI-vendor email domain.
+#     Catches the "Claude <noreply@anthropic.com>" / "Codex
+#     <noreply@openai.com>" shape regardless of the displayed name.
+hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*@(anthropic|openai)\.(com|ai)\b' || true)
+[ -n "$hits" ] && report "Co-Authored-By trailer uses an AI-vendor email domain — remove" "$hits"
 
 if [ "$violations" -gt 0 ]; then
     printf '\n[commit-msg] %d privacy violation(s) in commit message.\n' "$violations" >&2

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -34,12 +34,16 @@ report() {
 
 content=$(cat "$msg_file")
 
-# 1. Attribution trailer line — vendor-agnostic.
-#    Anchored to the start of a line (after optional whitespace) so a
-#    quoted mention inside body prose — e.g. a commit that documents
-#    the rule itself — does not false-fire. Real attribution trailers
-#    are virtually always alone on their own line.
-hits=$(printf '%s\n' "$content" | grep -niE '^[[:space:]]*generated with' || true)
+# 1. Attribution trailer line — vendor-agnostic, capitalised.
+#    Anchored to the start of a line and requires the next token to
+#    start with an uppercase letter (i.e. a proper-noun vendor name)
+#    so the rule fires on real attribution lines like
+#    `Generated with Claude Code` or `Generated with GitHub Copilot`
+#    while leaving lowercase prose like `Generated with care...` and
+#    quoted mentions of the rule name alone.
+#    Note: case-sensitive on purpose here (no -i) — real attribution
+#    trailers from AI tools all use proper capitalisation.
+hits=$(printf '%s\n' "$content" | grep -nE '^Generated with [A-Z]' || true)
 [ -n "$hits" ] && report "commit message contains an attribution trailer — strip per privacy convention" "$hits"
 
 # 2. Co-Authored-By trailer naming an AI assistant. Each vendor token

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -35,11 +35,12 @@ report() {
 content=$(cat "$msg_file")
 
 # Extract the trailer block — everything after the LAST blank line.
-# This is the conventional location for `Co-Authored-By:` and
-# attribution trailers; scoping the "Generated with" rule to this
-# block lets a body paragraph or list item that happens to mention
-# the phrase pass without false-firing.
-trailer_block=$(printf '%s\n' "$content" \
+# Strip `^#` Git editor comment lines first; without that, when the
+# message is composed via `git commit` (no -m), the trailer block
+# would otherwise be just Git's editor instructions and miss the
+# real trailers above them.
+content_no_comments=$(printf '%s\n' "$content" | grep -v '^#')
+trailer_block=$(printf '%s\n' "$content_no_comments" \
     | awk '/^$/ {n=NR} {lines[NR]=$0} END {for(i=n+1;i<=NR;i++) print lines[i]}')
 
 # 1. Attribution trailer line — vendor-agnostic, scoped to the
@@ -53,7 +54,7 @@ hits=$(printf '%s\n' "$trailer_block" | grep -niE '^[[:space:]]*generated with' 
 #     name. These tokens have no realistic human-name overlap. `gpt`
 #     is included here (word-bounded) — `\bgpt\b` matches the exact
 #     three-letter word, not the substring of `gpts@example.com`.
-hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*(\b(anthropic|copilot|codex|gpt)\b|chatgpt)' || true)
+hits=$(printf '%s\n' "$trailer_block" | grep -niE '^Co-Authored-By:.*(\b(anthropic|copilot|codex|gpt)\b|chatgpt)' || true)
 [ -n "$hits" ] && report "Co-Authored-By trailer names an AI assistant — remove" "$hits"
 
 # 2b. Co-Authored-By trailer with an ambiguous-with-human-names token
@@ -62,13 +63,13 @@ hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*(\b(anthropic|cop
 #     `Gemini AI`, `GPT-4 Assistant`, etc., while leaving legitimate
 #     human authors with first names like Claude/Bard alone.
 #     `gpt(-?[0-9]*)?` covers `GPT-4`, `GPT4`, and bare `GPT`.
-hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*\b(claude|bard|gemini|gpt-?[0-9]*)([[:space:]]+|-)(code|bot|ai|assistant)\b' || true)
+hits=$(printf '%s\n' "$trailer_block" | grep -niE '^Co-Authored-By:.*\b(claude|bard|gemini|gpt-?[0-9]*)([[:space:]]+|-)(code|bot|ai|assistant)\b' || true)
 [ -n "$hits" ] && report "Co-Authored-By trailer names an AI assistant — remove" "$hits"
 
 # 2c. Co-Authored-By trailer with a known AI-vendor email domain.
 #     Catches the "Claude <noreply@anthropic.com>" / "Codex
 #     <noreply@openai.com>" shape regardless of the displayed name.
-hits=$(printf '%s\n' "$content" | grep -niE '^Co-Authored-By:.*@(anthropic|openai)\.(com|ai)\b' || true)
+hits=$(printf '%s\n' "$trailer_block" | grep -niE '^Co-Authored-By:.*@(anthropic|openai)\.(com|ai)\b' || true)
 [ -n "$hits" ] && report "Co-Authored-By trailer uses an AI-vendor email domain — remove" "$hits"
 
 if [ "$violations" -gt 0 ]; then

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -66,8 +66,11 @@ if [ -n "$added" ]; then
     hits=$(printf '%s\n' "$added" | grep -E '![[:space:]]*[^[:space:](]+\([^)]*\)[[:space:]]+instanceof\b' || true)
     [ -n "$hits" ] && report "instanceof after !<call>() needs parens — write !(\$expr() instanceof Class)" "$hits"
 
-    # 2. Raw HTTP status header — prefer http_response_code()
-    hits=$(printf '%s\n' "$added" | grep -E "header\([\"']HTTP/[0-9]\.[0-9]" || true)
+    # 2. Raw HTTP status header — prefer http_response_code().
+    #    Allow whitespace between `(` and the opening quote so
+    #    `header( 'HTTP/1.1 404 Not Found')` (whitespace-formatted) is
+    #    also caught.
+    hits=$(printf '%s\n' "$added" | grep -E "header\([[:space:]]*[\"']HTTP/[0-9]\.[0-9]" || true)
     [ -n "$hits" ] && report "raw HTTP status header — use http_response_code(NNN) instead" "$hits"
 
     # 3. unserialize() must pass `'allowed_classes' => false`.
@@ -85,16 +88,18 @@ if [ -n "$added" ]; then
     hits=$(printf '%s\n' "$stripped" | grep -E '\bunserialize[[:space:]]*\(' | grep -vE "allowed_classes['\"]?[[:space:]]*=>[[:space:]]*false" || true)
     [ -n "$hits" ] && report "unserialize() must pass 'allowed_classes' => false — see PHP anti-patterns in conventions doc" "$hits"
 
-    # 4. extract() — banned in new code
-    hits=$(printf '%s\n' "$added" | grep -E '\bextract[[:space:]]*\(' || true)
+    # 4-6. Banned global functions: extract, eval, error_log.
+    #    The exclude pattern drops method calls (`$obj->extract(`) and
+    #    static calls (`Class::extract(`) — those are legitimate
+    #    user-defined methods that happen to share a name with a
+    #    banned global. Only the global-function form is rejected.
+    hits=$(printf '%s\n' "$added" | grep -E '\bextract[[:space:]]*\(' | grep -vE '(->|::)[[:space:]]*extract' || true)
     [ -n "$hits" ] && report "extract() is banned — access array keys explicitly" "$hits"
 
-    # 5. eval() — banned
-    hits=$(printf '%s\n' "$added" | grep -E '\beval[[:space:]]*\(' || true)
+    hits=$(printf '%s\n' "$added" | grep -E '\beval[[:space:]]*\(' | grep -vE '(->|::)[[:space:]]*eval' || true)
     [ -n "$hits" ] && report "eval() is banned — no exceptions" "$hits"
 
-    # 6. error_log() — use the PSR-3 logger in new code
-    hits=$(printf '%s\n' "$added" | grep -E '\berror_log[[:space:]]*\(' || true)
+    hits=$(printf '%s\n' "$added" | grep -E '\berror_log[[:space:]]*\(' | grep -vE '(->|::)[[:space:]]*error_log' || true)
     [ -n "$hits" ] && report "error_log() — use the PSR-3 logger instead in new code" "$hits"
 
     # 7. queryF() — deprecated in 2.7

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -32,6 +32,7 @@ diff_added() {
         ':(exclude)htdocs/xoops_lib/vendor/**' \
         ':(exclude)htdocs/class/libraries/vendor/**' \
         ':(exclude)tests/**' \
+        ':(exclude)**/tests/**' \
         | grep -E '^\+' \
         | grep -Ev '^\+\+\+ '
 }

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -21,9 +21,10 @@
 set -u
 
 # Pull added lines for a given pathspec. Filters ACMR (added, copied,
-# modified, renamed) so edits inside `git mv` don't bypass the sniffs.
+# modified, renamed) so edits inside `git mv` or `git cp` don't bypass
+# the sniffs.
 diff_added() {
-    git diff --cached --diff-filter=AMR -U0 -- "$@" \
+    git diff --cached --diff-filter=ACMR -U0 -- "$@" \
         | grep -E '^\+' \
         | grep -Ev '^\+\+\+ '
 }
@@ -51,11 +52,11 @@ if [ -n "$added" ]; then
     #    The expression body excludes ; & | ) so a same-line boolean
     #    sequence like `if (!$enabled && $obj instanceof Foo)` does not
     #    falsely look like `!$enabled instanceof Foo`.
-    hits=$(printf '%s\n' "$added" | grep -nE '![[:space:]]*[^[:space:](][^;&|)]*[[:space:]]+instanceof\b' || true)
+    hits=$(printf '%s\n' "$added" | grep -E '![[:space:]]*[^[:space:](][^;&|)]*[[:space:]]+instanceof\b' || true)
     [ -n "$hits" ] && report "instanceof after ! needs parens — write !(\$expr instanceof Class)" "$hits"
 
     # 2. Raw HTTP status header — prefer http_response_code()
-    hits=$(printf '%s\n' "$added" | grep -nE "header\([\"']HTTP/[0-9]\.[0-9]" || true)
+    hits=$(printf '%s\n' "$added" | grep -E "header\([\"']HTTP/[0-9]\.[0-9]" || true)
     [ -n "$hits" ] && report "raw HTTP status header — use http_response_code(NNN) instead" "$hits"
 
     # 3. unserialize() without allowed_classes restriction.
@@ -64,31 +65,31 @@ if [ -n "$added" ]; then
     #    `unserialize(` but not `allowed_classes`. Multi-line calls
     #    where allowed_classes is on a different line will false-fire;
     #    bypass with --no-verify and inline reason in those rare cases.
-    hits=$(printf '%s\n' "$added" | grep -nE '\bunserialize[[:space:]]*\(' | grep -vE 'allowed_classes' || true)
+    hits=$(printf '%s\n' "$added" | grep -E '\bunserialize[[:space:]]*\(' | grep -vE 'allowed_classes' || true)
     [ -n "$hits" ] && report "unserialize() must pass allowed_classes — see PHP anti-patterns in conventions doc" "$hits"
 
     # 4. extract() — banned in new code
-    hits=$(printf '%s\n' "$added" | grep -nE '\bextract[[:space:]]*\(' || true)
+    hits=$(printf '%s\n' "$added" | grep -E '\bextract[[:space:]]*\(' || true)
     [ -n "$hits" ] && report "extract() is banned — access array keys explicitly" "$hits"
 
     # 5. eval() — banned
-    hits=$(printf '%s\n' "$added" | grep -nE '\beval[[:space:]]*\(' || true)
+    hits=$(printf '%s\n' "$added" | grep -E '\beval[[:space:]]*\(' || true)
     [ -n "$hits" ] && report "eval() is banned — no exceptions" "$hits"
 
     # 6. error_log() — use the PSR-3 logger in new code
-    hits=$(printf '%s\n' "$added" | grep -nE '\berror_log[[:space:]]*\(' || true)
+    hits=$(printf '%s\n' "$added" | grep -E '\berror_log[[:space:]]*\(' || true)
     [ -n "$hits" ] && report "error_log() — use the PSR-3 logger instead in new code" "$hits"
 
     # 7. queryF() — deprecated in 2.7
-    hits=$(printf '%s\n' "$added" | grep -nE -- '->queryF[[:space:]]*\(' || true)
+    hits=$(printf '%s\n' "$added" | grep -E -- '->queryF[[:space:]]*\(' || true)
     [ -n "$hits" ] && report "queryF() is deprecated — exec() for writes/DDL, query() for SELECTs" "$hits"
 
     # 8. quoteString() — deprecated in 2.7
-    hits=$(printf '%s\n' "$added" | grep -nE -- '->quoteString[[:space:]]*\(' || true)
+    hits=$(printf '%s\n' "$added" | grep -E -- '->quoteString[[:space:]]*\(' || true)
     [ -n "$hits" ] && report "quoteString() is deprecated — use quote()" "$hits"
 
     # 9. `// removed` marker — BC-shim antipattern
-    hits=$(printf '%s\n' "$added" | grep -nE '//[[:space:]]*removed\b' || true)
+    hits=$(printf '%s\n' "$added" | grep -E '//[[:space:]]*removed\b' || true)
     [ -n "$hits" ] && report "leftover '// removed' marker — delete the code, do not annotate it" "$hits"
 
     # JSON_UNESCAPED_SLASHES sniff (previously rule 10) was removed:
@@ -104,7 +105,7 @@ if [ -n "$tpl_added" ]; then
     # by `<` so the valid `<{$var}>` form is excluded even when it
     # appears on the same line as a violation. The leading `(^|[^<])`
     # also lets the violation match at the very start of the line.
-    hits=$(printf '%s\n' "$tpl_added" | grep -nE '(^|[^<])\{\$[a-zA-Z_]' || true)
+    hits=$(printf '%s\n' "$tpl_added" | grep -E '(^|[^<])\{\$[a-zA-Z_]' || true)
     [ -n "$hits" ] && report "standard Smarty delimiter in .tpl — XOOPS uses <{ }> not { }" "$hits"
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -54,14 +54,17 @@ report() {
 # --- PHP pass -------------------------------------------------------
 if [ -n "$added" ]; then
 
-    # 1. !<expr> instanceof Class — matches $var, $this->prop, $arr[k],
-    #    Class::CONST, etc. The expression body is now a SINGLE token
-    #    (no whitespace, no ;&|()), so multi-token boolean sequences
-    #    like `!$enabled && $obj instanceof Foo` and `!$x and $y
-    #    instanceof Foo` (textual operators) are not mistakenly read
-    #    as `!$enabled instanceof Foo`.
+    # 1. !<expr> instanceof Class — two patterns:
+    #    (a) Plain token: $var, $this->prop, $arr[k], Class::CONST.
+    #        Body excludes whitespace + ;&|() so multi-token boolean
+    #        sequences `!$enabled && $obj instanceof Foo` and the
+    #        textual `!$x and $y instanceof Foo` don't false-fire.
+    #    (b) Method/function call: !$factory->make() instanceof Foo.
+    #        Same precedence bug; the body is `<token>(<args>)`.
     hits=$(printf '%s\n' "$added" | grep -E '![[:space:]]*[^[:space:](][^[:space:];&|)]*[[:space:]]+instanceof\b' || true)
     [ -n "$hits" ] && report "instanceof after ! needs parens — write !(\$expr instanceof Class)" "$hits"
+    hits=$(printf '%s\n' "$added" | grep -E '![[:space:]]*[^[:space:](]+\([^)]*\)[[:space:]]+instanceof\b' || true)
+    [ -n "$hits" ] && report "instanceof after !<call>() needs parens — write !(\$expr() instanceof Class)" "$hits"
 
     # 2. Raw HTTP status header — prefer http_response_code()
     hits=$(printf '%s\n' "$added" | grep -E "header\([\"']HTTP/[0-9]\.[0-9]" || true)
@@ -72,10 +75,14 @@ if [ -n "$added" ]; then
     #    word character. Require the literal `allowed_classes' => false`
     #    or `allowed_classes" => false` on the same line — accepting
     #    just the keyword would let `=> true` through (which allows ALL
-    #    classes — exactly the unsafe shape this rule catches). Multi-
-    #    line calls and rare allowlist usages need --no-verify; document
-    #    the reason in the commit body.
-    hits=$(printf '%s\n' "$added" | grep -E '\bunserialize[[:space:]]*\(' | grep -vE "allowed_classes['\"]?[[:space:]]*=>[[:space:]]*false" || true)
+    #    classes — exactly the unsafe shape this rule catches).
+    #    Strip `//` line-comments before the check so a hint-only
+    #    comment like `// TODO add allowed_classes => false` doesn't
+    #    falsely satisfy the rule for an actually-unsafe call.
+    #    Multi-line calls, block comments, and rare allowlist usages
+    #    need --no-verify; document the reason in the commit body.
+    stripped=$(printf '%s\n' "$added" | sed 's|//.*$||')
+    hits=$(printf '%s\n' "$stripped" | grep -E '\bunserialize[[:space:]]*\(' | grep -vE "allowed_classes['\"]?[[:space:]]*=>[[:space:]]*false" || true)
     [ -n "$hits" ] && report "unserialize() must pass 'allowed_classes' => false — see PHP anti-patterns in conventions doc" "$hits"
 
     # 4. extract() — banned in new code

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# .githooks/pre-commit — XOOPS antipattern sniffs
+#
+# Refuses commits that introduce known-bad shapes documented in CLAUDE.md.
+# Each rule corresponds to a real, post-hoc-caught bug in this repo's history.
+# Prose rules in CLAUDE.md are insufficient — patterns that have been
+# violated more than once must be mechanized here.
+#
+# Bypass (only when justified, document in commit body):
+#   git commit --no-verify
+#
+# Activation (one-time, per-clone):
+#   git config core.hooksPath .githooks
+#
+# Adding a new sniff:
+#   - Each block: extract `hits`, call `report` with a short label + sample lines
+#   - Match against staged ADDED lines only (so legacy code doesn't false-fire)
+#   - Prefer egrep -E syntax for portability across BSD/GNU grep
+
+set -u
+
+# Get added/modified PHP lines (only `+` lines from staged diff, header rows excluded)
+diff_added() {
+    git diff --cached --diff-filter=AM -U0 -- '*.php' \
+        | grep -E '^\+' \
+        | grep -Ev '^\+\+\+ '
+}
+
+added=$(diff_added)
+[ -z "$added" ] && exit 0
+
+violations=0
+report() {
+    printf '\n[pre-commit] %s\n' "$1" >&2
+    printf '%s\n' "$2" | head -10 >&2
+    violations=$((violations + 1))
+}
+
+# 1. !$var instanceof ClassName  (parses wrong: ! binds tighter than instanceof)
+hits=$(printf '%s\n' "$added" | grep -nE '!\$[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]+instanceof\b' || true)
+[ -n "$hits" ] && report "instanceof after ! needs parens — write !(\$var instanceof Class)" "$hits"
+
+# 2. Raw HTTP status header — prefer http_response_code()
+hits=$(printf '%s\n' "$added" | grep -nE "header\([\"']HTTP/[0-9]\.[0-9]" || true)
+[ -n "$hits" ] && report "raw HTTP status header — use http_response_code(NNN) instead" "$hits"
+
+# 3. unserialize() with no allowed_classes restriction
+hits=$(printf '%s\n' "$added" | grep -nE 'unserialize\([^,)]*\)[^,]' || true)
+[ -n "$hits" ] && report "unserialize() must pass allowed_classes — see CLAUDE.md PHP anti-patterns" "$hits"
+
+# 4. extract() — banned in new code (use array keys explicitly)
+hits=$(printf '%s\n' "$added" | grep -nE '\bextract[[:space:]]*\(' || true)
+[ -n "$hits" ] && report "extract() is banned — access array keys explicitly" "$hits"
+
+# 5. eval() — banned, no exceptions
+hits=$(printf '%s\n' "$added" | grep -nE '\beval[[:space:]]*\(' || true)
+[ -n "$hits" ] && report "eval() is banned — no exceptions" "$hits"
+
+# 6. error_log() — use Monolog PSR-3 logger in new code
+hits=$(printf '%s\n' "$added" | grep -nE '\berror_log[[:space:]]*\(' || true)
+[ -n "$hits" ] && report "error_log() — use the PSR-3 logger instead in new code" "$hits"
+
+# 7. queryF() — deprecated in 2.7 (PR #1644: bypassed Protector)
+hits=$(printf '%s\n' "$added" | grep -nE -- '->queryF[[:space:]]*\(' || true)
+[ -n "$hits" ] && report "queryF() is deprecated — exec() for writes/DDL, query() for SELECTs" "$hits"
+
+# 8. quoteString() — deprecated in 2.7
+hits=$(printf '%s\n' "$added" | grep -nE -- '->quoteString[[:space:]]*\(' || true)
+[ -n "$hits" ] && report "quoteString() is deprecated — use quote()" "$hits"
+
+# 9. // removed — BC-shim antipattern (CLAUDE.md universal rule)
+hits=$(printf '%s\n' "$added" | grep -nE '//[[:space:]]*removed\b' || true)
+[ -n "$hits" ] && report "leftover '// removed' marker — delete the code, do not annotate it" "$hits"
+
+# 10. JSON_UNESCAPED_SLASHES inside HTML — </script> breakout risk
+hits=$(printf '%s\n' "$added" | grep -nE 'JSON_UNESCAPED_SLASHES' || true)
+[ -n "$hits" ] && report "JSON_UNESCAPED_SLASHES — use JSON_HEX_TAG inside <script> contexts" "$hits"
+
+# 11. Standard Smarty delimiters in .tpl files (XOOPS uses <{ }>) — see SmartyDelimiterCheck below
+# (handled by the .tpl pass)
+
+# 12. Co-author / authorship leak in non-PHP — handled by commit-msg hook (see .githooks/commit-msg)
+
+# --- Smarty .tpl pass ----------------------------------------------------
+tpl_added=$(git diff --cached --diff-filter=AM -U0 -- '*.tpl' \
+    | grep -E '^\+' \
+    | grep -Ev '^\+\+\+ ')
+
+if [ -n "$tpl_added" ]; then
+    # XOOPS Smarty uses <{ }> delimiters — flag standard {{ }} or single {var} forms
+    hits=$(printf '%s\n' "$tpl_added" | grep -nE '\{\$[a-zA-Z_]' | grep -v '<{\$' || true)
+    [ -n "$hits" ] && report "standard Smarty delimiter in .tpl — XOOPS uses <{ }> not { }" "$hits"
+fi
+# -------------------------------------------------------------------------
+
+if [ "$violations" -gt 0 ]; then
+    printf '\n[pre-commit] %d antipattern(s) found in staged changes.\n' "$violations" >&2
+    printf '            Fix the code, or bypass with `git commit --no-verify` (and document why in the commit body).\n' >&2
+    exit 1
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # .githooks/pre-commit — XOOPS antipattern sniffs
 #
-# Refuses commits that introduce known-bad shapes documented in CLAUDE.md.
-# Each rule corresponds to a real, post-hoc-caught bug in this repo's history.
-# Prose rules in CLAUDE.md are insufficient — patterns that have been
-# violated more than once must be mechanized here.
+# Refuses commits that introduce known-bad shapes documented in the
+# project's conventions doc. Each rule corresponds to a real,
+# post-hoc-caught bug in this repo's history. Prose rules are
+# insufficient — patterns that have been violated more than once
+# must be mechanized here.
 #
 # Bypass (only when justified, document in commit body):
 #   git commit --no-verify
@@ -19,15 +20,21 @@
 
 set -u
 
-# Get added/modified PHP lines (only `+` lines from staged diff, header rows excluded)
+# Pull added lines for a given pathspec. Filters ACMR (added, copied,
+# modified, renamed) so edits inside `git mv` don't bypass the sniffs.
 diff_added() {
-    git diff --cached --diff-filter=AM -U0 -- '*.php' \
+    git diff --cached --diff-filter=AMR -U0 -- "$@" \
         | grep -E '^\+' \
         | grep -Ev '^\+\+\+ '
 }
 
-added=$(diff_added)
-[ -z "$added" ] && exit 0
+added=$(diff_added '*.php')
+tpl_added=$(diff_added '*.tpl')
+
+# Exit fast only when there is nothing for either pass to look at.
+if [ -z "$added" ] && [ -z "$tpl_added" ]; then
+    exit 0
+fi
 
 violations=0
 report() {
@@ -36,62 +43,70 @@ report() {
     violations=$((violations + 1))
 }
 
-# 1. !$var instanceof ClassName  (parses wrong: ! binds tighter than instanceof)
-hits=$(printf '%s\n' "$added" | grep -nE '!\$[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]+instanceof\b' || true)
-[ -n "$hits" ] && report "instanceof after ! needs parens — write !(\$var instanceof Class)" "$hits"
+# --- PHP pass -------------------------------------------------------
+if [ -n "$added" ]; then
 
-# 2. Raw HTTP status header — prefer http_response_code()
-hits=$(printf '%s\n' "$added" | grep -nE "header\([\"']HTTP/[0-9]\.[0-9]" || true)
-[ -n "$hits" ] && report "raw HTTP status header — use http_response_code(NNN) instead" "$hits"
+    # 1. !<expr> instanceof Class — broadened beyond bare $var: matches
+    #    $var, $this->prop, $obj->prop, $arr[k], Class::CONST, etc.
+    #    The expression body excludes ; & | ) so a same-line boolean
+    #    sequence like `if (!$enabled && $obj instanceof Foo)` does not
+    #    falsely look like `!$enabled instanceof Foo`.
+    hits=$(printf '%s\n' "$added" | grep -nE '![[:space:]]*[^[:space:](][^;&|)]*[[:space:]]+instanceof\b' || true)
+    [ -n "$hits" ] && report "instanceof after ! needs parens — write !(\$expr instanceof Class)" "$hits"
 
-# 3. unserialize() with no allowed_classes restriction
-hits=$(printf '%s\n' "$added" | grep -nE 'unserialize\([^,)]*\)[^,]' || true)
-[ -n "$hits" ] && report "unserialize() must pass allowed_classes — see CLAUDE.md PHP anti-patterns" "$hits"
+    # 2. Raw HTTP status header — prefer http_response_code()
+    hits=$(printf '%s\n' "$added" | grep -nE "header\([\"']HTTP/[0-9]\.[0-9]" || true)
+    [ -n "$hits" ] && report "raw HTTP status header — use http_response_code(NNN) instead" "$hits"
 
-# 4. extract() — banned in new code (use array keys explicitly)
-hits=$(printf '%s\n' "$added" | grep -nE '\bextract[[:space:]]*\(' || true)
-[ -n "$hits" ] && report "extract() is banned — access array keys explicitly" "$hits"
+    # 3. unserialize() without allowed_classes restriction.
+    #    \b excludes the magic method __unserialize() because '_' is a
+    #    word character. Reject when the SAME diff line contains
+    #    `unserialize(` but not `allowed_classes`. Multi-line calls
+    #    where allowed_classes is on a different line will false-fire;
+    #    bypass with --no-verify and inline reason in those rare cases.
+    hits=$(printf '%s\n' "$added" | grep -nE '\bunserialize[[:space:]]*\(' | grep -vE 'allowed_classes' || true)
+    [ -n "$hits" ] && report "unserialize() must pass allowed_classes — see PHP anti-patterns in conventions doc" "$hits"
 
-# 5. eval() — banned, no exceptions
-hits=$(printf '%s\n' "$added" | grep -nE '\beval[[:space:]]*\(' || true)
-[ -n "$hits" ] && report "eval() is banned — no exceptions" "$hits"
+    # 4. extract() — banned in new code
+    hits=$(printf '%s\n' "$added" | grep -nE '\bextract[[:space:]]*\(' || true)
+    [ -n "$hits" ] && report "extract() is banned — access array keys explicitly" "$hits"
 
-# 6. error_log() — use Monolog PSR-3 logger in new code
-hits=$(printf '%s\n' "$added" | grep -nE '\berror_log[[:space:]]*\(' || true)
-[ -n "$hits" ] && report "error_log() — use the PSR-3 logger instead in new code" "$hits"
+    # 5. eval() — banned
+    hits=$(printf '%s\n' "$added" | grep -nE '\beval[[:space:]]*\(' || true)
+    [ -n "$hits" ] && report "eval() is banned — no exceptions" "$hits"
 
-# 7. queryF() — deprecated in 2.7 (PR #1644: bypassed Protector)
-hits=$(printf '%s\n' "$added" | grep -nE -- '->queryF[[:space:]]*\(' || true)
-[ -n "$hits" ] && report "queryF() is deprecated — exec() for writes/DDL, query() for SELECTs" "$hits"
+    # 6. error_log() — use the PSR-3 logger in new code
+    hits=$(printf '%s\n' "$added" | grep -nE '\berror_log[[:space:]]*\(' || true)
+    [ -n "$hits" ] && report "error_log() — use the PSR-3 logger instead in new code" "$hits"
 
-# 8. quoteString() — deprecated in 2.7
-hits=$(printf '%s\n' "$added" | grep -nE -- '->quoteString[[:space:]]*\(' || true)
-[ -n "$hits" ] && report "quoteString() is deprecated — use quote()" "$hits"
+    # 7. queryF() — deprecated in 2.7
+    hits=$(printf '%s\n' "$added" | grep -nE -- '->queryF[[:space:]]*\(' || true)
+    [ -n "$hits" ] && report "queryF() is deprecated — exec() for writes/DDL, query() for SELECTs" "$hits"
 
-# 9. // removed — BC-shim antipattern (CLAUDE.md universal rule)
-hits=$(printf '%s\n' "$added" | grep -nE '//[[:space:]]*removed\b' || true)
-[ -n "$hits" ] && report "leftover '// removed' marker — delete the code, do not annotate it" "$hits"
+    # 8. quoteString() — deprecated in 2.7
+    hits=$(printf '%s\n' "$added" | grep -nE -- '->quoteString[[:space:]]*\(' || true)
+    [ -n "$hits" ] && report "quoteString() is deprecated — use quote()" "$hits"
 
-# 10. JSON_UNESCAPED_SLASHES inside HTML — </script> breakout risk
-hits=$(printf '%s\n' "$added" | grep -nE 'JSON_UNESCAPED_SLASHES' || true)
-[ -n "$hits" ] && report "JSON_UNESCAPED_SLASHES — use JSON_HEX_TAG inside <script> contexts" "$hits"
+    # 9. `// removed` marker — BC-shim antipattern
+    hits=$(printf '%s\n' "$added" | grep -nE '//[[:space:]]*removed\b' || true)
+    [ -n "$hits" ] && report "leftover '// removed' marker — delete the code, do not annotate it" "$hits"
 
-# 11. Standard Smarty delimiters in .tpl files (XOOPS uses <{ }>) — see SmartyDelimiterCheck below
-# (handled by the .tpl pass)
+    # JSON_UNESCAPED_SLASHES sniff (previously rule 10) was removed:
+    # the </script> breakout concern only applies inside HTML <script>
+    # contexts, and the repo legitimately uses the flag elsewhere
+    # (logging, plain JSON APIs). False positives outweighed catches.
+fi
 
-# 12. Co-author / authorship leak in non-PHP — handled by commit-msg hook (see .githooks/commit-msg)
-
-# --- Smarty .tpl pass ----------------------------------------------------
-tpl_added=$(git diff --cached --diff-filter=AM -U0 -- '*.tpl' \
-    | grep -E '^\+' \
-    | grep -Ev '^\+\+\+ ')
-
+# --- Smarty .tpl pass -----------------------------------------------
 if [ -n "$tpl_added" ]; then
-    # XOOPS Smarty uses <{ }> delimiters — flag standard {{ }} or single {var} forms
-    hits=$(printf '%s\n' "$tpl_added" | grep -nE '\{\$[a-zA-Z_]' | grep -v '<{\$' || true)
+    # XOOPS Smarty uses <{ }> delimiters — flag standard {$var} forms.
+    # The negative class `[^<]` anchors the match to a `{$` NOT preceded
+    # by `<` so the valid `<{$var}>` form is excluded even when it
+    # appears on the same line as a violation. The leading `(^|[^<])`
+    # also lets the violation match at the very start of the line.
+    hits=$(printf '%s\n' "$tpl_added" | grep -nE '(^|[^<])\{\$[a-zA-Z_]' || true)
     [ -n "$hits" ] && report "standard Smarty delimiter in .tpl — XOOPS uses <{ }> not { }" "$hits"
 fi
-# -------------------------------------------------------------------------
 
 if [ "$violations" -gt 0 ]; then
     printf '\n[pre-commit] %d antipattern(s) found in staged changes.\n' "$violations" >&2

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -21,10 +21,17 @@
 set -u
 
 # Pull added lines for a given pathspec. Filters ACMR (added, copied,
-# modified, renamed) so edits inside `git mv` or `git cp` don't bypass
-# the sniffs.
+# modified, renamed) so edits that show up via Git's rename or copy
+# detection are still scanned. Excluded paths:
+#   - `htdocs/xoops_lib/vendor/**` and `htdocs/class/libraries/vendor/**`
+#     (third-party code; contributors can't rewrite it)
+#   - `tests/**` (test files legitimately contain pattern literals like
+#     `queryF` / `quoteString` to assert that production code does not)
 diff_added() {
     git diff --cached --diff-filter=ACMR -U0 -- "$@" \
+        ':(exclude)htdocs/xoops_lib/vendor/**' \
+        ':(exclude)htdocs/class/libraries/vendor/**' \
+        ':(exclude)tests/**' \
         | grep -E '^\+' \
         | grep -Ev '^\+\+\+ '
 }
@@ -47,26 +54,29 @@ report() {
 # --- PHP pass -------------------------------------------------------
 if [ -n "$added" ]; then
 
-    # 1. !<expr> instanceof Class — broadened beyond bare $var: matches
-    #    $var, $this->prop, $obj->prop, $arr[k], Class::CONST, etc.
-    #    The expression body excludes ; & | ) so a same-line boolean
-    #    sequence like `if (!$enabled && $obj instanceof Foo)` does not
-    #    falsely look like `!$enabled instanceof Foo`.
-    hits=$(printf '%s\n' "$added" | grep -E '![[:space:]]*[^[:space:](][^;&|)]*[[:space:]]+instanceof\b' || true)
+    # 1. !<expr> instanceof Class — matches $var, $this->prop, $arr[k],
+    #    Class::CONST, etc. The expression body is now a SINGLE token
+    #    (no whitespace, no ;&|()), so multi-token boolean sequences
+    #    like `!$enabled && $obj instanceof Foo` and `!$x and $y
+    #    instanceof Foo` (textual operators) are not mistakenly read
+    #    as `!$enabled instanceof Foo`.
+    hits=$(printf '%s\n' "$added" | grep -E '![[:space:]]*[^[:space:](][^[:space:];&|)]*[[:space:]]+instanceof\b' || true)
     [ -n "$hits" ] && report "instanceof after ! needs parens — write !(\$expr instanceof Class)" "$hits"
 
     # 2. Raw HTTP status header — prefer http_response_code()
     hits=$(printf '%s\n' "$added" | grep -E "header\([\"']HTTP/[0-9]\.[0-9]" || true)
     [ -n "$hits" ] && report "raw HTTP status header — use http_response_code(NNN) instead" "$hits"
 
-    # 3. unserialize() without allowed_classes restriction.
+    # 3. unserialize() must pass `'allowed_classes' => false`.
     #    \b excludes the magic method __unserialize() because '_' is a
-    #    word character. Reject when the SAME diff line contains
-    #    `unserialize(` but not `allowed_classes`. Multi-line calls
-    #    where allowed_classes is on a different line will false-fire;
-    #    bypass with --no-verify and inline reason in those rare cases.
-    hits=$(printf '%s\n' "$added" | grep -E '\bunserialize[[:space:]]*\(' | grep -vE 'allowed_classes' || true)
-    [ -n "$hits" ] && report "unserialize() must pass allowed_classes — see PHP anti-patterns in conventions doc" "$hits"
+    #    word character. Require the literal `allowed_classes' => false`
+    #    or `allowed_classes" => false` on the same line — accepting
+    #    just the keyword would let `=> true` through (which allows ALL
+    #    classes — exactly the unsafe shape this rule catches). Multi-
+    #    line calls and rare allowlist usages need --no-verify; document
+    #    the reason in the commit body.
+    hits=$(printf '%s\n' "$added" | grep -E '\bunserialize[[:space:]]*\(' | grep -vE "allowed_classes['\"]?[[:space:]]*=>[[:space:]]*false" || true)
+    [ -n "$hits" ] && report "unserialize() must pass 'allowed_classes' => false — see PHP anti-patterns in conventions doc" "$hits"
 
     # 4. extract() — banned in new code
     hits=$(printf '%s\n' "$added" | grep -E '\bextract[[:space:]]*\(' || true)


### PR DESCRIPTION
Add a versioned git-hooks framework that mechanises the most-frequently-violated conventions. CI / dev tooling only — zero runtime impact.

## `.githooks/pre-commit`

Sniffs staged PHP and `.tpl` additions for **10** known-bad shapes:

1. `!$expr instanceof Class` (no parens — PHP precedence makes it always-`false`)
2. Raw `HTTP/1.x` status headers (use `http_response_code(NNN)`)
3. `unserialize()` without an `allowed_classes` restriction
4. `extract()` (banned)
5. `eval()` (banned, no exceptions)
6. `error_log()` (use the PSR-3 logger in new code)
7. `->queryF(` (deprecated since 2.7)
8. `->quoteString(` (deprecated)
9. `// removed` markers (BC-shim antipattern)
10. Standard Smarty `{$var}` delimiters in `.tpl` (XOOPS uses `<{$var}>`)

Diff filter is `ACMR` so edits inside `git mv` / `git cp` are also covered. Each sniff documents its rationale inline and points at the bug history that motivated it.

## `.githooks/commit-msg`

Refuses commit messages with attribution-trailer leaks:

- A line starting with `Generated with …` (vendor-agnostic) — anchored to trailer position so prose mentions of the rule don't false-fire
- `Co-Authored-By:` trailers naming an AI assistant (`claude`, `anthropic`, `gpt`, `copilot`, `codex`, `gemini`, `bard`) — vendor tokens wrapped in word boundaries so legitimate human names like `Claudia` or `Codexa` don't false-fire

The hook deliberately does **not** reject bare in-prose mentions of vendor names. That would false-fire on legitimate file or context references (e.g. `docs: update CLAUDE.md`).

## `.gitattributes`

- `.githooks/* text eol=lf` — keep hook scripts LF-only on Windows checkouts so they remain runnable on Linux/macOS
- `/.githooks/** export-ignore` — hooks don't ship in distribution archives

## Activation

Per-clone, opt-in:

```bash
git config core.hooksPath .githooks
```

Default behaviour for contributors who don't opt in is unchanged. Bypass policy: `--no-verify` for justified false positives, document the reason in the commit body. The most common real-world false-positive case (covered in `.githooks/README.md`) is a multi-line `unserialize()` where `allowed_classes` appears on a different added line than the call itself.

## Test plan
- [ ] After clone, `git config core.hooksPath .githooks` activates the hooks
- [ ] A diff with `!$x instanceof Y` is rejected; `!($x instanceof Y)` is accepted
- [ ] A commit-message body that mentions the trailer rule in passing is accepted; an actual trailer line is rejected
- [ ] A `Co-Authored-By: Claudia Smith <claudia@example.com>` (real name) is accepted; a `Co-Authored-By: Claude Code <noreply@anthropic.com>` is rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Git hooks to enforce code quality standards during development, including pre-commit validation of PHP and template files, and commit-message checks.
  * Added documentation for enabling and using versioned Git hooks configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->