### PR TITLE
helper-based atomic-write cleanup; replace @unlink/@chmod

### DIFF
--- a/htdocs/include/cp_functions.php
+++ b/htdocs/include/cp_functions.php
@@ -121,6 +121,39 @@ function xoops_file_label($filename)
 }
 
 /**
+ * Best-effort file removal used by atomic-write cleanup paths and similar
+ * fire-and-forget cleanup. Skips non-existent paths so already-deleted
+ * files don't trigger warnings, suppresses the unlink() warning via a
+ * scoped error_reporting() toggle (no `@` operator), and re-checks
+ * existence after a failed unlink — only logging when the file is still
+ * present, so TOCTOU races resolve silently.
+ *
+ * @param string $path    Absolute path to the file to remove.
+ * @param string $context Short label used in the warning message
+ *                        (e.g. 'temporary', 'backup').
+ *
+ * @return void
+ */
+function xoops_remove_file_quietly($path, $context = 'temporary')
+{
+    if (!file_exists($path)) {
+        return;
+    }
+    $previousLevel = error_reporting(0);
+    try {
+        $ok = unlink($path);
+    } finally {
+        error_reporting($previousLevel);
+    }
+    if (!$ok && file_exists($path)) {
+        trigger_error(
+            sprintf('Failed to remove %s file: %s', $context, xoops_file_label($path)),
+            E_USER_WARNING
+        );
+    }
+}
+
+/**
  * Write a file through a temporary sibling and replace the target on success.
  *
  * @param string $filename
@@ -141,13 +174,13 @@ function xoops_write_file_atomically($filename, $content)
     $expectedBytes = strlen($content);
     $bytesWritten  = file_put_contents($tempFile, $content, LOCK_EX);
     if ($bytesWritten === false) {
-        @unlink($tempFile);
+        xoops_remove_file_quietly($tempFile, 'temporary');
         trigger_error(sprintf('Failed to write file: %s', $label), E_USER_WARNING);
 
         return false;
     }
     if ($bytesWritten !== $expectedBytes) {
-        @unlink($tempFile);
+        xoops_remove_file_quietly($tempFile, 'temporary');
         trigger_error(
             sprintf(
                 'Short write for %s: wrote %d of %d bytes',
@@ -167,11 +200,25 @@ function xoops_write_file_atomically($filename, $content)
             $targetPerms = $currentPerms & 0777;
         }
     }
-    @chmod($tempFile, $targetPerms);
+    if (!chmod($tempFile, $targetPerms)) {
+        // Non-fatal: file is written, only the perms didn't take. Continue
+        // with the rename rather than aborting — most callers care about
+        // content integrity over exact perms.
+        trigger_error(
+            sprintf('Failed to set permissions on temp file for %s', $label),
+            E_USER_WARNING
+        );
+    }
 
+    // The four @rename(...) calls below are inside `if (!...)` checks —
+    // failure is detected by the boolean return and reported via
+    // trigger_error(). The `@` is retained to suppress PHP's native
+    // warning, which would otherwise double-report alongside our own
+    // diagnostic line. Removing it would not improve detection but would
+    // pollute display_errors output.
     if (!@rename($tempFile, $filename)) {
         if (!file_exists($filename)) {
-            @unlink($tempFile);
+            xoops_remove_file_quietly($tempFile, 'temporary');
             trigger_error(sprintf(XOOPS_WRITE_FILE_WRITE_ERROR, $label), E_USER_WARNING);
 
             return false;
@@ -179,14 +226,16 @@ function xoops_write_file_atomically($filename, $content)
 
         $backupFile = tempnam($directory, 'xwb');
         if ($backupFile === false) {
-            @unlink($tempFile);
+            xoops_remove_file_quietly($tempFile, 'temporary');
             trigger_error(sprintf(XOOPS_WRITE_FILE_WRITE_ERROR, $label), E_USER_WARNING);
 
             return false;
         }
-        @unlink($backupFile);
+        // tempnam() created a 0-byte placeholder we don't need; remove it
+        // so the rename below can take its slot.
+        xoops_remove_file_quietly($backupFile, 'backup');
         if (!@rename($filename, $backupFile)) {
-            @unlink($tempFile);
+            xoops_remove_file_quietly($tempFile, 'temporary');
             trigger_error(sprintf(XOOPS_WRITE_FILE_WRITE_ERROR, $label), E_USER_WARNING);
 
             return false;
@@ -194,7 +243,7 @@ function xoops_write_file_atomically($filename, $content)
 
         if (!@rename($tempFile, $filename)) {
             if (!@rename($backupFile, $filename)) {
-                @unlink($tempFile);
+                xoops_remove_file_quietly($tempFile, 'temporary');
                 trigger_error(
                     sprintf(
                         'Failed to replace file and restore original: %s. Original content was left in backup file %s; manual restoration may be required.',
@@ -207,13 +256,13 @@ function xoops_write_file_atomically($filename, $content)
                 return false;
             }
 
-            @unlink($tempFile);
+            xoops_remove_file_quietly($tempFile, 'temporary');
             trigger_error(sprintf(XOOPS_WRITE_FILE_WRITE_ERROR, $label), E_USER_WARNING);
 
             return false;
         }
 
-        @unlink($backupFile);
+        xoops_remove_file_quietly($backupFile, 'backup');
     }
 
     return true;

--- a/htdocs/include/cp_functions.php
+++ b/htdocs/include/cp_functions.php
@@ -121,6 +121,39 @@ function xoops_file_label($filename)
 }
 
 /**
+ * Set file permissions, suppressing the native PHP warning on failure
+ * via the same scoped error_reporting() toggle used by
+ * xoops_remove_file_quietly(). Without this, a chmod() failure produces
+ * TWO log lines: the native PHP warning AND the project's own
+ * trigger_error(). The helper consolidates them into a single
+ * project-standard warning based on the boolean return value.
+ *
+ * @param string $path    Absolute path to the file.
+ * @param int    $perms   Permission bits (octal).
+ * @param string $context Short label used in the warning message
+ *                        (e.g. 'temp', 'temp guard').
+ *
+ * @return bool True on success, false on failure (warning already emitted).
+ */
+function xoops_chmod_quietly($path, $perms, $context = 'temp')
+{
+    $previousLevel = error_reporting(0);
+    try {
+        $ok = chmod($path, $perms);
+    } finally {
+        error_reporting($previousLevel);
+    }
+    if (!$ok) {
+        trigger_error(
+            sprintf('Failed to set permissions on %s file: %s', $context, xoops_file_label($path)),
+            E_USER_WARNING
+        );
+    }
+
+    return $ok;
+}
+
+/**
  * Best-effort file removal used by atomic-write cleanup paths and similar
  * fire-and-forget cleanup. Skips non-existent paths so already-deleted
  * files don't trigger warnings, suppresses the unlink() warning via a
@@ -200,15 +233,12 @@ function xoops_write_file_atomically($filename, $content)
             $targetPerms = $currentPerms & 0777;
         }
     }
-    if (!chmod($tempFile, $targetPerms)) {
-        // Non-fatal: file is written, only the perms didn't take. Continue
-        // with the rename rather than aborting — most callers care about
-        // content integrity over exact perms.
-        trigger_error(
-            sprintf('Failed to set permissions on temp file for %s', $label),
-            E_USER_WARNING
-        );
-    }
+    // Non-fatal: file is written, only the perms may not take. Continue
+    // with the rename rather than aborting — most callers care about
+    // content integrity over exact perms. The helper suppresses the
+    // native PHP warning so a single failure produces a single
+    // project-standard log line.
+    xoops_chmod_quietly($tempFile, $targetPerms, 'temp');
 
     // The four @rename(...) calls below are inside `if (!...)` checks —
     // failure is detected by the boolean return and reported via

--- a/htdocs/include/cp_functions.php
+++ b/htdocs/include/cp_functions.php
@@ -137,6 +137,12 @@ function xoops_file_label($filename)
  */
 function xoops_chmod_quietly($path, $perms, $context = 'temp')
 {
+    // Initialise $ok before the try block: error_reporting(0) does NOT
+    // disable user-defined error handlers, only the native warning. A
+    // naively written handler that always throws (without checking
+    // error_reporting() & $errno) would propagate out of the try block
+    // before chmod() returns, leaving $ok unset. Defensive default.
+    $ok            = false;
     $previousLevel = error_reporting(0);
     try {
         $ok = chmod($path, $perms);
@@ -172,6 +178,10 @@ function xoops_remove_file_quietly($path, $context = 'temporary')
     if (!file_exists($path)) {
         return;
     }
+    // Initialise $ok defensively — see xoops_chmod_quietly() for the
+    // rationale (error_reporting(0) does not disable user-defined
+    // error handlers).
+    $ok            = false;
     $previousLevel = error_reporting(0);
     try {
         $ok = unlink($path);

--- a/htdocs/include/cp_functions.php
+++ b/htdocs/include/cp_functions.php
@@ -175,7 +175,12 @@ function xoops_chmod_quietly($path, $perms, $context = 'temp')
  */
 function xoops_remove_file_quietly($path, $context = 'temporary')
 {
-    if (!file_exists($path)) {
+    // file_exists() returns false for broken symlinks, so a dangling
+    // symlink would be skipped here and also bypass the post-unlink
+    // existence check below — leaving the orphaned link in place. Treat
+    // links as existing too: unlink() can remove broken symlinks just
+    // fine, and the targets they point to are not what we care about.
+    if (!file_exists($path) && !is_link($path)) {
         return;
     }
     // Initialise $ok defensively — see xoops_chmod_quietly() for the
@@ -188,7 +193,7 @@ function xoops_remove_file_quietly($path, $context = 'temporary')
     } finally {
         error_reporting($previousLevel);
     }
-    if (!$ok && file_exists($path)) {
+    if (!$ok && (file_exists($path) || is_link($path))) {
         trigger_error(
             sprintf('Failed to remove %s file: %s', $context, xoops_file_label($path)),
             E_USER_WARNING

--- a/htdocs/include/cp_functions.php
+++ b/htdocs/include/cp_functions.php
@@ -142,10 +142,17 @@ function xoops_chmod_quietly($path, $perms, $context = 'temp')
     // naively written handler that always throws (without checking
     // error_reporting() & $errno) would propagate out of the try block
     // before chmod() returns, leaving $ok unset. Defensive default.
+    // Catch \Throwable too: chmod() raises ValueError on PHP 8+ for
+    // paths containing a null byte, and a user error handler may throw
+    // ErrorException for other filesystem conditions. Both are reported
+    // as a single project-standard warning, never propagated out of a
+    // best-effort cleanup helper.
     $ok            = false;
     $previousLevel = error_reporting(0);
     try {
         $ok = chmod($path, $perms);
+    } catch (\Throwable $e) {
+        $ok = false;
     } finally {
         error_reporting($previousLevel);
     }
@@ -180,20 +187,40 @@ function xoops_remove_file_quietly($path, $context = 'temporary')
     // existence check below — leaving the orphaned link in place. Treat
     // links as existing too: unlink() can remove broken symlinks just
     // fine, and the targets they point to are not what we care about.
-    if (!file_exists($path) && !is_link($path)) {
+    //
+    // file_exists() / is_link() can themselves raise ValueError on PHP
+    // 8+ when the path contains a null byte. Treat any throw from the
+    // pre-check as "nothing to do" — there is no file we could safely
+    // remove, and propagating the exception out of a best-effort
+    // cleanup helper would abort the caller's unrelated work.
+    try {
+        if (!file_exists($path) && !is_link($path)) {
+            return;
+        }
+    } catch (\Throwable $e) {
         return;
     }
     // Initialise $ok defensively — see xoops_chmod_quietly() for the
     // rationale (error_reporting(0) does not disable user-defined
-    // error handlers).
+    // error handlers). Catch \Throwable around unlink() for the same
+    // ValueError-on-null-byte / throwing-error-handler reasons.
     $ok            = false;
     $previousLevel = error_reporting(0);
     try {
         $ok = unlink($path);
+    } catch (\Throwable $e) {
+        $ok = false;
     } finally {
         error_reporting($previousLevel);
     }
-    if (!$ok && (file_exists($path) || is_link($path))) {
+    // Same try/catch shape around the post-unlink probe: if the path
+    // contained a null byte we have nothing useful to report anyway.
+    try {
+        $stillPresent = file_exists($path) || is_link($path);
+    } catch (\Throwable $e) {
+        $stillPresent = false;
+    }
+    if (!$ok && $stillPresent) {
         trigger_error(
             sprintf('Failed to remove %s file: %s', $context, xoops_file_label($path)),
             E_USER_WARNING

--- a/htdocs/include/cp_functions.php
+++ b/htdocs/include/cp_functions.php
@@ -18,6 +18,13 @@
 define('XOOPS_CPFUNC_LOADED', 1);
 define('XOOPS_WRITE_FILE_WRITE_ERROR', 'Failed to write file: %s');
 
+// xoops_file_label(), xoops_chmod_quietly(), and xoops_remove_file_quietly()
+// live in a side-effect-free include so callers that only need the
+// file helpers (e.g. modules/system/class/maintenance.php, also loaded
+// from upgrade scripts) don't pick up the XOOPS_CPFUNC_LOADED define,
+// which forces redirect_header() into the 'default' theme.
+require_once __DIR__ . '/file_safety.php';
+
 /**
  * CP Header
  *
@@ -100,132 +107,6 @@ function xoopsfwrite()
     }
 
     return true;
-}
-
-/**
- * Create a short, non-sensitive file label for warnings.
- *
- * @param string $filename
- * @return string
- */
-function xoops_file_label($filename)
-{
-    $normalized = str_replace('\\', '/', $filename);
-    $rootPrefix = rtrim(str_replace('\\', '/', XOOPS_ROOT_PATH), '/') . '/';
-
-    if (strncmp($normalized, $rootPrefix, strlen($rootPrefix)) === 0) {
-        return substr($normalized, strlen($rootPrefix));
-    }
-
-    return basename($filename);
-}
-
-/**
- * Set file permissions, suppressing the native PHP warning on failure
- * via the same scoped error_reporting() toggle used by
- * xoops_remove_file_quietly(). Without this, a chmod() failure produces
- * TWO log lines: the native PHP warning AND the project's own
- * trigger_error(). The helper consolidates them into a single
- * project-standard warning based on the boolean return value.
- *
- * @param string $path    Absolute path to the file.
- * @param int    $perms   Permission bits (octal).
- * @param string $context Short label used in the warning message
- *                        (e.g. 'temp', 'temp guard').
- *
- * @return bool True on success, false on failure (warning already emitted).
- */
-function xoops_chmod_quietly($path, $perms, $context = 'temp')
-{
-    // Initialise $ok before the try block: error_reporting(0) does NOT
-    // disable user-defined error handlers, only the native warning. A
-    // naively written handler that always throws (without checking
-    // error_reporting() & $errno) would propagate out of the try block
-    // before chmod() returns, leaving $ok unset. Defensive default.
-    // Catch \Throwable too: chmod() raises ValueError on PHP 8+ for
-    // paths containing a null byte, and a user error handler may throw
-    // ErrorException for other filesystem conditions. Both are reported
-    // as a single project-standard warning, never propagated out of a
-    // best-effort cleanup helper.
-    $ok            = false;
-    $previousLevel = error_reporting(0);
-    try {
-        $ok = chmod($path, $perms);
-    } catch (\Throwable $e) {
-        $ok = false;
-    } finally {
-        error_reporting($previousLevel);
-    }
-    if (!$ok) {
-        trigger_error(
-            sprintf('Failed to set permissions on %s file: %s', $context, xoops_file_label($path)),
-            E_USER_WARNING
-        );
-    }
-
-    return $ok;
-}
-
-/**
- * Best-effort file removal used by atomic-write cleanup paths and similar
- * fire-and-forget cleanup. Skips non-existent paths so already-deleted
- * files don't trigger warnings, suppresses the unlink() warning via a
- * scoped error_reporting() toggle (no `@` operator), and re-checks
- * existence after a failed unlink — only logging when the file is still
- * present, so TOCTOU races resolve silently.
- *
- * @param string $path    Absolute path to the file to remove.
- * @param string $context Short label used in the warning message
- *                        (e.g. 'temporary', 'backup').
- *
- * @return void
- */
-function xoops_remove_file_quietly($path, $context = 'temporary')
-{
-    // file_exists() returns false for broken symlinks, so a dangling
-    // symlink would be skipped here and also bypass the post-unlink
-    // existence check below — leaving the orphaned link in place. Treat
-    // links as existing too: unlink() can remove broken symlinks just
-    // fine, and the targets they point to are not what we care about.
-    //
-    // file_exists() / is_link() can themselves raise ValueError on PHP
-    // 8+ when the path contains a null byte. Treat any throw from the
-    // pre-check as "nothing to do" — there is no file we could safely
-    // remove, and propagating the exception out of a best-effort
-    // cleanup helper would abort the caller's unrelated work.
-    try {
-        if (!file_exists($path) && !is_link($path)) {
-            return;
-        }
-    } catch (\Throwable $e) {
-        return;
-    }
-    // Initialise $ok defensively — see xoops_chmod_quietly() for the
-    // rationale (error_reporting(0) does not disable user-defined
-    // error handlers). Catch \Throwable around unlink() for the same
-    // ValueError-on-null-byte / throwing-error-handler reasons.
-    $ok            = false;
-    $previousLevel = error_reporting(0);
-    try {
-        $ok = unlink($path);
-    } catch (\Throwable $e) {
-        $ok = false;
-    } finally {
-        error_reporting($previousLevel);
-    }
-    // Same try/catch shape around the post-unlink probe: if the path
-    // contained a null byte we have nothing useful to report anyway.
-    try {
-        $stillPresent = file_exists($path) || is_link($path);
-    } catch (\Throwable $e) {
-        $stillPresent = false;
-    }
-    if (!$ok && $stillPresent) {
-        trigger_error(
-            sprintf('Failed to remove %s file: %s', $context, xoops_file_label($path)),
-            E_USER_WARNING
-        );
-    }
 }
 
 /**

--- a/htdocs/include/file_safety.php
+++ b/htdocs/include/file_safety.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Side-effect-free file-safety helpers.
+ *
+ * Hosts the three small filesystem helpers used by atomic-write and
+ * cleanup paths:
+ *
+ *  - xoops_file_label()        — root-relative label for warnings
+ *  - xoops_chmod_quietly()     — scoped-suppressed chmod() with single warning
+ *  - xoops_remove_file_quietly() — scoped-suppressed unlink() with single warning
+ *
+ * They originally lived in include/cp_functions.php, but that file
+ * unconditionally `define()`s XOOPS_CPFUNC_LOADED, which include/
+ * functions.php keys off to force redirect_header() into the 'default'
+ * theme. Including cp_functions.php from non-CP contexts (notably the
+ * upgrade scripts that instantiate SystemMaintenance directly) was
+ * silently flipping that flag. This file deliberately has NO module-
+ * level side effects — it can be required from anywhere without
+ * affecting redirect rendering, theme selection, or any other global
+ * state. cp_functions.php now requires this file as well, so existing
+ * call sites continue to work unchanged.
+ *
+ * Each function is wrapped in a function_exists() guard so the file is
+ * safe to require_once multiple times across mixed load orders.
+ *
+ * You may not change or alter any portion of this comment or credits
+ * of supporting developers from this source code or any supporting source code
+ * which is considered copyrighted (c) material of the original comment or credit authors.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright       (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license             GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @package             kernel
+ * @since               2.7.0
+ */
+
+defined('XOOPS_ROOT_PATH') || exit('Restricted access');
+
+if (!function_exists('xoops_file_label')) {
+    /**
+     * Create a short, non-sensitive file label for warnings.
+     *
+     * Returns the path relative to XOOPS_ROOT_PATH when the file lives
+     * under the install root, otherwise the basename only. Used by
+     * atomic-write callers that want to surface a bit of context
+     * ("which area of the install failed") without leaking the full
+     * server-side filesystem layout.
+     *
+     * @param string $filename
+     * @return string
+     */
+    function xoops_file_label($filename)
+    {
+        $normalized = str_replace('\\', '/', $filename);
+        $rootPrefix = rtrim(str_replace('\\', '/', XOOPS_ROOT_PATH), '/') . '/';
+
+        if (strncmp($normalized, $rootPrefix, strlen($rootPrefix)) === 0) {
+            return substr($normalized, strlen($rootPrefix));
+        }
+
+        return basename($filename);
+    }
+}
+
+if (!function_exists('xoops_safe_basename')) {
+    /**
+     * Strict basename for warning messages emitted by the cleanup
+     * helpers. Normalises backslashes to '/' first so a Windows-style
+     * path stored in a cross-platform context still collapses to just
+     * the filename. Use this where the warning must NEVER disclose any
+     * directory structure (e.g. cleanup of orphan/temp files).
+     *
+     * @param string $path
+     * @return string
+     */
+    function xoops_safe_basename($path)
+    {
+        return basename(str_replace('\\', '/', (string) $path));
+    }
+}
+
+if (!function_exists('xoops_chmod_quietly')) {
+    /**
+     * Set file permissions, suppressing the native PHP warning on failure
+     * via the same scoped error_reporting() toggle used by
+     * xoops_remove_file_quietly(). Without this, a chmod() failure
+     * produces TWO log lines: the native PHP warning AND the project's
+     * own trigger_error(). The helper consolidates them into a single
+     * project-standard warning based on the boolean return value.
+     *
+     * @param string $path    Absolute path to the file.
+     * @param int    $perms   Permission bits (octal).
+     * @param string $context Short label used in the warning message
+     *                        (e.g. 'temp', 'temp guard').
+     *
+     * @return bool True on success, false on failure (warning already emitted).
+     */
+    function xoops_chmod_quietly($path, $perms, $context = 'temp')
+    {
+        // Initialise $ok before the try block: error_reporting(0) does NOT
+        // disable user-defined error handlers, only the native warning. A
+        // naively written handler that always throws (without checking
+        // error_reporting() & $errno) would propagate out of the try block
+        // before chmod() returns, leaving $ok unset. Defensive default.
+        // Catch \Throwable too: chmod() raises ValueError on PHP 8+ for
+        // paths containing a null byte, and a user error handler may throw
+        // ErrorException for other filesystem conditions. Both are reported
+        // as a single project-standard warning, never propagated out of a
+        // best-effort cleanup helper.
+        $ok            = false;
+        $previousLevel = error_reporting(0);
+        try {
+            $ok = chmod($path, $perms);
+        } catch (\Throwable $e) {
+            $ok = false;
+        } finally {
+            error_reporting($previousLevel);
+        }
+        if (!$ok) {
+            // basename-only label: cleanup-helper warnings never need
+            // directory context, and the strict form keeps install
+            // layout out of any error log a site operator may share.
+            trigger_error(
+                sprintf('Failed to set permissions on %s file: %s', $context, xoops_safe_basename($path)),
+                E_USER_WARNING
+            );
+        }
+
+        return $ok;
+    }
+}
+
+if (!function_exists('xoops_remove_file_quietly')) {
+    /**
+     * Best-effort file removal used by atomic-write cleanup paths and similar
+     * fire-and-forget cleanup. Skips non-existent paths so already-deleted
+     * files don't trigger warnings, suppresses the unlink() warning via a
+     * scoped error_reporting() toggle (no `@` operator), and re-checks
+     * existence after a failed unlink — only logging when the file is still
+     * present, so TOCTOU races resolve silently.
+     *
+     * @param string $path    Absolute path to the file to remove.
+     * @param string $context Short label used in the warning message
+     *                        (e.g. 'temporary', 'backup').
+     *
+     * @return void
+     */
+    function xoops_remove_file_quietly($path, $context = 'temporary')
+    {
+        // file_exists() returns false for broken symlinks, so a dangling
+        // symlink would be skipped here and also bypass the post-unlink
+        // existence check below — leaving the orphaned link in place. Treat
+        // links as existing too: unlink() can remove broken symlinks just
+        // fine, and the targets they point to are not what we care about.
+        //
+        // file_exists() / is_link() can themselves raise ValueError on PHP
+        // 8+ when the path contains a null byte. Treat any throw from the
+        // pre-check as "nothing to do" — there is no file we could safely
+        // remove, and propagating the exception out of a best-effort
+        // cleanup helper would abort the caller's unrelated work.
+        try {
+            if (!file_exists($path) && !is_link($path)) {
+                return;
+            }
+        } catch (\Throwable $e) {
+            return;
+        }
+        // Initialise $ok defensively — see xoops_chmod_quietly() for the
+        // rationale (error_reporting(0) does not disable user-defined
+        // error handlers). Catch \Throwable around unlink() for the same
+        // ValueError-on-null-byte / throwing-error-handler reasons.
+        $ok            = false;
+        $previousLevel = error_reporting(0);
+        try {
+            $ok = unlink($path);
+        } catch (\Throwable $e) {
+            $ok = false;
+        } finally {
+            error_reporting($previousLevel);
+        }
+        // Same try/catch shape around the post-unlink probe: if the path
+        // contained a null byte we have nothing useful to report anyway.
+        try {
+            $stillPresent = file_exists($path) || is_link($path);
+        } catch (\Throwable $e) {
+            $stillPresent = false;
+        }
+        if (!$ok && $stillPresent) {
+            // basename-only label: see xoops_chmod_quietly() rationale.
+            trigger_error(
+                sprintf('Failed to remove %s file: %s', $context, xoops_safe_basename($path)),
+                E_USER_WARNING
+            );
+        }
+    }
+}

--- a/htdocs/include/file_safety.php
+++ b/htdocs/include/file_safety.php
@@ -72,12 +72,34 @@ if (!function_exists('xoops_safe_basename')) {
      * the filename. Use this where the warning must NEVER disclose any
      * directory structure (e.g. cleanup of orphan/temp files).
      *
+     * Defensive shape, mirroring xoops_chmod_quietly() /
+     * xoops_remove_file_quietly(): reject null-byte payloads up front
+     * and wrap basename() in catch(\Throwable). Empirically basename()
+     * does not throw on a "\0"-bearing path in PHP 8.2-8.4 (it returns
+     * the byte verbatim), but the helpers it serves are documented as
+     * best-effort/non-propagating, so the same guarantee must hold here
+     * — a stray null byte in a future PHP version, a userland override,
+     * or a throwing error handler must NOT escape the cleanup path. A
+     * literal "\0" in the formatted trigger_error() output would also
+     * confuse log parsers; returning a fixed placeholder keeps the
+     * warning readable.
+     *
      * @param string $path
      * @return string
      */
     function xoops_safe_basename($path)
     {
-        return basename(str_replace('\\', '/', (string) $path));
+        $normalized = str_replace('\\', '/', (string) $path);
+
+        if (str_contains($normalized, "\0")) {
+            return 'invalid-path';
+        }
+
+        try {
+            return basename($normalized);
+        } catch (\Throwable $e) {
+            return 'invalid-path';
+        }
     }
 }
 

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -194,6 +194,13 @@ class SystemMaintenance
             ? rtrim($avatarRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR
             : null;
 
+        // Track whether every DELETE in the sweep succeeded. The method
+        // contract is `@return bool`, but the previous implementation
+        // unconditionally returned true even if a DELETE failed and an
+        // orphaned row was left behind. Callers can now distinguish a
+        // clean sweep from a partial one.
+        $deleteOk = true;
+
         /** @var array $myrow */
         while (false !== ($myrow = $this->db->fetchArray($result))) {
             // Avatar files are stored as 'avatars/<filename>'
@@ -226,7 +233,9 @@ class SystemMaintenance
             $avatarId   = (int) ($myrow['avatar_id'] ?? 0);
             $avatarFile = ltrim(str_replace('\\', '/', (string) ($myrow['avatar_file'] ?? '')), '/');
             if ('' === $avatarFile) {
-                $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $avatarId);
+                if (!$this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $avatarId)) {
+                    $deleteOk = false;
+                }
                 continue;
             }
             $avatarCandidate = XOOPS_UPLOAD_PATH . '/' . $avatarFile;
@@ -240,12 +249,16 @@ class SystemMaintenance
                 xoops_remove_file_quietly($avatarCandidate, 'orphaned avatar');
             }
             //clean avatar table
-            $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $avatarId);
+            if (!$this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $avatarId)) {
+                $deleteOk = false;
+            }
         }
         //clean any deleted users from avatar_user_link table
-        $result2 = $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar_user_link') . ' WHERE user_id NOT IN (SELECT uid FROM ' . $this->db->prefix('users') . ')');
+        if (!$this->db->exec('DELETE FROM ' . $this->db->prefix('avatar_user_link') . ' WHERE user_id NOT IN (SELECT uid FROM ' . $this->db->prefix('users') . ')')) {
+            $deleteOk = false;
+        }
 
-        return true;
+        return $deleteOk;
     }
 
     /**
@@ -344,13 +357,28 @@ class SystemMaintenance
 
             if (!@rename($tempFile, $filename)) {
                 xoops_remove_file_quietly($tempFile, 'temp guard');
+                // Track whether the backup-restore step succeeded so the
+                // composite failure warning can communicate that the
+                // original guard file is intact (vs. the worse case
+                // where both replace and restore failed and manual
+                // intervention may be required).
+                $restoredBackup = false;
                 if ($backupFile !== null) {
                     if (!@rename($backupFile, $filename)) {
                         trigger_error(sprintf('Failed to restore original guard file: %s', $label), E_USER_WARNING);
+                    } else {
+                        $restoredBackup = true;
                     }
                 }
 
-                trigger_error(sprintf('Failed to replace guard file: %s', $label), E_USER_WARNING);
+                trigger_error(
+                    sprintf(
+                        'Failed to replace guard file: %s%s',
+                        $label,
+                        $restoredBackup ? ' (original restored)' : ''
+                    ),
+                    E_USER_WARNING
+                );
             } elseif ($backupFile !== null) {
                 xoops_remove_file_quietly($backupFile, 'backup guard');
             }

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -23,11 +23,18 @@
 // for consistency with the rest of the codebase.
 defined('XOOPS_ROOT_PATH') || exit('Restricted access');
 
-// xoops_remove_file_quietly() lives in cp_functions.php; admin and install
-// callers normally load it via cp_header.php / page_moduleinstaller.php,
-// but require it explicitly here so SystemMaintenance is self-sufficient
-// regardless of which context instantiates it.
-require_once XOOPS_ROOT_PATH . '/include/cp_functions.php';
+// xoops_remove_file_quietly() and friends live in include/file_safety.php
+// — a deliberately side-effect-free file. Earlier revisions required
+// include/cp_functions.php here, which defines XOOPS_CPFUNC_LOADED;
+// include/functions.php keys off that constant to force redirect_header()
+// into the 'default' theme. SystemMaintenance is also instantiated from
+// upgrade/upd_2.5.10-to-2.5.11/index.php and upgrade/upd_2.5.11-to-2.7.0/
+// index.php, so loading cp_functions.php at class-file-load time was
+// silently overriding the configured theme during upgrades. Loading just
+// the helpers avoids that side effect; CP and admin callers still see
+// XOOPS_CPFUNC_LOADED via their own cp_header.php / page_moduleinstaller.php
+// load paths.
+require_once XOOPS_ROOT_PATH . '/include/file_safety.php';
 
 /**
  * System Maintenance

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -19,6 +19,12 @@
 //    throw new \RuntimeException('XOOPS root path not defined');
 //}
 
+// xoops_remove_file_quietly() lives in cp_functions.php; admin and install
+// callers normally load it via cp_header.php / page_moduleinstaller.php,
+// but require it explicitly here so SystemMaintenance is self-sufficient
+// regardless of which context instantiates it.
+require_once XOOPS_ROOT_PATH . '/include/cp_functions.php';
+
 /**
  * System Maintenance
  *
@@ -168,8 +174,33 @@ class SystemMaintenance
 
         /** @var array $myrow */
         while (false !== ($myrow = $this->db->fetchArray($result))) {
-            //delete file
-            @unlink(XOOPS_UPLOAD_PATH . '/' . $myrow['avatar_file']);
+            // Avatar files are stored as 'avatars/<filename>' (see
+            // kernel/avatar.php and the various admin/edituser writers),
+            // so basename() would silently bypass cleanup. Instead:
+            //   - normalise backslashes to '/' (Windows-historic data)
+            //   - strip leading slashes (defends against absolute paths
+            //     accidentally or maliciously stored in the column)
+            //   - resolve via realpath() so any '../' segments collapse
+            //   - confirm the resolved path is contained inside the
+            //     resolved upload-root (prefix check with a trailing
+            //     separator so 'uploadsX/...' doesn't satisfy 'uploads')
+            //   - confirm it's a regular file before removal.
+            // Only then invoke the cleanup helper.
+            $avatarFile = ltrim(str_replace('\\', '/', (string) ($myrow['avatar_file'] ?? '')), '/');
+            if ('' === $avatarFile) {
+                $result1 = $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $myrow['avatar_id']);
+                continue;
+            }
+            $avatarPath = realpath(XOOPS_UPLOAD_PATH . '/' . $avatarFile);
+            $uploadRoot = realpath(XOOPS_UPLOAD_PATH);
+            if (
+                is_string($avatarPath)
+                && is_string($uploadRoot)
+                && str_starts_with($avatarPath, rtrim($uploadRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR)
+                && is_file($avatarPath)
+            ) {
+                xoops_remove_file_quietly($avatarPath, 'orphaned avatar');
+            }
             //clean avatar table
             $result1 = $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $myrow['avatar_id']);
         }
@@ -221,10 +252,10 @@ class SystemMaintenance
         $result = file_put_contents($tempFile, $content, LOCK_EX);
 
         if ($result === false) {
-            @unlink($tempFile);
+            xoops_remove_file_quietly($tempFile, 'temp guard');
             trigger_error(sprintf('Failed to write guard file: %s', $label), E_USER_WARNING);
         } elseif ($result !== $expected) {
-            @unlink($tempFile);
+            xoops_remove_file_quietly($tempFile, 'temp guard');
             trigger_error(
                 sprintf(
                     'Short write for guard file %s: wrote %d of %d bytes',
@@ -242,20 +273,34 @@ class SystemMaintenance
                     $targetPerms = $currentPerms & 0777;
                 }
             }
-            @chmod($tempFile, $targetPerms);
+            if (!chmod($tempFile, $targetPerms)) {
+                // Non-fatal: content is written, only the perms didn't
+                // take. Continue with the rename rather than aborting.
+                trigger_error(
+                    sprintf('Failed to set permissions on temp guard file for %s', $label),
+                    E_USER_WARNING
+                );
+            }
 
+            // The @rename(...) calls below are inside `if (!...)` checks —
+            // failure is detected by the boolean return and reported via
+            // trigger_error(). The `@` is retained to suppress PHP's
+            // native warning, which would otherwise double-report
+            // alongside our own diagnostic.
             $backupFile = null;
             if (file_exists($filename)) {
                 $backupFile = tempnam(dirname($filename), 'mtb');
                 if ($backupFile === false) {
-                    @unlink($tempFile);
+                    xoops_remove_file_quietly($tempFile, 'temp guard');
                     trigger_error(sprintf('Failed to create backup file for %s', $label), E_USER_WARNING);
 
                     return;
                 }
-                @unlink($backupFile);
+                // tempnam() created a 0-byte placeholder; remove it so
+                // the rename below can take its slot.
+                xoops_remove_file_quietly($backupFile, 'backup guard');
                 if (!@rename($filename, $backupFile)) {
-                    @unlink($tempFile);
+                    xoops_remove_file_quietly($tempFile, 'temp guard');
                     trigger_error(sprintf('Failed to back up guard file: %s', $label), E_USER_WARNING);
 
                     return;
@@ -263,7 +308,7 @@ class SystemMaintenance
             }
 
             if (!@rename($tempFile, $filename)) {
-                @unlink($tempFile);
+                xoops_remove_file_quietly($tempFile, 'temp guard');
                 if ($backupFile !== null) {
                     if (!@rename($backupFile, $filename)) {
                         trigger_error(sprintf('Failed to restore original guard file: %s', $label), E_USER_WARNING);
@@ -271,8 +316,8 @@ class SystemMaintenance
                 }
 
                 trigger_error(sprintf('Failed to replace guard file: %s', $label), E_USER_WARNING);
-            } elseif ($backupFile !== null && file_exists($backupFile) && !@unlink($backupFile)) {
-                trigger_error(sprintf('Failed to remove backup guard file: %s', $label), E_USER_WARNING);
+            } elseif ($backupFile !== null) {
+                xoops_remove_file_quietly($backupFile, 'backup guard');
             }
         }
     }

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -15,9 +15,14 @@
  * @package             system
  */
 
-//if (!defined('XOOPS_ROOT_PATH')) {
-//    throw new \RuntimeException('XOOPS root path not defined');
-//}
+// Direct-access guard: this file is module/admin-only and must never
+// execute outside a bootstrapped XOOPS context. Without this, the
+// require_once below would fail with an "undefined constant" fatal
+// when the file is hit via a direct URL, leaking server path details
+// in the error message.
+if (!defined('XOOPS_ROOT_PATH')) {
+    exit();
+}
 
 // xoops_remove_file_quietly() lives in cp_functions.php; admin and install
 // callers normally load it via cp_header.php / page_moduleinstaller.php,

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -195,9 +195,15 @@ class SystemMaintenance
             //     separator so 'uploadsX/...' doesn't satisfy 'uploads')
             //   - confirm it's a regular file before removal.
             // Only then invoke the cleanup helper.
+            // (int) cast on avatar_id is defence-in-depth: the value is
+            // DB-origin so SQL injection is implausible, but the project
+            // convention is to never concatenate non-cast values into
+            // SQL strings. The cast also silences SonarCloud's
+            // concatenation warning on these DELETE statements.
+            $avatarId   = (int) ($myrow['avatar_id'] ?? 0);
             $avatarFile = ltrim(str_replace('\\', '/', (string) ($myrow['avatar_file'] ?? '')), '/');
             if ('' === $avatarFile) {
-                $result1 = $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $myrow['avatar_id']);
+                $result1 = $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $avatarId);
                 continue;
             }
             $avatarPath = realpath(XOOPS_UPLOAD_PATH . '/' . $avatarFile);
@@ -210,7 +216,7 @@ class SystemMaintenance
                 xoops_remove_file_quietly($avatarPath, 'orphaned avatar');
             }
             //clean avatar table
-            $result1 = $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $myrow['avatar_id']);
+            $result1 = $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $avatarId);
         }
         //clean any deleted users from avatar_user_link table
         $result2 = $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar_user_link') . ' WHERE user_id NOT IN (SELECT uid FROM ' . $this->db->prefix('users') . ')');

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -160,6 +160,8 @@ class SystemMaintenance
      * @author slider84 of Team FrXoops
      *
      * @return boolean
