### PR TITLE
fix(mailer): harden constructor for missing mailer config

### DIFF
--- a/htdocs/class/mail/xoopsmultimailer.php
+++ b/htdocs/class/mail/xoopsmultimailer.php
@@ -147,26 +147,67 @@ class XoopsMultiMailer extends PHPMailer
         /** @var XoopsConfigHandler $config_handler */
         $config_handler    = xoops_getHandler('config');
         $xoopsMailerConfig = $config_handler->getConfigsByCat(XOOPS_CONF_MAILER);
-        $this->From        = $xoopsMailerConfig['from'];
-        if ('' == $this->From) {
-            $this->From = $GLOBALS['xoopsConfig']['adminmail'];
+        // Defensive: if XOOPS_CONF_MAILER rows are missing from the DB
+        // (mid-upgrade, fresh install before first save, partial config),
+        // getConfigsByCat() can return [] / null. Normalise to an array
+        // so the (?? '' / ?? []) accesses below are uniform — without
+        // this, a missing config blanks every request that touches mail
+        // (notifications, password reset, contact form).
+        if (!is_array($xoopsMailerConfig)) {
+            $xoopsMailerConfig = [];
+        }
+
+        $this->From = (string) ($xoopsMailerConfig['from'] ?? '');
+        if ('' === $this->From) {
+            $this->From = (string) ($GLOBALS['xoopsConfig']['adminmail'] ?? '');
         }
         $this->Sender = $this->From;
-        if ('smtpauth' === $xoopsMailerConfig['mailmethod']) {
+
+        // ?? alone doesn't catch an empty-string mailmethod (existing key,
+        // blank value), which would set $this->Mailer = '' and PHPMailer
+        // rejects that. Normalise null/missing/empty to 'mail'.
+        $mailMethod = trim((string) ($xoopsMailerConfig['mailmethod'] ?? ''));
+        if ('' === $mailMethod) {
+            $mailMethod = 'mail';
+        }
+        // smtphost has historically been stored as either a flat string,
+        // a comma- or semicolon-separated string, or an array (the
+        // underlying schema inconsistency is still unresolved — see TODO
+        // below). Plain (array) on a separated string yields one bogus
+        // host element, so split string forms first; (array) on the
+        // already-array form is a no-op. trim() removes surrounding
+        // whitespace each segment may carry from manual admin edits.
+        $smtpHosts = $xoopsMailerConfig['smtphost'] ?? [];
+        if (is_string($smtpHosts)) {
+            $smtpHosts = preg_split('/[;,]+/', $smtpHosts, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        }
+        // Cast each element to string before trim — a corrupted stored
+        // array could contain null or non-string elements, and trim(null)
+        // is deprecated in PHP 8.1+.
+        $smtpHosts = array_filter(
+            array_map(static fn ($host) => trim((string) $host), (array) $smtpHosts),
+            'strlen'
+        );
+
+        if ('smtpauth' === $mailMethod) {
             $this->Mailer   = 'smtp';
             $this->SMTPAuth = true;
-            // TODO: change value type of xoopsConfig 'smtphost' from array to text
-            $this->Host     = implode(';', $xoopsMailerConfig['smtphost']);
-            $this->Username = $xoopsMailerConfig['smtpuser'];
-            $this->Password = $xoopsMailerConfig['smtppass'];
+            // TODO: normalise xoopsConfig 'smtphost' storage type
+            //       (currently mixed string/array; see $smtpHosts above).
+            $this->Host     = implode(';', $smtpHosts);
+            $this->Username = (string) ($xoopsMailerConfig['smtpuser'] ?? '');
+            $this->Password = (string) ($xoopsMailerConfig['smtppass'] ?? '');
         } else {
-            $this->Mailer   = $xoopsMailerConfig['mailmethod'];
+            $this->Mailer   = $mailMethod;
             $this->SMTPAuth = false;
-            $this->Sendmail = $xoopsMailerConfig['sendmailpath'];
-            $this->Host     = implode(';', $xoopsMailerConfig['smtphost']);
+            // Preserve the class-default $Sendmail ('/usr/sbin/sendmail') if
+            // the config key is missing — otherwise we'd silently overwrite
+            // it with '' and break sendmail delivery on a partial config.
+            $this->Sendmail = (string) ($xoopsMailerConfig['sendmailpath'] ?? $this->Sendmail);
+            $this->Host     = implode(';', $smtpHosts);
         }
         $this->CharSet = strtolower(_CHARSET);
-        $xoopsLanguage = preg_replace('/[^a-zA-Z0-9_-]/', '', $GLOBALS['xoopsConfig']['language']);
+        $xoopsLanguage = preg_replace('/[^a-zA-Z0-9_-]/', '', (string) ($GLOBALS['xoopsConfig']['language'] ?? 'english'));
         if (file_exists(XOOPS_ROOT_PATH . '/language/' . $xoopsLanguage . '/phpmailer.php')) {
             include XOOPS_ROOT_PATH . '/language/' . $xoopsLanguage . '/phpmailer.php';
             $this->language = $PHPMAILER_LANG;

--- a/htdocs/class/mail/xoopsmultimailer.php
+++ b/htdocs/class/mail/xoopsmultimailer.php
@@ -147,12 +147,14 @@ class XoopsMultiMailer extends PHPMailer
         /** @var XoopsConfigHandler $config_handler */
         $config_handler    = xoops_getHandler('config');
         $xoopsMailerConfig = $config_handler->getConfigsByCat(XOOPS_CONF_MAILER);
-        // Defensive: if XOOPS_CONF_MAILER rows are missing from the DB
-        // (mid-upgrade, fresh install before first save, partial config),
-        // getConfigsByCat() can return [] / null. Normalise to an array
-        // so the (?? '' / ?? []) accesses below are uniform — without
-        // this, a missing config blanks every request that touches mail
-        // (notifications, password reset, contact form).
+        // Core XoopsConfigHandler::getConfigsByCat() returns an array
+        // (possibly empty), but keep this guard defensive for custom
+        // handlers, mocked/test bootstraps, or unexpected states. The
+        // null-coalescing below then covers the case where rows for
+        // individual keys are missing (mid-upgrade, fresh install before
+        // first save, partial config), which would otherwise blank every
+        // mail-touching request (notifications, password reset, contact
+        // form).
         if (!is_array($xoopsMailerConfig)) {
             $xoopsMailerConfig = [];
         }
@@ -171,15 +173,22 @@ class XoopsMultiMailer extends PHPMailer
             $mailMethod = 'mail';
         }
         // smtphost has historically been stored as either a flat string,
-        // a comma- or semicolon-separated string, or an array (the
-        // underlying schema inconsistency is still unresolved — see TODO
-        // below). Plain (array) on a separated string yields one bogus
-        // host element, so split string forms first; (array) on the
-        // already-array form is a no-op. trim() removes surrounding
-        // whitespace each segment may carry from manual admin edits.
+        // a separator-joined string, or an array (the underlying schema
+        // inconsistency is still unresolved — see TODO below). Plain
+        // (array) on a separated string yields one bogus host element,
+        // so split string forms first. The split set covers all three
+        // delimiters seen in the wild:
+        //   - '|' is XOOPS' canonical array-form input delimiter; see
+        //     XoopsConfigItem::setConfValueForInput in
+        //     htdocs/kernel/configitem.php (explode('|', ...) before
+        //     serialize). It can persist in 'text'-valuetype rows or in
+        //     manually-edited config_value strings.
+        //   - ';' / ',' are common admin-typed delimiters when the value
+        //     was stored as text rather than an array.
+        // (array) on the already-array form is a no-op.
         $smtpHosts = $xoopsMailerConfig['smtphost'] ?? [];
         if (is_string($smtpHosts)) {
-            $smtpHosts = preg_split('/[;,]+/', $smtpHosts, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+            $smtpHosts = preg_split('/[|;,]+/', $smtpHosts, -1, PREG_SPLIT_NO_EMPTY) ?: [];
         }
         // Cast each element to string before trim — a corrupted stored
         // array could contain null or non-string elements, and trim(null)
@@ -200,10 +209,17 @@ class XoopsMultiMailer extends PHPMailer
         } else {
             $this->Mailer   = $mailMethod;
             $this->SMTPAuth = false;
-            // Preserve the class-default $Sendmail ('/usr/sbin/sendmail') if
-            // the config key is missing — otherwise we'd silently overwrite
-            // it with '' and break sendmail delivery on a partial config.
-            $this->Sendmail = (string) ($xoopsMailerConfig['sendmailpath'] ?? $this->Sendmail);
+            // Preserve the class-default $Sendmail ('/usr/sbin/sendmail')
+            // when the config value is missing OR an empty/whitespace
+            // string. ?? alone only catches null/missing — the existing-
+            // but-blank case (admin cleared the field, or a partial save
+            // left an empty string) would still overwrite with '' and
+            // break sendmail delivery. Same shape as the mailmethod
+            // normalisation above.
+            $sendmailPath = trim((string) ($xoopsMailerConfig['sendmailpath'] ?? ''));
+            if ('' !== $sendmailPath) {
+                $this->Sendmail = $sendmailPath;
+            }
             $this->Host     = implode(';', $smtpHosts);
         }
         $this->CharSet = strtolower(_CHARSET);


### PR DESCRIPTION
  ## Summary

  `XoopsMultiMailer::__construct()` previously dereferenced six keys from `getConfigsByCat(XOOPS_CONF_MAILER)` and one from `$GLOBALS['xoopsConfig']`
  without null guards. A partial mailer config (mid-upgrade, fresh install before first save, DB corruption) blanks **every** request that touches mail —
  notifications, password reset, contact form, etc.

  This PR adds defensive null-coalescing across all six config keys plus the language fallback, with four corner cases protected:

  - **mailmethod**: `??` alone doesn't catch an existing-but-blank value; we normalise via `trim()` + explicit `''` check so a blank value falls back to `'mail'` instead of setting `$this->Mailer = ''` (which PHPMailer rejects).
  - **sendmailpath**: falls back to the class-level default `$this->Sendmail = '/usr/sbin/sendmail'` rather than `''`, so a missing config key doesn't silently break sendmail delivery.
  - **smtphost**: split string forms on `[;,]+` first, then per-element `(string)` cast before `trim()` (`trim(null)` is deprecated in PHP 8.1+), then `array_filter` on `strlen`. Plain `(array)` on a comma-separated string yielded one bogus host element; this handles flat string, comma- or semicolon-separated string, and array forms even when the stored array contains null or scalar non-string elements (ints, bools).
  - **language**: `(string) (... ?? 'english')` before `preg_replace()` so the input is never null.

  No behaviour change when the config is fully populated.

  ## Test plan

  - [ ] Verify mail still sends on fully-configured site (notifications, password reset).
  - [ ] Verify the constructor no longer fatals when `XOOPS_CONF_MAILER` rows are absent.
  - [ ] Verify `mailmethod=''` (existing key, blank value) falls back to `'mail'`.
  - [ ] Verify `mailmethod=sendmail` with no `sendmailpath` falls back to the class default `/usr/sbin/sendmail`.
  - [ ] Verify `smtphost` accepts string (single, comma- or semicolon-separated) and array forms, and tolerates null/scalar non-string elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email configuration normalization to ensure settings are consistently interpreted and applied across all delivery methods.
  * Enhanced SMTP and Sendmail handling so host, authentication, sender, and envelope-from are resolved more reliably for varied configurations.
  * Strengthened message formatting and error mapping to align with standards, improving delivery reliability and clearer failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->