### PR TITLE
strip leading space before <?php in language index files

### DIFF
--- a/upgrade/language/english/index.php
+++ b/upgrade/language/english/index.php
@@ -1,2 +1,2 @@
- <?php
+<?php
 header('HTTP/1.0 404 Not Found');

--- a/upgrade/language/index.php
+++ b/upgrade/language/index.php
@@ -1,2 +1,2 @@
- <?php
+<?php
 header('HTTP/1.0 404 Not Found');


### PR DESCRIPTION
  upgrade/language/index.php and upgrade/language/english/index.php
  each began with a literal space (0x20) before the <?php opening tag.
  Two consequences:

    - That space is sent to the client as raw output before any PHP runs. The header('HTTP/1.0 404 Not Found') call on line 2 then runs after output has started, so the header is silently lost and the directory listing leaks instead of returning a 404.
    - Bots / scrapers indexing the upgrade/language/ tree see the space + a successful 200 response, defeating the access guard these files were placed there to provide.

  Fix is byte-level: remove the leading 0x20 so each file begins
  with the literal '<?php' at byte 0.

  Scope verified: a sweep of all 24 upgrade/**/index.php files
  confirmed only these two had a non-'<' first byte; the other 22
  were already correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PHP file structure in upgrade language modules to ensure proper initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->