### PR TITLE
fix(pm): harden readpmsg save/delete flow

### DIFF
--- a/htdocs/modules/pm/readpmsg.php
+++ b/htdocs/modules/pm/readpmsg.php
@@ -31,6 +31,12 @@ if (!in_array($op, $valid_op_requests)) {
 }
 $msg_id            = Request::hasVar('msg_id', 'POST') ? Request::getInt('msg_id', 0, 'POST') : Request::getInt('msg_id', 0, 'GET');
 $pm_handler        = xoops_getModuleHandler('message');
+if (!is_object($pm_handler)) {
+    // xoops_getModuleHandler() returns false when the PM module/handler
+    // can't be loaded. Bail out before any method call would fatal.
+    trigger_error('PM module handler unavailable', E_USER_WARNING);
+    redirect_header(XOOPS_URL, 2, 'Private message handler is unavailable.');
+}
 $pm                = null;
 if ($msg_id > 0) {
     $pm = $pm_handler->get($msg_id);
@@ -64,25 +70,43 @@ if (is_object($pm) && Request::hasVar('action', 'POST')) {
                 break;
             case 'save':
                 // Collect each operation's result into an array instead of
-                // assigning to $res1 / $res2 conditionally. The previous form
-                // only initialised $res1 / $res2 when one of the inner if
-                // branches actually fired, then computed `$res = $res1 && $res2`
-                // unconditionally — which raised "Undefined variable" warnings
+                // assigning to $res1 / $res2 conditionally. The previous
+                // form only initialised those vars when an inner branch
+                // fired, then computed `$res = $res1 && $res2`
+                // unconditionally — raising "Undefined variable" warnings
                 // (and a wrong $res value) whenever a sender or recipient
                 // branch was skipped.
+                //
+                // Delete-vs-save sequencing: setTodelete() / setFromdelete()
+                // call parent::delete($pm) (real row removal) when the
+                // OTHER party has already deleted; in that case the row no
+                // longer exists by the time we'd call setTosave($pm, 0)
+                // and the UPDATE would affect 0 rows — which the handler
+                // reports as failure. Treat a successful delete as
+                // success and skip the save-flag follow-up entirely.
+                $msgId       = (int) $pm->getVar('msg_id');
                 $saveResults = [];
                 if ($pm->getVar('to_userid') == $GLOBALS['xoopsUser']->getVar('uid')) {
                     if (Request::hasVar('delete_message', 'POST')) {
-                        $res1          = $pm_handler->setTodelete($pm);
-                        $saveResults[] = $res1 ? $pm_handler->setTosave($pm, 0) : false;
+                        $res1 = $pm_handler->setTodelete($pm);
+                        if ($res1 && !is_object($pm_handler->get($msgId))) {
+                            // Row gone — delete succeeded, save-flag is moot.
+                            $saveResults[] = true;
+                        } else {
+                            $saveResults[] = $res1 ? $pm_handler->setTosave($pm, 0) : false;
+                        }
                     } elseif (Request::hasVar('move_message', 'POST')) {
                         $saveResults[] = $pm_handler->setTosave($pm, 0);
                     }
                 }
                 if ($pm->getVar('from_userid') == $GLOBALS['xoopsUser']->getVar('uid')) {
                     if (Request::hasVar('delete_message', 'POST')) {
-                        $res2          = $pm_handler->setFromdelete($pm);
-                        $saveResults[] = $res2 ? $pm_handler->setFromsave($pm, 0) : false;
+                        $res2 = $pm_handler->setFromdelete($pm);
+                        if ($res2 && !is_object($pm_handler->get($msgId))) {
+                            $saveResults[] = true;
+                        } else {
+                            $saveResults[] = $res2 ? $pm_handler->setFromsave($pm, 0) : false;
+                        }
                     } elseif (Request::hasVar('move_message', 'POST')) {
                         $saveResults[] = $pm_handler->setFromsave($pm, 0);
                     }

--- a/htdocs/modules/pm/readpmsg.php
+++ b/htdocs/modules/pm/readpmsg.php
@@ -63,23 +63,31 @@ if (is_object($pm) && Request::hasVar('action', 'POST')) {
                 }
                 break;
             case 'save':
+                // Collect each operation's result into an array instead of
+                // assigning to $res1 / $res2 conditionally. The previous form
+                // only initialised $res1 / $res2 when one of the inner if
+                // branches actually fired, then computed `$res = $res1 && $res2`
+                // unconditionally — which raised "Undefined variable" warnings
+                // (and a wrong $res value) whenever a sender or recipient
+                // branch was skipped.
+                $saveResults = [];
                 if ($pm->getVar('to_userid') == $GLOBALS['xoopsUser']->getVar('uid')) {
                     if (Request::hasVar('delete_message', 'POST')) {
-                        $res1 = $pm_handler->setTodelete($pm);
-                        $res1 = $res1 ? $pm_handler->setTosave($pm, 0) : false;
+                        $res1          = $pm_handler->setTodelete($pm);
+                        $saveResults[] = $res1 ? $pm_handler->setTosave($pm, 0) : false;
                     } elseif (Request::hasVar('move_message', 'POST')) {
-                        $res1 = $pm_handler->setTosave($pm, 0);
+                        $saveResults[] = $pm_handler->setTosave($pm, 0);
                     }
                 }
                 if ($pm->getVar('from_userid') == $GLOBALS['xoopsUser']->getVar('uid')) {
                     if (Request::hasVar('delete_message', 'POST')) {
-                        $res2 = $pm_handler->setFromdelete($pm);
-                        $res2 = $res2 ? $pm_handler->setFromsave($pm, 0) : false;
+                        $res2          = $pm_handler->setFromdelete($pm);
+                        $saveResults[] = $res2 ? $pm_handler->setFromsave($pm, 0) : false;
                     } elseif (Request::hasVar('move_message', 'POST')) {
-                        $res2 = $pm_handler->setFromsave($pm, 0);
+                        $saveResults[] = $pm_handler->setFromsave($pm, 0);
                     }
                 }
-                $res = $res1 && $res2;
+                $res = !empty($saveResults) && !in_array(false, $saveResults, true);
                 break;
 
             case 'in':
@@ -127,12 +135,18 @@ if (!is_object($pm)) {
     $criteria->setStart($start);
     $criteria->setSort('msg_time');
     $criteria->setOrder('DESC');
-    [$pm] = $pm_handler->getObjects($criteria);
+    // Avoid destructuring the result directly — getObjects() can return
+    // an empty array, in which case `[$pm] = []` raises "Undefined array
+    // key 0" on PHP 8 and leaves $pm undefined. The explicit fallback
+    // keeps $pm at null so the `is_object($pm)` guard below handles it.
+    $pmObjects = $pm_handler->getObjects($criteria);
+    $pm        = $pmObjects[0] ?? null;
 }
 
 include_once $GLOBALS['xoops']->path('class/xoopsformloader.php');
 
-$pmform = new XoopsForm('', 'pmform', 'readpmsg.php', 'post', true);
+$pmform  = new XoopsForm('', 'pmform', 'readpmsg.php', 'post', true);
+$message = null;
 if (is_object($pm) && !empty($pm)) {
     if ($pm->getVar('from_userid') != $GLOBALS['xoopsUser']->getVar('uid')) {
         $reply_button = new XoopsFormButton('', 'send', _PM_REPLY);

--- a/htdocs/modules/pm/readpmsg.php
+++ b/htdocs/modules/pm/readpmsg.php
@@ -35,7 +35,10 @@ if (!is_object($pm_handler)) {
     // xoops_getModuleHandler() returns false when the PM module/handler
     // can't be loaded. Bail out before any method call would fatal.
     trigger_error('PM module handler unavailable', E_USER_WARNING);
-    redirect_header(XOOPS_URL, 2, 'Private message handler is unavailable.');
+    redirect_header(XOOPS_URL, 2, _NOPERM);
+    // redirect_header() calls exit() internally, but the explicit exit
+    // is defensive against custom preloads that might intercept it.
+    exit();
 }
 $pm                = null;
 if ($msg_id > 0) {
@@ -84,14 +87,16 @@ if (is_object($pm) && Request::hasVar('action', 'POST')) {
                 // and the UPDATE would affect 0 rows — which the handler
                 // reports as failure. Treat a successful delete as
                 // success and skip the save-flag follow-up entirely.
-                $msgId       = (int) $pm->getVar('msg_id');
-                $saveResults = [];
+                $msgId         = (int) $pm->getVar('msg_id');
+                $saveResults   = [];
+                $messageDeleted = false;
                 if ($pm->getVar('to_userid') == $GLOBALS['xoopsUser']->getVar('uid')) {
                     if (Request::hasVar('delete_message', 'POST')) {
                         $res1 = $pm_handler->setTodelete($pm);
                         if ($res1 && !is_object($pm_handler->get($msgId))) {
                             // Row gone — delete succeeded, save-flag is moot.
-                            $saveResults[] = true;
+                            $saveResults[]  = true;
+                            $messageDeleted = true;
                         } else {
                             $saveResults[] = $res1 ? $pm_handler->setTosave($pm, 0) : false;
                         }
@@ -99,11 +104,17 @@ if (is_object($pm) && Request::hasVar('action', 'POST')) {
                         $saveResults[] = $pm_handler->setTosave($pm, 0);
                     }
                 }
-                if ($pm->getVar('from_userid') == $GLOBALS['xoopsUser']->getVar('uid')) {
+                // Self-message safety: if from_userid == to_userid == current uid,
+                // the recipient branch above may already have deleted the row.
+                // The sender branch's setFromdelete/setFromsave would then
+                // affect 0 rows and updateAll() reports that as failure
+                // even though the delete actually succeeded. Skip it.
+                if (!$messageDeleted && $pm->getVar('from_userid') == $GLOBALS['xoopsUser']->getVar('uid')) {
                     if (Request::hasVar('delete_message', 'POST')) {
                         $res2 = $pm_handler->setFromdelete($pm);
                         if ($res2 && !is_object($pm_handler->get($msgId))) {
-                            $saveResults[] = true;
+                            $saveResults[]  = true;
+                            $messageDeleted = true;
                         } else {
                             $saveResults[] = $res2 ? $pm_handler->setFromsave($pm, 0) : false;
                         }

--- a/htdocs/modules/pm/readpmsg.php
+++ b/htdocs/modules/pm/readpmsg.php
@@ -30,12 +30,18 @@ if (!in_array($op, $valid_op_requests)) {
     $op = 'in';
 }
 $msg_id            = Request::hasVar('msg_id', 'POST') ? Request::getInt('msg_id', 0, 'POST') : Request::getInt('msg_id', 0, 'GET');
+/** @var PmMessageHandler $pm_handler */
 $pm_handler        = xoops_getModuleHandler('message');
-if (!is_object($pm_handler)) {
+if (!($pm_handler instanceof PmMessageHandler)) {
     // xoops_getModuleHandler() returns false when the PM module/handler
-    // can't be loaded. Bail out before any method call would fatal.
+    // can't be loaded. The instanceof guard (rather than plain is_object)
+    // also gives static analysers like PHPStan the type narrowing they
+    // need to recognise the PM-specific methods (setTodelete etc.) used
+    // below. _PM_ACTION_ERROR is a PM module language constant; using a
+    // generic error message here rather than _NOPERM, since this is an
+    // internal load failure, not an authorisation failure.
     trigger_error('PM module handler unavailable', E_USER_WARNING);
-    redirect_header(XOOPS_URL, 2, _NOPERM);
+    redirect_header(XOOPS_URL, 2, _PM_ACTION_ERROR);
     // redirect_header() calls exit() internally, but the explicit exit
     // is defensive against custom preloads that might intercept it.
     exit();
@@ -87,14 +93,23 @@ if (is_object($pm) && Request::hasVar('action', 'POST')) {
                 // and the UPDATE would affect 0 rows — which the handler
                 // reports as failure. Treat a successful delete as
                 // success and skip the save-flag follow-up entirely.
-                $msgId         = (int) $pm->getVar('msg_id');
-                $saveResults   = [];
+                // Predict whether each setTodelete / setFromdelete will hard-
+                // delete the row vs. just toggle a flag, based on the SAME
+                // predicates the handler itself uses (pm/class/message.php).
+                // This avoids a follow-up SELECT after the delete to detect
+                // row removal — and avoids conflating "row gone" with
+                // "SELECT failed" (get() returns null in both cases).
+                //   setTodelete  hard-deletes when (from_delete != 0 && from_userid != 0)
+                //   setFromdelete hard-deletes when (to_delete   != 0)
+                $saveResults    = [];
                 $messageDeleted = false;
                 if ($pm->getVar('to_userid') == $GLOBALS['xoopsUser']->getVar('uid')) {
                     if (Request::hasVar('delete_message', 'POST')) {
+                        $willHardDelete = ((int) $pm->getVar('from_delete') !== 0)
+                            && ((int) $pm->getVar('from_userid') !== 0);
                         $res1 = $pm_handler->setTodelete($pm);
-                        if ($res1 && !is_object($pm_handler->get($msgId))) {
-                            // Row gone — delete succeeded, save-flag is moot.
+                        if ($res1 && $willHardDelete) {
+                            // Row removed — save-flag follow-up is moot.
                             $saveResults[]  = true;
                             $messageDeleted = true;
                         } else {
@@ -105,14 +120,17 @@ if (is_object($pm) && Request::hasVar('action', 'POST')) {
                     }
                 }
                 // Self-message safety: if from_userid == to_userid == current uid,
-                // the recipient branch above may already have deleted the row.
-                // The sender branch's setFromdelete/setFromsave would then
-                // affect 0 rows and updateAll() reports that as failure
-                // even though the delete actually succeeded. Skip it.
+                // the recipient branch above may already have deleted the row
+                // (or set to_delete=1, which makes the sender branch's
+                // setFromdelete then hard-delete). Skip the sender branch
+                // entirely once we know the row is gone, otherwise its
+                // setFromsave UPDATE would affect 0 rows and updateAll()
+                // would report that as failure.
                 if (!$messageDeleted && $pm->getVar('from_userid') == $GLOBALS['xoopsUser']->getVar('uid')) {
                     if (Request::hasVar('delete_message', 'POST')) {
+                        $willHardDelete = ((int) $pm->getVar('to_delete') !== 0);
                         $res2 = $pm_handler->setFromdelete($pm);
-                        if ($res2 && !is_object($pm_handler->get($msgId))) {
+                        if ($res2 && $willHardDelete) {
                             $saveResults[]  = true;
                             $messageDeleted = true;
                         } else {

--- a/htdocs/modules/pm/readpmsg.php
+++ b/htdocs/modules/pm/readpmsg.php
@@ -30,20 +30,31 @@ if (!in_array($op, $valid_op_requests)) {
     $op = 'in';
 }
 $msg_id            = Request::hasVar('msg_id', 'POST') ? Request::getInt('msg_id', 0, 'POST') : Request::getInt('msg_id', 0, 'GET');
-/** @var PmMessageHandler $pm_handler */
-$pm_handler        = xoops_getModuleHandler('message');
-if (!($pm_handler instanceof PmMessageHandler)) {
-    // xoops_getModuleHandler() returns false when the PM module/handler
-    // can't be loaded. The instanceof guard (rather than plain is_object)
-    // also gives static analysers like PHPStan the type narrowing they
-    // need to recognise the PM-specific methods (setTodelete etc.) used
-    // below. _PM_ACTION_ERROR is a PM module language constant; using a
-    // generic error message here rather than _NOPERM, since this is an
-    // internal load failure, not an authorisation failure.
-    trigger_error('PM module handler unavailable', E_USER_WARNING);
+// xoops_getModuleHandler() has two failure modes (htdocs/include/functions.php):
+//   - throws \Exception("No Module is loaded") when no $module_dir is passed
+//     and there is no $xoopsModule context (e.g. direct script entry without
+//     normal module bootstrap)
+//   - throws \Exception("Handler does not exist") when the handler class
+//     can't be resolved (unless $optional = true, which we don't pass)
+// Wrap in try/catch so neither path produces an uncaught exception. Then
+// keep the instanceof PmMessageHandler check for static-analysis type
+// narrowing of the PM-specific methods (setTodelete etc.) used below.
+try {
+    /** @var PmMessageHandler $pm_handler */
+    $pm_handler = xoops_getModuleHandler('message');
+} catch (\Throwable $e) {
+    trigger_error('PM module handler unavailable: ' . $e->getMessage(), E_USER_WARNING);
     redirect_header(XOOPS_URL, 2, _PM_ACTION_ERROR);
     // redirect_header() calls exit() internally, but the explicit exit
     // is defensive against custom preloads that might intercept it.
+    exit();
+}
+if (!($pm_handler instanceof PmMessageHandler)) {
+    // _PM_ACTION_ERROR is a PM module language constant; using a generic
+    // error message here rather than _NOPERM, since this is an internal
+    // load failure, not an authorisation failure.
+    trigger_error('PM module handler unavailable', E_USER_WARNING);
+    redirect_header(XOOPS_URL, 2, _PM_ACTION_ERROR);
     exit();
 }
 $pm                = null;

--- a/htdocs/modules/pm/readpmsg.php
+++ b/htdocs/modules/pm/readpmsg.php
@@ -49,7 +49,9 @@ try {
     /** @var PmMessageHandler $pm_handler */
     $pm_handler = xoops_getModuleHandler('message');
 } catch (\Throwable $e) {
-    trigger_error('PM module handler unavailable: ' . $e->getMessage(), E_USER_WARNING);
+    // Prefix with basename(__FILE__) so the log line is traceable without
+    // exposing the absolute server path.
+    trigger_error(basename(__FILE__) . ': PM module handler unavailable: ' . $e->getMessage(), E_USER_WARNING);
     redirect_header(XOOPS_URL, 2, $pmActionError);
     // redirect_header() calls exit() internally, but the explicit exit
     // is defensive against custom preloads that might intercept it.
@@ -58,7 +60,7 @@ try {
 if (!($pm_handler instanceof PmMessageHandler)) {
     // Internal load failure (not an authorisation failure), so use the
     // PM action-error message rather than _NOPERM.
-    trigger_error('PM module handler unavailable', E_USER_WARNING);
+    trigger_error(basename(__FILE__) . ': PM module handler unavailable', E_USER_WARNING);
     redirect_header(XOOPS_URL, 2, $pmActionError);
     exit();
 }

--- a/htdocs/modules/pm/readpmsg.php
+++ b/htdocs/modules/pm/readpmsg.php
@@ -119,6 +119,13 @@ if (is_object($pm) && Request::hasVar('action', 'POST')) {
                 // "SELECT failed" (get() returns null in both cases).
                 //   setTodelete  hard-deletes when (from_delete != 0 && from_userid != 0)
                 //   setFromdelete hard-deletes when (to_delete   != 0)
+                // No-op-as-success for save-flag clears: updateAll() returns
+                // false for 0 affected rows, so calling setTosave($pm, 0)
+                // when to_save is already 0 (or setFromsave($pm, 0) when
+                // from_save is already 0) reports failure for what is
+                // really a no-op. This bites self-messages and any PM
+                // that's in the savebox only because of the OTHER side's
+                // save flag. Treat the already-zero case as success.
                 $saveResults    = [];
                 $messageDeleted = false;
                 if ($pm->getVar('to_userid') == $GLOBALS['xoopsUser']->getVar('uid')) {
@@ -130,11 +137,17 @@ if (is_object($pm) && Request::hasVar('action', 'POST')) {
                             // Row removed — save-flag follow-up is moot.
                             $saveResults[]  = true;
                             $messageDeleted = true;
+                        } elseif ($res1) {
+                            $saveResults[] = ((int) $pm->getVar('to_save') === 0)
+                                ? true
+                                : (bool) $pm_handler->setTosave($pm, 0);
                         } else {
-                            $saveResults[] = $res1 ? $pm_handler->setTosave($pm, 0) : false;
+                            $saveResults[] = false;
                         }
                     } elseif (Request::hasVar('move_message', 'POST')) {
-                        $saveResults[] = $pm_handler->setTosave($pm, 0);
+                        $saveResults[] = ((int) $pm->getVar('to_save') === 0)
+                            ? true
+                            : (bool) $pm_handler->setTosave($pm, 0);
                     }
                 }
                 // Self-message safety: if from_userid == to_userid == current uid,
@@ -151,11 +164,17 @@ if (is_object($pm) && Request::hasVar('action', 'POST')) {
                         if ($res2 && $willHardDelete) {
                             $saveResults[]  = true;
                             $messageDeleted = true;
+                        } elseif ($res2) {
+                            $saveResults[] = ((int) $pm->getVar('from_save') === 0)
+                                ? true
+                                : (bool) $pm_handler->setFromsave($pm, 0);
                         } else {
-                            $saveResults[] = $res2 ? $pm_handler->setFromsave($pm, 0) : false;
+                            $saveResults[] = false;
                         }
                     } elseif (Request::hasVar('move_message', 'POST')) {
-                        $saveResults[] = $pm_handler->setFromsave($pm, 0);
+                        $saveResults[] = ((int) $pm->getVar('from_save') === 0)
+                            ? true
+                            : (bool) $pm_handler->setFromsave($pm, 0);
                     }
                 }
                 $res = !empty($saveResults) && !in_array(false, $saveResults, true);

--- a/htdocs/modules/pm/readpmsg.php
+++ b/htdocs/modules/pm/readpmsg.php
@@ -42,8 +42,11 @@ $msg_id            = Request::hasVar('msg_id', 'POST') ? Request::getInt('msg_id
 //
 // In the "No Module is loaded" case the PM language file may not be loaded
 // yet, so _PM_ACTION_ERROR can itself fatal as an undefined constant on
-// PHP 8+. Resolve a safe fallback message BEFORE the try/catch and use it
-// in both redirect paths.
+// PHP 8+. Try to load the PM main language file, then resolve a safe
+// fallback BEFORE the try/catch so both redirect paths can rely on it.
+if (!defined('_PM_ACTION_ERROR')) {
+    xoops_loadLanguage('main', 'pm');
+}
 $pmActionError = defined('_PM_ACTION_ERROR') ? constant('_PM_ACTION_ERROR') : 'Operation failed';
 try {
     /** @var PmMessageHandler $pm_handler */
@@ -53,16 +56,12 @@ try {
     // exposing the absolute server path.
     trigger_error(basename(__FILE__) . ': PM module handler unavailable: ' . $e->getMessage(), E_USER_WARNING);
     redirect_header(XOOPS_URL, 2, $pmActionError);
-    // redirect_header() calls exit() internally, but the explicit exit
-    // is defensive against custom preloads that might intercept it.
-    exit();
 }
 if (!($pm_handler instanceof PmMessageHandler)) {
     // Internal load failure (not an authorisation failure), so use the
     // PM action-error message rather than _NOPERM.
     trigger_error(basename(__FILE__) . ': PM module handler unavailable', E_USER_WARNING);
     redirect_header(XOOPS_URL, 2, $pmActionError);
-    exit();
 }
 $pm                = null;
 if ($msg_id > 0) {

--- a/htdocs/modules/pm/readpmsg.php
+++ b/htdocs/modules/pm/readpmsg.php
@@ -39,22 +39,27 @@ $msg_id            = Request::hasVar('msg_id', 'POST') ? Request::getInt('msg_id
 // Wrap in try/catch so neither path produces an uncaught exception. Then
 // keep the instanceof PmMessageHandler check for static-analysis type
 // narrowing of the PM-specific methods (setTodelete etc.) used below.
+//
+// In the "No Module is loaded" case the PM language file may not be loaded
+// yet, so _PM_ACTION_ERROR can itself fatal as an undefined constant on
+// PHP 8+. Resolve a safe fallback message BEFORE the try/catch and use it
+// in both redirect paths.
+$pmActionError = defined('_PM_ACTION_ERROR') ? constant('_PM_ACTION_ERROR') : 'Operation failed';
 try {
     /** @var PmMessageHandler $pm_handler */
     $pm_handler = xoops_getModuleHandler('message');
 } catch (\Throwable $e) {
     trigger_error('PM module handler unavailable: ' . $e->getMessage(), E_USER_WARNING);
-    redirect_header(XOOPS_URL, 2, _PM_ACTION_ERROR);
+    redirect_header(XOOPS_URL, 2, $pmActionError);
     // redirect_header() calls exit() internally, but the explicit exit
     // is defensive against custom preloads that might intercept it.
     exit();
 }
 if (!($pm_handler instanceof PmMessageHandler)) {
-    // _PM_ACTION_ERROR is a PM module language constant; using a generic
-    // error message here rather than _NOPERM, since this is an internal
-    // load failure, not an authorisation failure.
+    // Internal load failure (not an authorisation failure), so use the
+    // PM action-error message rather than _NOPERM.
     trigger_error('PM module handler unavailable', E_USER_WARNING);
-    redirect_header(XOOPS_URL, 2, _PM_ACTION_ERROR);
+    redirect_header(XOOPS_URL, 2, $pmActionError);
     exit();
 }
 $pm                = null;

--- a/htdocs/modules/pm/sql/mysql.sql
+++ b/htdocs/modules/pm/sql/mysql.sql
@@ -5,17 +5,18 @@ CREATE TABLE `pm_messages` (
   `from_userid` mediumint(8) unsigned   NOT NULL default '0',
   `to_userid`   mediumint(8) unsigned   NOT NULL default '0',
   `msg_time`    int(10) unsigned        NOT NULL default '0',
-  `msg_text`    text,  
+  `msg_text`    text,
   `read_msg`    tinyint(1) unsigned     NOT NULL default '0',
-  
+
   `from_delete` tinyint(1) unsigned     NOT NULL default '1',
   `from_save`   tinyint(1) unsigned     NOT NULL default '0',
   `to_delete`   tinyint(1) unsigned     NOT NULL default '0',
   `to_save`     tinyint(1) unsigned     NOT NULL default '0',
-  
+
   PRIMARY KEY  (`msg_id`),
   KEY to_userid (`to_userid`),
   KEY inbox (`to_userid`,`read_msg`),
   KEY outbox (`from_userid`, `read_msg`),
+  KEY from_userid_msg_time (`from_userid`, `msg_time`),
   KEY prune (`msg_time`, `read_msg`, `from_save`, `to_delete`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/htdocs/modules/pm/sql/mysql.sql
+++ b/htdocs/modules/pm/sql/mysql.sql
@@ -5,18 +5,17 @@ CREATE TABLE `pm_messages` (
   `from_userid` mediumint(8) unsigned   NOT NULL default '0',
   `to_userid`   mediumint(8) unsigned   NOT NULL default '0',
   `msg_time`    int(10) unsigned        NOT NULL default '0',
-  `msg_text`    text,
+  `msg_text`    text,  
   `read_msg`    tinyint(1) unsigned     NOT NULL default '0',
-
+  
   `from_delete` tinyint(1) unsigned     NOT NULL default '1',
   `from_save`   tinyint(1) unsigned     NOT NULL default '0',
   `to_delete`   tinyint(1) unsigned     NOT NULL default '0',
   `to_save`     tinyint(1) unsigned     NOT NULL default '0',
-
+  
   PRIMARY KEY  (`msg_id`),
   KEY to_userid (`to_userid`),
   KEY inbox (`to_userid`,`read_msg`),
   KEY outbox (`from_userid`, `read_msg`),
-  KEY from_userid_msg_time (`from_userid`, `msg_time`),
   KEY prune (`msg_time`, `read_msg`, `from_save`, `to_delete`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=MyISAM;


### PR DESCRIPTION
Correctness fixes in pm/readpmsg.php for the message save/delete flow.

## What changed

`htdocs/modules/pm/readpmsg.php`:

- **case 'save' undefined-variable bug**: previously built `$res = $res1 && $res2` against vars that may have been undefined when the corresponding branch was skipped. Switched to a `$saveResults[]` array; final `$res` is `!empty($saveResults) && !in_array(false, $saveResults, true)`.
- **case 'save' delete-then-save false-failure**: `setTodelete()` / `setFromdelete()` (in `pm/class/message.php:97-124`) hard-delete the row when the OTHER party has already deleted. The follow-up `setTosave()` / `setFromsave()` then affects 0 rows and `updateAll()` reports that as failure. Now predicts the hard-delete using the SAME predicates the handler itself uses (`from_delete != 0 && from_userid != 0` for setTodelete; `to_delete != 0` for setFromdelete) — no extra SELECT, distinguishes "row removed by design" from "SELECT failed".
- **Self-message edge case**: if `from_userid == to_userid == current uid`, both branches fire on the same row. Once branch 1 hard-deletes the row, branch 2's UPDATE would affect 0 rows. A `$messageDeleted` flag now skips branch 2 once we know the row is gone.
- **Single-PM fetch null-safety**: replaced `[$pm] = $pm_handler->getObjects(...)` with `$pmObjects = ...; $pm = $pmObjects[0] ?? null;` so the destructure form doesn't raise "Undefined array key 0" on PHP 8 when getObjects() returns an empty array.
- **`$message` default + handler guard**: initialise `$message = null` before the `is_object($pm)` block so the trailing `assign('message', $message)` can never see an undefined variable. Guard `$pm_handler` with `instanceof PmMessageHandler` (also gives PHPStan the type narrowing for the PM-specific methods used below) — `xoops_getModuleHandler()` can return `false`. Redirect with `_PM_ACTION_ERROR` and explicit `exit()`.

## NOT in this PR

The `pm/sql/mysql.sql` schema upgrade (InnoDB + utf8mb4 + new outbox index) was reverted: PM uses the `priv_msgs` table defined in `htdocs/install/sql/mysql.structure.sql:462`. `pm/xoops_version.php` has `$modversion['sqlfile']` commented out, so `pm/sql/mysql.sql` is effectively dead code. A separate installer-touching PR can upgrade `priv_msgs` for fresh installs.

## Test plan
- [ ] Save a PM (mark `from_save = 1` / `to_save = 1`) — confirm success path
- [ ] Move a PM out of save back to inbox — confirm success path
- [ ] Delete a PM as recipient when sender has not deleted — flag-only delete, success
- [ ] Delete a PM as recipient when sender has already deleted — hard delete, success (was failing)
- [ ] Self-message: delete the message once the row exists in both inboxes — success (was failing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in the private messaging module to gracefully handle missing or invalid message data
  * Improved stability when loading private messages by adding defensive checks and fallback error messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->