+     *
+     * @throws \RuntimeException If the avatar table query fails.
      */
     public function CleanAvatar()
     {
@@ -210,7 +212,7 @@ class SystemMaintenance
             $avatarId   = (int) ($myrow['avatar_id'] ?? 0);
             $avatarFile = ltrim(str_replace('\\', '/', (string) ($myrow['avatar_file'] ?? '')), '/');
             if ('' === $avatarFile) {
-                $result1 = $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $avatarId);
+                $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $avatarId);
                 continue;
             }
             $avatarPath = realpath(XOOPS_UPLOAD_PATH . '/' . $avatarFile);
@@ -223,7 +225,7 @@ class SystemMaintenance
                 xoops_remove_file_quietly($avatarPath, 'orphaned avatar');
             }
             //clean avatar table
-            $result1 = $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $avatarId);
+            $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $avatarId);
         }
         //clean any deleted users from avatar_user_link table
         $result2 = $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar_user_link') . ' WHERE user_id NOT IN (SELECT uid FROM ' . $this->db->prefix('users') . ')');

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -172,27 +172,34 @@ class SystemMaintenance
             );
         }
 
-        // Resolve the upload-root once for the whole sweep. Both realpath()
-        // and the trailing-separator prefix are constant for the run, so
-        // computing them per row would do unnecessary filesystem work on
-        // installations with large numbers of orphaned avatars.
-        $uploadRoot       = realpath(XOOPS_UPLOAD_PATH);
-        $uploadRootPrefix = is_string($uploadRoot)
-            ? rtrim($uploadRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR
+        // Resolve the avatars subdirectory once for the whole sweep.
+        // Custom avatars live under XOOPS_UPLOAD_PATH/avatars/ (see
+        // kernel/avatar.php and the various admin/edituser writers, all
+        // of which prepend 'avatars/' to the stored filename). Narrowing
+        // the containment check to this subtree is defence-in-depth: an
+        // avatar_file value that points elsewhere under uploads/ —
+        // legacy data, custom-module write, or accidental insertion —
+        // is now skipped instead of silently deleting an unrelated
+        // upload. realpath() is constant for the run, so per-row
+        // resolution would just be wasted filesystem work on
+        // installations with large orphaned-avatar tables.
+        $avatarRoot       = realpath(XOOPS_UPLOAD_PATH . '/avatars');
+        $avatarRootPrefix = is_string($avatarRoot)
+            ? rtrim($avatarRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR
             : null;
 
         /** @var array $myrow */
         while (false !== ($myrow = $this->db->fetchArray($result))) {
-            // Avatar files are stored as 'avatars/<filename>' (see
-            // kernel/avatar.php and the various admin/edituser writers),
-            // so basename() would silently bypass cleanup. Instead:
+            // Avatar files are stored as 'avatars/<filename>'
+            // (kernel/avatar.php and 14 admin/edituser writers), so
+            // basename() would silently bypass cleanup. Instead:
             //   - normalise backslashes to '/' (Windows-historic data)
             //   - strip leading slashes (defends against absolute paths
             //     accidentally or maliciously stored in the column)
             //   - resolve via realpath() so any '../' segments collapse
             //   - confirm the resolved path is contained inside the
-            //     resolved upload-root (prefix check with a trailing
-            //     separator so 'uploadsX/...' doesn't satisfy 'uploads')
+            //     resolved avatars/ subdir (trailing-separator prefix
+            //     so 'avatarsX/...' doesn't satisfy 'avatars')
             //   - confirm it's a regular file before removal.
             // Only then invoke the cleanup helper.
             // (int) cast on avatar_id is defence-in-depth: the value is
@@ -209,8 +216,8 @@ class SystemMaintenance
             $avatarPath = realpath(XOOPS_UPLOAD_PATH . '/' . $avatarFile);
             if (
                 is_string($avatarPath)
-                && is_string($uploadRootPrefix)
-                && str_starts_with($avatarPath, $uploadRootPrefix)
+                && is_string($avatarRootPrefix)
+                && str_starts_with($avatarPath, $avatarRootPrefix)
                 && is_file($avatarPath)
             ) {
                 xoops_remove_file_quietly($avatarPath, 'orphaned avatar');
@@ -287,14 +294,11 @@ class SystemMaintenance
                     $targetPerms = $currentPerms & 0777;
                 }
             }
-            if (!chmod($tempFile, $targetPerms)) {
-                // Non-fatal: content is written, only the perms didn't
-                // take. Continue with the rename rather than aborting.
-                trigger_error(
-                    sprintf('Failed to set permissions on temp guard file for %s', $label),
-                    E_USER_WARNING
-                );
-            }
+            // Non-fatal: content is written, only the perms may not
+            // take. Continue with the rename rather than aborting. The
+            // helper suppresses the native PHP warning so a single
+            // failure produces a single project-standard log line.
+            xoops_chmod_quietly($tempFile, $targetPerms, 'temp guard');
 
             // The @rename(...) calls below are inside `if (!...)` checks —
             // failure is detected by the boolean return and reported via

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -232,21 +232,24 @@ class SystemMaintenance
             // concatenation warning on these DELETE statements.
             $avatarId   = (int) ($myrow['avatar_id'] ?? 0);
             $avatarFile = ltrim(str_replace('\\', '/', (string) ($myrow['avatar_file'] ?? '')), '/');
-            if ('' === $avatarFile) {
-                if (!$this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $avatarId)) {
-                    $deleteOk = false;
+            // Reject null-byte payloads BEFORE any filesystem call:
+            // dirname(), realpath(), is_file(), and is_link() all raise
+            // ValueError on PHP 8+ when the argument contains "\0".
+            // Letting that propagate would abort the sweep mid-loop and
+            // skip the avatar_user_link cleanup that follows. The DB
+            // row is still deleted unconditionally below — a malformed
+            // path should never block reclaiming the orphaned row.
+            if ('' !== $avatarFile && !str_contains($avatarFile, "\0")) {
+                $avatarCandidate = XOOPS_UPLOAD_PATH . '/' . $avatarFile;
+                $avatarParent    = realpath(dirname($avatarCandidate));
+                if (
+                    is_string($avatarParent)
+                    && is_string($avatarRootPrefix)
+                    && str_starts_with(rtrim($avatarParent, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR, $avatarRootPrefix)
+                    && (is_file($avatarCandidate) || is_link($avatarCandidate))
+                ) {
+                    xoops_remove_file_quietly($avatarCandidate, 'orphaned avatar');
                 }
-                continue;
-            }
-            $avatarCandidate = XOOPS_UPLOAD_PATH . '/' . $avatarFile;
-            $avatarParent    = realpath(dirname($avatarCandidate));
-            if (
-                is_string($avatarParent)
-                && is_string($avatarRootPrefix)
-                && str_starts_with(rtrim($avatarParent, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR, $avatarRootPrefix)
-                && (is_file($avatarCandidate) || is_link($avatarCandidate))
-            ) {
-                xoops_remove_file_quietly($avatarCandidate, 'orphaned avatar');
             }
             //clean avatar table
             if (!$this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $avatarId)) {

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -172,6 +172,15 @@ class SystemMaintenance
             );
         }
 
+        // Resolve the upload-root once for the whole sweep. Both realpath()
+        // and the trailing-separator prefix are constant for the run, so
+        // computing them per row would do unnecessary filesystem work on
+        // installations with large numbers of orphaned avatars.
+        $uploadRoot       = realpath(XOOPS_UPLOAD_PATH);
+        $uploadRootPrefix = is_string($uploadRoot)
+            ? rtrim($uploadRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR
+            : null;
+
         /** @var array $myrow */
         while (false !== ($myrow = $this->db->fetchArray($result))) {
             // Avatar files are stored as 'avatars/<filename>' (see
@@ -192,11 +201,10 @@ class SystemMaintenance
                 continue;
             }
             $avatarPath = realpath(XOOPS_UPLOAD_PATH . '/' . $avatarFile);
-            $uploadRoot = realpath(XOOPS_UPLOAD_PATH);
             if (
                 is_string($avatarPath)
-                && is_string($uploadRoot)
-                && str_starts_with($avatarPath, rtrim($uploadRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR)
+                && is_string($uploadRootPrefix)
+                && str_starts_with($avatarPath, $uploadRootPrefix)
                 && is_file($avatarPath)
             ) {
                 xoops_remove_file_quietly($avatarPath, 'orphaned avatar');

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -19,10 +19,9 @@
 // execute outside a bootstrapped XOOPS context. Without this, the
 // require_once below would fail with an "undefined constant" fatal
 // when the file is hit via a direct URL, leaking server path details
-// in the error message.
-if (!defined('XOOPS_ROOT_PATH')) {
-    exit();
-}
+// in the error message. Uses the project-standard one-liner shape
+// for consistency with the rest of the codebase.
+defined('XOOPS_ROOT_PATH') || exit('Restricted access');
 
 // xoops_remove_file_quietly() lives in cp_functions.php; admin and install
 // callers normally load it via cp_header.php / page_moduleinstaller.php,
@@ -164,7 +163,7 @@ class SystemMaintenance
      *
      * @author slider84 of Team FrXoops
      *
-     * @return boolean
+     * @return bool
      *
      * @throws \RuntimeException If the avatar table query fails.
      */
@@ -203,12 +202,22 @@ class SystemMaintenance
             //   - normalise backslashes to '/' (Windows-historic data)
             //   - strip leading slashes (defends against absolute paths
             //     accidentally or maliciously stored in the column)
-            //   - resolve via realpath() so any '../' segments collapse
-            //   - confirm the resolved path is contained inside the
-            //     resolved avatars/ subdir (trailing-separator prefix
-            //     so 'avatarsX/...' doesn't satisfy 'avatars')
-            //   - confirm it's a regular file before removal.
-            // Only then invoke the cleanup helper.
+            //   - resolve the parent directory via realpath() so any
+            //     '../' segments collapse, and confirm the parent is
+            //     inside the resolved avatars/ subdir (trailing-
+            //     separator prefix so 'avatarsX/...' doesn't satisfy
+            //     'avatars')
+            //   - confirm the candidate is a regular file OR a symlink
+            //     before removal.
+            // Then invoke the cleanup helper on the ORIGINAL candidate
+            // path (not the realpath result). This matters when the
+            // avatar entry is a symlink: realpath() resolves to the
+            // symlink target, so unlinking the resolved path would
+            // delete the target file (potentially another avatar)
+            // instead of the symlink itself. Resolving the PARENT only
+            // keeps the containment check honest without following the
+            // symlink into the wrong file.
+            //
             // (int) cast on avatar_id is defence-in-depth: the value is
             // DB-origin so SQL injection is implausible, but the project
             // convention is to never concatenate non-cast values into
@@ -220,14 +229,15 @@ class SystemMaintenance
                 $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $avatarId);
                 continue;
             }
-            $avatarPath = realpath(XOOPS_UPLOAD_PATH . '/' . $avatarFile);
+            $avatarCandidate = XOOPS_UPLOAD_PATH . '/' . $avatarFile;
+            $avatarParent    = realpath(dirname($avatarCandidate));
             if (
-                is_string($avatarPath)
+                is_string($avatarParent)
                 && is_string($avatarRootPrefix)
-                && str_starts_with($avatarPath, $avatarRootPrefix)
-                && is_file($avatarPath)
+                && str_starts_with(rtrim($avatarParent, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR, $avatarRootPrefix)
+                && (is_file($avatarCandidate) || is_link($avatarCandidate))
             ) {
-                xoops_remove_file_quietly($avatarPath, 'orphaned avatar');
+                xoops_remove_file_quietly($avatarCandidate, 'orphaned avatar');
             }
             //clean avatar table
             $this->db->exec('DELETE FROM ' . $this->db->prefix('avatar') . ' WHERE avatar_id=' . $avatarId);

--- a/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
@@ -345,10 +345,16 @@ class SystemMaintenanceTest extends KernelTestCase
             }
             $path = $scratchAbs . '/' . $entry;
             if (is_file($path)) {
-                @unlink($path);
+                $this->assertTrue(
+                    unlink($path),
+                    'Could not clean up scratch-dir entry: ' . $path
+                );
             }
         }
-        @rmdir($scratchAbs);
+        $this->assertTrue(
+            rmdir($scratchAbs),
+            'Could not remove scratch dir: ' . $scratchAbs
+        );
     }
 
     /**
@@ -430,7 +436,9 @@ class SystemMaintenanceTest extends KernelTestCase
             $this->assertTrue($maintenance->CleanAvatar(), 'expected CleanAvatar() to report a clean sweep');
             $this->assertFileExists($outside, 'traversal target outside upload root must not be removed');
         } finally {
-            @unlink($outside);
+            if (file_exists($outside)) {
+                $this->assertTrue(unlink($outside), 'Could not clean up fixture: ' . $outside);
+            }
         }
     }
 
@@ -462,7 +470,9 @@ class SystemMaintenanceTest extends KernelTestCase
             $this->assertTrue($maintenance->CleanAvatar(), 'expected CleanAvatar() to report a clean sweep');
             $this->assertFileExists($outside, 'absolute-path fixture must not be removed by avatar cleanup');
         } finally {
-            @unlink($outside);
+            if (file_exists($outside)) {
+                $this->assertTrue(unlink($outside), 'Could not clean up fixture: ' . $outside);
+            }
         }
     }
 
@@ -559,9 +569,11 @@ class SystemMaintenanceTest extends KernelTestCase
             $this->assertTrue($maintenance->CleanAvatar(), 'expected CleanAvatar() to report a clean sweep');
             $this->assertFileExists($fixturePath, 'non-avatar file under uploads/ must not be removed');
         } finally {
-            @unlink($fixturePath);
-            if ($created) {
-                @rmdir($filesDir);
+            if (file_exists($fixturePath)) {
+                $this->assertTrue(unlink($fixturePath), 'Could not clean up fixture: ' . $fixturePath);
+            }
+            if ($created && is_dir($filesDir)) {
+                $this->assertTrue(rmdir($filesDir), 'Could not clean up files dir: ' . $filesDir);
             }
         }
     }

--- a/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
@@ -329,7 +329,9 @@ class SystemMaintenanceTest extends KernelTestCase
     }
 
     /**
-     * Recursively remove the per-test scratch directory.
+     * Remove the per-test scratch directory and the files directly under
+     * it. Fixtures are flat (single-level), so a single scandir + rmdir
+     * pass is sufficient — no recursive descent.
      */
     private function removeScratchDir(string $scratchRel): void
     {
@@ -364,7 +366,7 @@ class SystemMaintenanceTest extends KernelTestCase
     }
 
     #[Test]
-    public function cleanAvatarRemovesValidAvatarFileUnderUploadRoot(): void
+    public function testCleanAvatarRemovesValidAvatarFileUnderUploadRoot(): void
     {
         $scratchRel       = $this->avatarScratchRel();
         [$rel, $abs]      = $this->placeFixtureAvatar($scratchRel, 'foo.png');
@@ -379,7 +381,7 @@ class SystemMaintenanceTest extends KernelTestCase
 
         $maintenance = $this->createMaintenance($db);
         try {
-            $maintenance->CleanAvatar();
+            $this->assertTrue($maintenance->CleanAvatar(), 'expected CleanAvatar() to report a clean sweep');
             $this->assertFileDoesNotExist($abs, 'fixture avatar should have been removed');
         } finally {
             $this->removeScratchDir($scratchRel);
@@ -387,7 +389,7 @@ class SystemMaintenanceTest extends KernelTestCase
     }
 
     #[Test]
-    public function cleanAvatarSkipsTraversalPathButStillDeletesDbRow(): void
+    public function testCleanAvatarSkipsTraversalPathButStillDeletesDbRow(): void
     {
         // To meaningfully exercise the upload-root containment check the
         // fixture has to live at the location the traversal string
@@ -425,7 +427,7 @@ class SystemMaintenanceTest extends KernelTestCase
             $resolved = realpath(XOOPS_UPLOAD_PATH . '/' . $traversalRel);
             $this->assertSame(realpath($outside), $resolved, 'traversal must actually resolve to the fixture');
 
-            $maintenance->CleanAvatar();
+            $this->assertTrue($maintenance->CleanAvatar(), 'expected CleanAvatar() to report a clean sweep');
             $this->assertFileExists($outside, 'traversal target outside upload root must not be removed');
         } finally {
             @unlink($outside);
@@ -433,7 +435,7 @@ class SystemMaintenanceTest extends KernelTestCase
     }
 
     #[Test]
-    public function cleanAvatarSkipsAbsolutePathButStillDeletesDbRow(): void
+    public function testCleanAvatarSkipsAbsolutePathButStillDeletesDbRow(): void
     {
         // An absolute path stored in avatar_file should not allow the
         // cleanup to escape XOOPS_UPLOAD_PATH. Use a temp fixture rather
@@ -457,7 +459,7 @@ class SystemMaintenanceTest extends KernelTestCase
 
         $maintenance = $this->createMaintenance($db);
         try {
-            $maintenance->CleanAvatar();
+            $this->assertTrue($maintenance->CleanAvatar(), 'expected CleanAvatar() to report a clean sweep');
             $this->assertFileExists($outside, 'absolute-path fixture must not be removed by avatar cleanup');
         } finally {
             @unlink($outside);
@@ -465,7 +467,7 @@ class SystemMaintenanceTest extends KernelTestCase
     }
 
     #[Test]
-    public function cleanAvatarHandlesMissingFileAndStillDeletesDbRow(): void
+    public function testCleanAvatarHandlesMissingFileAndStillDeletesDbRow(): void
     {
         $db = $this->createMockDatabase();
         $this->stubAvatarSweep($db, [
@@ -476,11 +478,11 @@ class SystemMaintenanceTest extends KernelTestCase
         $db->expects($this->exactly(2))->method('exec')->willReturn(true);
 
         $maintenance = $this->createMaintenance($db);
-        $maintenance->CleanAvatar(); // assertion is the exec() call count
+        $this->assertTrue($maintenance->CleanAvatar(), 'expected CleanAvatar() to report a clean sweep');
     }
 
     #[Test]
-    public function cleanAvatarHandlesEmptyAvatarFileAndStillDeletesDbRow(): void
+    public function testCleanAvatarHandlesEmptyAvatarFileAndStillDeletesDbRow(): void
     {
         $db = $this->createMockDatabase();
         $this->stubAvatarSweep($db, [
@@ -489,11 +491,11 @@ class SystemMaintenanceTest extends KernelTestCase
         $db->expects($this->exactly(2))->method('exec')->willReturn(true);
 
         $maintenance = $this->createMaintenance($db);
-        $maintenance->CleanAvatar();
+        $this->assertTrue($maintenance->CleanAvatar(), 'expected CleanAvatar() to report a clean sweep');
     }
 
     #[Test]
-    public function cleanAvatarHandlesNullByteAvatarFileAndStillDeletesDbRow(): void
+    public function testCleanAvatarHandlesNullByteAvatarFileAndStillDeletesDbRow(): void
     {
         // On PHP 8+ dirname()/realpath()/is_file()/is_link() raise
         // ValueError when the argument contains "\0". CleanAvatar() must
@@ -508,11 +510,11 @@ class SystemMaintenanceTest extends KernelTestCase
         $db->expects($this->exactly(2))->method('exec')->willReturn(true);
 
         $maintenance = $this->createMaintenance($db);
-        $maintenance->CleanAvatar();
+        $this->assertTrue($maintenance->CleanAvatar(), 'expected CleanAvatar() to report a clean sweep');
     }
 
     #[Test]
-    public function cleanAvatarSkipsNonAvatarsSubdirUnderUploadRoot(): void
+    public function testCleanAvatarSkipsNonAvatarsSubdirUnderUploadRoot(): void
     {
         // Defence-in-depth: even an avatar_file value that points to a
         // legitimate path UNDER XOOPS_UPLOAD_PATH but OUTSIDE the
@@ -554,7 +556,7 @@ class SystemMaintenanceTest extends KernelTestCase
                 'fixture must be inside uploads/'
             );
 
-            $maintenance->CleanAvatar();
+            $this->assertTrue($maintenance->CleanAvatar(), 'expected CleanAvatar() to report a clean sweep');
             $this->assertFileExists($fixturePath, 'non-avatar file under uploads/ must not be removed');
         } finally {
             @unlink($fixturePath);
@@ -565,7 +567,7 @@ class SystemMaintenanceTest extends KernelTestCase
     }
 
     #[Test]
-    public function cleanAvatarNormalisesBackslashesInAvatarFile(): void
+    public function testCleanAvatarNormalisesBackslashesInAvatarFile(): void
     {
         // Windows-historic data may store 'avatars\foo.png'. The cleanup
         // should normalise it and remove the file under XOOPS_UPLOAD_PATH.
@@ -584,10 +586,34 @@ class SystemMaintenanceTest extends KernelTestCase
 
         $maintenance = $this->createMaintenance($db);
         try {
-            $maintenance->CleanAvatar();
+            $this->assertTrue($maintenance->CleanAvatar(), 'expected CleanAvatar() to report a clean sweep');
             $this->assertFileDoesNotExist($abs, 'backslash-normalised avatar should be removed');
         } finally {
             $this->removeScratchDir($scratchRel);
         }
+    }
+
+    #[Test]
+    public function testCleanAvatarReturnsFalseWhenAvatarDeleteFails(): void
+    {
+        // Locks in the boolean contract introduced for CleanAvatar(): a
+        // failing DELETE must surface as a `false` return so callers can
+        // distinguish a clean sweep from a partial one. The first exec()
+        // (per-row avatar DELETE) returns false; the second (trailing
+        // avatar_user_link cleanup) still returns true. Either failing
+        // alone is enough to flip the return value.
+        $db = $this->createMockDatabase();
+        $this->stubAvatarSweep($db, [
+            ['avatar_id' => 500, 'avatar_file' => ''],
+        ]);
+        $db->expects($this->exactly(2))
+            ->method('exec')
+            ->willReturnOnConsecutiveCalls(false, true);
+
+        $maintenance = $this->createMaintenance($db);
+        $this->assertFalse(
+            $maintenance->CleanAvatar(),
+            'CleanAvatar() must return false when any DELETE in the sweep fails'
+        );
     }
 }

--- a/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
@@ -343,7 +343,8 @@ class SystemMaintenanceTest extends KernelTestCase
     /**
      * Stub the database mock so $db->query() returns a sentinel result and
      * $db->fetchArray() yields the supplied avatar rows once, then false.
-     * Returns the mock for further expectations.
+     * The caller still holds the mock and can attach further expectations
+     * directly (this helper does not return it).
      */
     private function stubAvatarSweep($db, array $rows): void
     {
@@ -379,16 +380,23 @@ class SystemMaintenanceTest extends KernelTestCase
     #[Test]
     public function cleanAvatarSkipsTraversalPathButStillDeletesDbRow(): void
     {
-        // Place a real fixture OUTSIDE the upload root so a successful
-        // traversal would visibly remove it; the test asserts it survives.
-        $outside = sys_get_temp_dir() . '/xoops_avatar_traversal_target_' . uniqid() . '.png';
+        // To meaningfully exercise the upload-root containment check the
+        // fixture has to live at the location the traversal string
+        // ACTUALLY resolves to. dirname(realpath(XOOPS_UPLOAD_PATH)) is
+        // the parent of the upload root, so a fixture placed there is
+        // reachable via '../<basename>' relative to XOOPS_UPLOAD_PATH.
+        // Result:
+        //   - realpath() succeeds (the file exists at the parent dir)
+        //   - the prefix check rejects it (not under uploads/)
+        //   - the fixture survives — exercising the containment branch
+        // Without this setup, realpath() would just return false on a
+        // non-existent target and the test would pass for the wrong
+        // reason.
+        $uploadRoot = realpath(XOOPS_UPLOAD_PATH);
+        $this->assertIsString($uploadRoot, 'XOOPS_UPLOAD_PATH must resolve via realpath()');
+        $outside = dirname($uploadRoot) . DIRECTORY_SEPARATOR . 'xoops_avatar_traversal_target_' . uniqid() . '.png';
         file_put_contents($outside, 'must-not-be-removed');
-
-        // Compute the relative '../' path from XOOPS_UPLOAD_PATH that
-        // would resolve to $outside. Even if the relative form is not
-        // exact, realpath() will either resolve outside the upload root
-        // (rejected by the prefix check) or fail (also rejected).
-        $traversalRel = '../../' . basename($outside);
+        $traversalRel = '../' . basename($outside);
 
         $db = $this->createMockDatabase();
         $this->stubAvatarSweep($db, [
@@ -399,6 +407,13 @@ class SystemMaintenanceTest extends KernelTestCase
 
         $maintenance = $this->createMaintenance($db);
         try {
+            // Sanity: realpath of the traversal path resolves to the
+            // fixture (i.e. realpath() succeeds) — proving this test
+            // really exercises the prefix-check branch and not the
+            // realpath()-returns-false short-circuit.
+            $resolved = realpath(XOOPS_UPLOAD_PATH . '/' . $traversalRel);
+            $this->assertSame(realpath($outside), $resolved, 'traversal must actually resolve to the fixture');
+
             $maintenance->CleanAvatar();
             $this->assertFileExists($outside, 'traversal target outside upload root must not be removed');
         } finally {
@@ -410,20 +425,30 @@ class SystemMaintenanceTest extends KernelTestCase
     public function cleanAvatarSkipsAbsolutePathButStillDeletesDbRow(): void
     {
         // An absolute path stored in avatar_file should not allow the
-        // cleanup to escape XOOPS_UPLOAD_PATH. The ltrim('/') step in
-        // CleanAvatar() turns '/etc/hosts' into 'etc/hosts' which is
-        // then resolved relative to the upload root — and almost
-        // certainly does not exist. realpath() returns false → skipped.
+        // cleanup to escape XOOPS_UPLOAD_PATH. Use a temp fixture rather
+        // than hard-coding /etc/hosts so the test runs on every OS
+        // (Windows CI doesn't have /etc/hosts at the same location).
+        // The ltrim('/') step turns '/abs/path/foo.png' into
+        // 'abs/path/foo.png' which is then resolved relative to the
+        // upload root — typically to a non-existent path, so realpath()
+        // returns false and the cleanup is skipped.
+        $outside = tempnam(sys_get_temp_dir(), 'xoops_avatar_absolute_');
+        $this->assertNotFalse($outside, 'tempnam should succeed');
+        file_put_contents($outside, 'must-not-be-removed');
+
         $db = $this->createMockDatabase();
         $this->stubAvatarSweep($db, [
-            ['avatar_id' => 100, 'avatar_file' => '/etc/hosts'],
+            ['avatar_id' => 100, 'avatar_file' => $outside],
         ]);
         $db->expects($this->exactly(2))->method('exec')->willReturn(true);
 
         $maintenance = $this->createMaintenance($db);
-        $this->assertFileExists('/etc/hosts', 'pre-test sanity: /etc/hosts should exist');
-        $maintenance->CleanAvatar();
-        $this->assertFileExists('/etc/hosts', '/etc/hosts must not be removed by avatar cleanup');
+        try {
+            $maintenance->CleanAvatar();
+            $this->assertFileExists($outside, 'absolute-path fixture must not be removed by avatar cleanup');
+        } finally {
+            @unlink($outside);
+        }
     }
 
     #[Test]

--- a/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
@@ -480,6 +480,57 @@ class SystemMaintenanceTest extends KernelTestCase
     }
 
     #[Test]
+    public function cleanAvatarSkipsNonAvatarsSubdirUnderUploadRoot(): void
+    {
+        // Defence-in-depth: even an avatar_file value that points to a
+        // legitimate path UNDER XOOPS_UPLOAD_PATH but OUTSIDE the
+        // avatars/ subtree must not be removed by the avatar sweep.
+        // Place a fixture at uploads/files/<unique>.doc, set avatar_file
+        // to that path, verify the file survives.
+        $filesDir = XOOPS_UPLOAD_PATH . '/files';
+        $created  = false;
+        if (!is_dir($filesDir)) {
+            if (!mkdir($filesDir, 0755, true) && !is_dir($filesDir)) {
+                $this->fail('Could not create test files dir: ' . $filesDir);
+            }
+            $created = true;
+        }
+        $fixtureName = '_test_nonavatar_' . getmypid() . '_' . uniqid() . '.doc';
+        $fixturePath = $filesDir . '/' . $fixtureName;
+        file_put_contents($fixturePath, 'must-not-be-removed');
+        $rel = 'files/' . $fixtureName;
+
+        $db = $this->createMockDatabase();
+        $this->stubAvatarSweep($db, [
+            ['avatar_id' => 500, 'avatar_file' => $rel],
+        ]);
+        $db->expects($this->exactly(2))->method('exec')->willReturn(true);
+
+        $maintenance = $this->createMaintenance($db);
+        try {
+            // Sanity: the resolved path IS under uploads/ but NOT under
+            // uploads/avatars/, so the broad upload-root check would
+            // have allowed deletion. Asserting the resolution succeeds
+            // proves the test really exercises the narrow prefix branch.
+            $resolved = realpath($fixturePath);
+            $this->assertIsString($resolved, 'fixture should resolve');
+            $this->assertStringStartsWith(
+                rtrim((string) realpath(XOOPS_UPLOAD_PATH), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR,
+                $resolved,
+                'fixture must be inside uploads/'
+            );
+
+            $maintenance->CleanAvatar();
+            $this->assertFileExists($fixturePath, 'non-avatar file under uploads/ must not be removed');
+        } finally {
+            @unlink($fixturePath);
+            if ($created) {
+                @rmdir($filesDir);
+            }
+        }
+    }
+
+    #[Test]
     public function cleanAvatarNormalisesBackslashesInAvatarFile(): void
     {
         // Windows-historic data may store 'avatars\foo.png'. The cleanup

--- a/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
@@ -365,7 +365,7 @@ class SystemMaintenanceTest extends KernelTestCase
         ]);
         // exec() called twice: once for DELETE FROM avatar, once for the
         // avatar_user_link cleanup at the end of CleanAvatar().
-        $db->expects($this->exactly(2))->method('exec')->willReturn(1);
+        $db->expects($this->exactly(2))->method('exec')->willReturn(true);
 
         $maintenance = $this->createMaintenance($db);
         try {
@@ -395,7 +395,7 @@ class SystemMaintenanceTest extends KernelTestCase
             ['avatar_id' => 99, 'avatar_file' => $traversalRel],
         ]);
         // DB row + avatar_user_link cleanup still execute.
-        $db->expects($this->exactly(2))->method('exec')->willReturn(1);
+        $db->expects($this->exactly(2))->method('exec')->willReturn(true);
 
         $maintenance = $this->createMaintenance($db);
         try {
@@ -418,7 +418,7 @@ class SystemMaintenanceTest extends KernelTestCase
         $this->stubAvatarSweep($db, [
             ['avatar_id' => 100, 'avatar_file' => '/etc/hosts'],
         ]);
-        $db->expects($this->exactly(2))->method('exec')->willReturn(1);
+        $db->expects($this->exactly(2))->method('exec')->willReturn(true);
 
         $maintenance = $this->createMaintenance($db);
         $this->assertFileExists('/etc/hosts', 'pre-test sanity: /etc/hosts should exist');
@@ -435,7 +435,7 @@ class SystemMaintenanceTest extends KernelTestCase
             // return false. The DB row cleanup must still run.
             ['avatar_id' => 200, 'avatar_file' => 'avatars/nonexistent_' . uniqid() . '.png'],
         ]);
-        $db->expects($this->exactly(2))->method('exec')->willReturn(1);
+        $db->expects($this->exactly(2))->method('exec')->willReturn(true);
 
         $maintenance = $this->createMaintenance($db);
         $maintenance->CleanAvatar(); // assertion is the exec() call count
@@ -448,7 +448,7 @@ class SystemMaintenanceTest extends KernelTestCase
         $this->stubAvatarSweep($db, [
             ['avatar_id' => 300, 'avatar_file' => ''],
         ]);
-        $db->expects($this->exactly(2))->method('exec')->willReturn(1);
+        $db->expects($this->exactly(2))->method('exec')->willReturn(true);
 
         $maintenance = $this->createMaintenance($db);
         $maintenance->CleanAvatar();
@@ -470,7 +470,7 @@ class SystemMaintenanceTest extends KernelTestCase
         $this->stubAvatarSweep($db, [
             ['avatar_id' => 400, 'avatar_file' => $winRel],
         ]);
-        $db->expects($this->exactly(2))->method('exec')->willReturn(1);
+        $db->expects($this->exactly(2))->method('exec')->willReturn(true);
 
         $maintenance = $this->createMaintenance($db);
         try {

--- a/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
@@ -261,4 +261,223 @@ class SystemMaintenanceTest extends KernelTestCase
         // Invalid table still false from cache
         $this->assertFalse($method->invoke($maintenance, 'nonexistent'));
     }
+
+    // ---------------------------------------------------------------
+    // CleanAvatar() — orphan avatar file/row cleanup.
+    //
+    // The method scans the avatar table for custom-avatar rows whose
+    // owning user has been deleted, removes the on-disk file (when it
+    // is safely contained under XOOPS_UPLOAD_PATH), and deletes both
+    // the avatar row and any leftover avatar_user_link rows.
+    //
+    // These tests cover the path-traversal-safe resolution introduced
+    // when @unlink() was replaced by xoops_remove_file_quietly():
+    //   - happy path: avatars/<file> under XOOPS_UPLOAD_PATH is removed
+    //   - traversal / absolute / outside-root inputs are silently skipped
+    //   - the avatar DB row is deleted regardless of file-removal outcome
+    //   - empty avatar_file deletes the DB row and continues
+    //
+    // Filesystem fixtures live in a unique subdirectory under
+    // XOOPS_UPLOAD_PATH/avatars/ so the tests do not collide with each
+    // other or with anything else in the upload tree.
+    // ---------------------------------------------------------------
+
+    /**
+     * Returns the per-test scratch subdirectory under XOOPS_UPLOAD_PATH/avatars/.
+     * The path is RELATIVE to the upload root, formatted with forward slashes
+     * so it can be embedded in avatar_file values verbatim.
+     */
+    private function avatarScratchRel(): string
+    {
+        return 'avatars/_test_' . getmypid() . '_' . uniqid();
+    }
+
+    /**
+     * Build the absolute filesystem path that corresponds to a relative
+     * avatar_file value (e.g. 'avatars/foo.png').
+     */
+    private function uploadAbs(string $rel): string
+    {
+        return XOOPS_UPLOAD_PATH . '/' . $rel;
+    }
+
+    /**
+     * Create the scratch directory and place a fixture avatar file inside.
+     * Returns [$relPath, $absPath] where $relPath is what would be stored
+     * in the avatar_file column and $absPath is the on-disk location.
+     */
+    private function placeFixtureAvatar(string $scratchRel, string $filename): array
+    {
+        $scratchAbs = $this->uploadAbs($scratchRel);
+        if (!is_dir($scratchAbs) && !mkdir($scratchAbs, 0755, true) && !is_dir($scratchAbs)) {
+            $this->fail('Could not create test scratch dir: ' . $scratchAbs);
+        }
+        $absPath = $scratchAbs . '/' . $filename;
+        file_put_contents($absPath, 'fixture');
+        $relPath = $scratchRel . '/' . $filename;
+
+        return [$relPath, $absPath];
+    }
+
+    /**
+     * Recursively remove the per-test scratch directory.
+     */
+    private function removeScratchDir(string $scratchRel): void
+    {
+        $scratchAbs = $this->uploadAbs($scratchRel);
+        if (!is_dir($scratchAbs)) {
+            return;
+        }
+        foreach (scandir($scratchAbs) ?: [] as $entry) {
+            if ('.' === $entry || '..' === $entry) {
+                continue;
+            }
+            $path = $scratchAbs . '/' . $entry;
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+        @rmdir($scratchAbs);
+    }
+
+    /**
+     * Stub the database mock so $db->query() returns a sentinel result and
+     * $db->fetchArray() yields the supplied avatar rows once, then false.
+     * Returns the mock for further expectations.
+     */
+    private function stubAvatarSweep($db, array $rows): void
+    {
+        $db->method('query')->willReturn('mock_result');
+        $db->method('isResultSet')->willReturn(true);
+        $rows[] = false; // end-of-result sentinel
+        $db->method('fetchArray')->willReturnOnConsecutiveCalls(...$rows);
+    }
+
+    #[Test]
+    public function cleanAvatarRemovesValidAvatarFileUnderUploadRoot(): void
+    {
+        $scratchRel       = $this->avatarScratchRel();
+        [$rel, $abs]      = $this->placeFixtureAvatar($scratchRel, 'foo.png');
+
+        $db = $this->createMockDatabase();
+        $this->stubAvatarSweep($db, [
+            ['avatar_id' => 42, 'avatar_file' => $rel],
+        ]);
+        // exec() called twice: once for DELETE FROM avatar, once for the
+        // avatar_user_link cleanup at the end of CleanAvatar().
+        $db->expects($this->exactly(2))->method('exec')->willReturn(1);
+
+        $maintenance = $this->createMaintenance($db);
+        try {
+            $maintenance->CleanAvatar();
+            $this->assertFileDoesNotExist($abs, 'fixture avatar should have been removed');
+        } finally {
+            $this->removeScratchDir($scratchRel);
+        }
+    }
+
+    #[Test]
+    public function cleanAvatarSkipsTraversalPathButStillDeletesDbRow(): void
+    {
+        // Place a real fixture OUTSIDE the upload root so a successful
+        // traversal would visibly remove it; the test asserts it survives.
+        $outside = sys_get_temp_dir() . '/xoops_avatar_traversal_target_' . uniqid() . '.png';
+        file_put_contents($outside, 'must-not-be-removed');
+
+        // Compute the relative '../' path from XOOPS_UPLOAD_PATH that
+        // would resolve to $outside. Even if the relative form is not
+        // exact, realpath() will either resolve outside the upload root
+        // (rejected by the prefix check) or fail (also rejected).
+        $traversalRel = '../../' . basename($outside);
+
+        $db = $this->createMockDatabase();
+        $this->stubAvatarSweep($db, [
+            ['avatar_id' => 99, 'avatar_file' => $traversalRel],
+        ]);
+        // DB row + avatar_user_link cleanup still execute.
+        $db->expects($this->exactly(2))->method('exec')->willReturn(1);
+
+        $maintenance = $this->createMaintenance($db);
+        try {
+            $maintenance->CleanAvatar();
+            $this->assertFileExists($outside, 'traversal target outside upload root must not be removed');
+        } finally {
+            @unlink($outside);
+        }
+    }
+
+    #[Test]
+    public function cleanAvatarSkipsAbsolutePathButStillDeletesDbRow(): void
+    {
+        // An absolute path stored in avatar_file should not allow the
+        // cleanup to escape XOOPS_UPLOAD_PATH. The ltrim('/') step in
+        // CleanAvatar() turns '/etc/hosts' into 'etc/hosts' which is
+        // then resolved relative to the upload root — and almost
+        // certainly does not exist. realpath() returns false → skipped.
+        $db = $this->createMockDatabase();
+        $this->stubAvatarSweep($db, [
+            ['avatar_id' => 100, 'avatar_file' => '/etc/hosts'],
+        ]);
+        $db->expects($this->exactly(2))->method('exec')->willReturn(1);
+
+        $maintenance = $this->createMaintenance($db);
+        $this->assertFileExists('/etc/hosts', 'pre-test sanity: /etc/hosts should exist');
+        $maintenance->CleanAvatar();
+        $this->assertFileExists('/etc/hosts', '/etc/hosts must not be removed by avatar cleanup');
+    }
+
+    #[Test]
+    public function cleanAvatarHandlesMissingFileAndStillDeletesDbRow(): void
+    {
+        $db = $this->createMockDatabase();
+        $this->stubAvatarSweep($db, [
+            // File reference that does not exist on disk — realpath() will
+            // return false. The DB row cleanup must still run.
+            ['avatar_id' => 200, 'avatar_file' => 'avatars/nonexistent_' . uniqid() . '.png'],
+        ]);
+        $db->expects($this->exactly(2))->method('exec')->willReturn(1);
+
+        $maintenance = $this->createMaintenance($db);
+        $maintenance->CleanAvatar(); // assertion is the exec() call count
+    }
+
+    #[Test]
+    public function cleanAvatarHandlesEmptyAvatarFileAndStillDeletesDbRow(): void
+    {
+        $db = $this->createMockDatabase();
+        $this->stubAvatarSweep($db, [
+            ['avatar_id' => 300, 'avatar_file' => ''],
+        ]);
+        $db->expects($this->exactly(2))->method('exec')->willReturn(1);
+
+        $maintenance = $this->createMaintenance($db);
+        $maintenance->CleanAvatar();
+    }
+
+    #[Test]
+    public function cleanAvatarNormalisesBackslashesInAvatarFile(): void
+    {
+        // Windows-historic data may store 'avatars\foo.png'. The cleanup
+        // should normalise it and remove the file under XOOPS_UPLOAD_PATH.
+        $scratchRel       = $this->avatarScratchRel();
+        [$rel, $abs]      = $this->placeFixtureAvatar($scratchRel, 'win.png');
+        // Replace forward slashes with backslashes only in the segment
+        // separator, NOT inside the scratch directory name (it has '_'
+        // not '\\'). This is what a Windows-saved row looked like.
+        $winRel = str_replace('/', '\\', $rel);
+
+        $db = $this->createMockDatabase();
+        $this->stubAvatarSweep($db, [
+            ['avatar_id' => 400, 'avatar_file' => $winRel],
+        ]);
+        $db->expects($this->exactly(2))->method('exec')->willReturn(1);
+
+        $maintenance = $this->createMaintenance($db);
+        try {
+            $maintenance->CleanAvatar();
+            $this->assertFileDoesNotExist($abs, 'backslash-normalised avatar should be removed');
+        } finally {
+            $this->removeScratchDir($scratchRel);
+        }
+    }
 }

--- a/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
@@ -493,6 +493,25 @@ class SystemMaintenanceTest extends KernelTestCase
     }
 
     #[Test]
+    public function cleanAvatarHandlesNullByteAvatarFileAndStillDeletesDbRow(): void
+    {
+        // On PHP 8+ dirname()/realpath()/is_file()/is_link() raise
+        // ValueError when the argument contains "\0". CleanAvatar() must
+        // skip the filesystem work for such a row but still issue both
+        // DELETEs — the per-row avatar DELETE and the trailing
+        // avatar_user_link cleanup — so the malformed row doesn't block
+        // the rest of the sweep.
+        $db = $this->createMockDatabase();
+        $this->stubAvatarSweep($db, [
+            ['avatar_id' => 400, 'avatar_file' => "avatars/evil\0.png"],
+        ]);
+        $db->expects($this->exactly(2))->method('exec')->willReturn(true);
+
+        $maintenance = $this->createMaintenance($db);
+        $maintenance->CleanAvatar();
+    }
+
+    #[Test]
     public function cleanAvatarSkipsNonAvatarsSubdirUnderUploadRoot(): void
     {
         // Defence-in-depth: even an avatar_file value that points to a

--- a/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
+++ b/tests/unit/htdocs/modules/system/SystemMaintenanceTest.php
@@ -313,7 +313,16 @@ class SystemMaintenanceTest extends KernelTestCase
             $this->fail('Could not create test scratch dir: ' . $scratchAbs);
         }
         $absPath = $scratchAbs . '/' . $filename;
-        file_put_contents($absPath, 'fixture');
+        // Assert the fixture write actually succeeded with the expected
+        // byte count — otherwise a happy-path test could later "pass"
+        // because CleanAvatar() found no file to delete
+        // (assertFileDoesNotExist would succeed even though the cleanup
+        // never ran on a real fixture). Checking the byte count also
+        // catches partial-write failures, not just "false return".
+        $bytesWritten = file_put_contents($absPath, 'fixture');
+        $this->assertNotFalse($bytesWritten, 'Could not write fixture avatar: ' . $absPath);
+        $this->assertSame(strlen('fixture'), $bytesWritten);
+        $this->assertFileExists($absPath);
         $relPath = $scratchRel . '/' . $filename;
 
         return [$relPath, $absPath];
@@ -395,7 +404,9 @@ class SystemMaintenanceTest extends KernelTestCase
         $uploadRoot = realpath(XOOPS_UPLOAD_PATH);
         $this->assertIsString($uploadRoot, 'XOOPS_UPLOAD_PATH must resolve via realpath()');
         $outside = dirname($uploadRoot) . DIRECTORY_SEPARATOR . 'xoops_avatar_traversal_target_' . uniqid() . '.png';
-        file_put_contents($outside, 'must-not-be-removed');
+        $bytesWritten = file_put_contents($outside, 'must-not-be-removed');
+        $this->assertNotFalse($bytesWritten, 'Could not write traversal fixture: ' . $outside);
+        $this->assertSame(strlen('must-not-be-removed'), $bytesWritten);
         $traversalRel = '../' . basename($outside);
 
         $db = $this->createMockDatabase();
@@ -434,7 +445,9 @@ class SystemMaintenanceTest extends KernelTestCase
         // returns false and the cleanup is skipped.
         $outside = tempnam(sys_get_temp_dir(), 'xoops_avatar_absolute_');
         $this->assertNotFalse($outside, 'tempnam should succeed');
-        file_put_contents($outside, 'must-not-be-removed');
+        $bytesWritten = file_put_contents($outside, 'must-not-be-removed');
+        $this->assertNotFalse($bytesWritten, 'Could not write absolute-path fixture: ' . $outside);
+        $this->assertSame(strlen('must-not-be-removed'), $bytesWritten);
 
         $db = $this->createMockDatabase();
         $this->stubAvatarSweep($db, [
@@ -497,7 +510,9 @@ class SystemMaintenanceTest extends KernelTestCase
         }
         $fixtureName = '_test_nonavatar_' . getmypid() . '_' . uniqid() . '.doc';
         $fixturePath = $filesDir . '/' . $fixtureName;
-        file_put_contents($fixturePath, 'must-not-be-removed');
+        $bytesWritten = file_put_contents($fixturePath, 'must-not-be-removed');
+        $this->assertNotFalse($bytesWritten, 'Could not write non-avatar fixture: ' . $fixturePath);
+        $this->assertSame(strlen('must-not-be-removed'), $bytesWritten);
         $rel = 'files/' . $fixtureName;
 
         $db = $this->createMockDatabase();


### PR DESCRIPTION
Changes:
cp_functions.php:
        + xoops_remove_file_quietly($path, $context): new helper for best-effort file removal. Skips non-existent paths, suppresses the unlink warning via
   a SCOPED error_reporting() toggle (no @ operator) wrapped in try/finally, and re-checks file_exists() after a failed unlink — only logging when the
  file is still present so TOCTOU races resolve silently. Uses xoops_file_label() for non-sensitive path labels in warnings.
        - 9 @unlink cleanup sites replaced with the helper.
        - @chmod($tempFile, $perms) replaced with checked chmod() that logs on failure but continues (content is already written).

modules/system/class/maintenance.php:
        + Explicit `require_once .../include/cp_functions.php` so SystemMaintenance is self-sufficient regardless of which caller (admin, install,
  modulesadmin, preferences) loads it.
        - 6 atomic-write @unlink cleanup sites replaced with the helper.
        - @chmod replaced with checked + warn (mirrors cp_functions.php).
        - cleanOrphanedAvatars(): @unlink replaced with the helper plus a path-traversal-safe resolution. Avatar rows store 'avatars/<filename>'
  (kernel/avatar.php and 14 admin/profile writers), so basename() would have stripped the directory and silently bypassed all orphan cleanup. The new form
   normalises backslashes, strips leading slashes, resolves via realpath() with upload-root containment, and confirms is_file() before removal. The DB row
   cleanup runs unconditionally.

Intentionally retained:
      - The 7 @rename(...) calls inside `if (!...)` checks. These are the core atomic-move operations; the boolean return is already detected and reported
   via trigger_error(). Removing the @ would let PHP's native warning fire alongside our diagnostic, double-reporting one event into display_errors
  output. Comment block in each file documents the rationale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filesystem safety helpers for quieter removal/chmod and safer path handling.

* **Bug Fixes**
  * More reliable atomic file writes with quieter error handling, non-fatal permission attempts, and dependable temporary/backup cleanup and restore.
  * Hardened avatar cleanup: path normalization, strict resolved-path validation, and best-effort quiet deletion while still cleaning related database links.
  * Maintenance now reliably loads required file-safety routines.

* **Tests**
  * Added unit tests covering avatar cleanup, path traversal, missing files, null-byte and Windows-style paths.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XOOPS/XoopsCore27/pull/52)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->