### PR TITLE
test(file-safety): pin null-byte contract for cleanup helpers

### DIFF
--- a/tests/unit/htdocs/include/FileSafetyTest.php
+++ b/tests/unit/htdocs/include/FileSafetyTest.php
@@ -50,13 +50,15 @@ class FileSafetyTest extends TestCase
         // local error handler instead of the @ operator to swallow the
         // warning — this codebase forbids @-suppression and we want to
         // assert the warning still fires.
-        $captured = null;
-        set_error_handler(static function (int $level, string $msg) use (&$captured): bool {
+        $captured            = [];
+        $unexpectedWarnings  = [];
+        set_error_handler(static function (int $level, string $msg) use (&$captured, &$unexpectedWarnings): bool {
             if (E_USER_WARNING === $level) {
-                $captured = $msg;
+                $captured[] = $msg;
                 return true;
             }
-            return false;
+            $unexpectedWarnings[] = [$level, $msg];
+            return true;
         });
 
         try {
@@ -66,16 +68,18 @@ class FileSafetyTest extends TestCase
         }
 
         $this->assertFalse($result, 'chmod on a null-byte path must report failure');
-        $this->assertNotNull($captured, 'helper must still emit one E_USER_WARNING on failure');
-        $this->assertStringContainsString('invalid-path', (string) $captured);
+        $this->assertSame([], $unexpectedWarnings, 'native chmod warnings must be suppressed');
+        $this->assertCount(1, $captured, 'helper must emit exactly one E_USER_WARNING on failure');
+        $this->assertStringContainsString('invalid-path', $captured[0]);
     }
 
     public function testXoopsRemoveFileQuietlyDoesNotPropagateOnNullBytePath(): void
     {
-        // The pre-check file_exists() / is_link() does not throw on a
-        // "\0"-bearing path in PHP 8.2-8.4 (it returns false), so the
-        // helper returns early without ever reaching unlink(). The
-        // contract being tested is just "no exception escapes".
+        // The pre-check file_exists() / is_link() may return false or
+        // throw for a "\0"-bearing path depending on PHP/runtime
+        // behavior. The helper wraps both in catch(\Throwable) for
+        // forward-compat and userland error handlers that may throw.
+        // The contract being tested is simply that no exception escapes.
         xoops_remove_file_quietly("bad\0path");
         $this->assertTrue(true, 'xoops_remove_file_quietly returned without throwing');
     }

--- a/tests/unit/htdocs/include/FileSafetyTest.php
+++ b/tests/unit/htdocs/include/FileSafetyTest.php
@@ -7,13 +7,15 @@ use PHPUnit\Framework\TestCase;
 require_once XOOPS_ROOT_PATH . '/include/file_safety.php';
 
 /**
- * Coverage for the three side-effect-free file helpers in
- * htdocs/include/file_safety.php. The helpers are documented as
- * best-effort / non-propagating: on any failure they emit a single
- * E_USER_WARNING (or return early) and continue. These tests pin that
- * contract specifically against null-byte payloads, which trigger
- * ValueError in the underlying filesystem calls on PHP 8+ — the case
- * that motivated the explicit catch(\Throwable) wrappers and the
+ * Coverage for the four file-safety helpers in
+ * htdocs/include/file_safety.php: xoops_safe_basename(),
+ * xoops_chmod_quietly(), xoops_remove_file_quietly(), and
+ * xoops_file_label(). The first three are documented as best-effort /
+ * non-propagating: on any failure they emit a single E_USER_WARNING
+ * (or return early) and continue. These tests pin that contract
+ * specifically against null-byte payloads, which trigger ValueError
+ * in the underlying filesystem calls on PHP 8+ — the case that
+ * motivated the explicit catch(\Throwable) wrappers and the
  * xoops_safe_basename() defensive shape.
  */
 class FileSafetyTest extends TestCase
@@ -115,6 +117,14 @@ class FileSafetyTest extends TestCase
         // strip-prefix branch and the basename fallback.
         $absUnderRoot = rtrim(XOOPS_ROOT_PATH, '/\\') . '/uploads/foo.png';
         $this->assertSame('uploads/foo.png', xoops_file_label($absUnderRoot));
+
+        // Backslash separators under XOOPS_ROOT_PATH must collapse to
+        // forward slashes so the relative label looks the same on
+        // Windows and *nix. The outside-root branch falls through to
+        // basename(), which is platform-dependent on '\\' — not
+        // asserted here.
+        $absUnderRootBackslash = rtrim(str_replace('/', '\\', XOOPS_ROOT_PATH), '\\') . '\\uploads\\bar.png';
+        $this->assertSame('uploads/bar.png', xoops_file_label($absUnderRootBackslash));
 
         $absOutside = sys_get_temp_dir() . '/foo.png';
         $this->assertSame('foo.png', xoops_file_label($absOutside));

--- a/tests/unit/htdocs/include/FileSafetyTest.php
+++ b/tests/unit/htdocs/include/FileSafetyTest.php
@@ -10,13 +10,17 @@ require_once XOOPS_ROOT_PATH . '/include/file_safety.php';
  * Coverage for the four file-safety helpers in
  * htdocs/include/file_safety.php: xoops_safe_basename(),
  * xoops_chmod_quietly(), xoops_remove_file_quietly(), and
- * xoops_file_label(). The first three are documented as best-effort /
- * non-propagating: on any failure they emit a single E_USER_WARNING
- * (or return early) and continue. These tests pin that contract
- * specifically against null-byte payloads, which trigger ValueError
- * in the underlying filesystem calls on PHP 8+ — the case that
- * motivated the explicit catch(\Throwable) wrappers and the
- * xoops_safe_basename() defensive shape.
+ * xoops_file_label(). These helpers are tested as defensive /
+ * non-propagating, but with different failure contracts:
+ * xoops_safe_basename() returns a fixed placeholder for invalid
+ * paths, while xoops_chmod_quietly() and
+ * xoops_remove_file_quietly() may either emit a single
+ * E_USER_WARNING or return without warning for guarded / no-op
+ * cases. These tests pin that behavior specifically against
+ * null-byte payloads, which trigger ValueError in underlying
+ * filesystem calls on PHP 8+ and motivated the explicit
+ * catch(\Throwable) wrappers and xoops_safe_basename()'s
+ * defensive shape.
  */
 class FileSafetyTest extends TestCase
 {

--- a/tests/unit/htdocs/include/FileSafetyTest.php
+++ b/tests/unit/htdocs/include/FileSafetyTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once XOOPS_ROOT_PATH . '/include/file_safety.php';
+
+/**
+ * Coverage for the three side-effect-free file helpers in
+ * htdocs/include/file_safety.php. The helpers are documented as
+ * best-effort / non-propagating: on any failure they emit a single
+ * E_USER_WARNING (or return early) and continue. These tests pin that
+ * contract specifically against null-byte payloads, which trigger
+ * ValueError in the underlying filesystem calls on PHP 8+ — the case
+ * that motivated the explicit catch(\Throwable) wrappers and the
+ * xoops_safe_basename() defensive shape.
+ */
+class FileSafetyTest extends TestCase
+{
+    public function testXoopsSafeBasenameReturnsPlaceholderForNullBytePath(): void
+    {
+        $this->assertSame(
+            'invalid-path',
+            xoops_safe_basename("bad\0path"),
+            'null-byte payload must collapse to the fixed placeholder'
+        );
+    }
+
+    public function testXoopsSafeBasenameNormalisesBackslashes(): void
+    {
+        $this->assertSame(
+            'foo.png',
+            xoops_safe_basename('avatars\\sub\\foo.png'),
+            'Windows-style separators must be normalised before basename()'
+        );
+    }
+
+    public function testXoopsSafeBasenamePassesThroughOrdinaryPath(): void
+    {
+        $this->assertSame('foo.png', xoops_safe_basename('avatars/foo.png'));
+    }
+
+    public function testXoopsChmodQuietlyDoesNotPropagateOnNullBytePath(): void
+    {
+        // chmod() raises ValueError on PHP 8+ when its $filename
+        // argument contains "\0". xoops_chmod_quietly() must catch that
+        // and report failure via its boolean return + a single
+        // E_USER_WARNING, never letting the exception escape. Use a
+        // local error handler instead of the @ operator to swallow the
+        // warning — this codebase forbids @-suppression and we want to
+        // assert the warning still fires.
+        $captured = null;
+        set_error_handler(static function (int $level, string $msg) use (&$captured): bool {
+            if (E_USER_WARNING === $level) {
+                $captured = $msg;
+                return true;
+            }
+            return false;
+        });
+
+        try {
+            $result = xoops_chmod_quietly("bad\0path", 0644, 'test');
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertFalse($result, 'chmod on a null-byte path must report failure');
+        $this->assertNotNull($captured, 'helper must still emit one E_USER_WARNING on failure');
+        $this->assertStringContainsString('invalid-path', (string) $captured);
+    }
+
+    public function testXoopsRemoveFileQuietlyDoesNotPropagateOnNullBytePath(): void
+    {
+        // The pre-check file_exists() / is_link() does not throw on a
+        // "\0"-bearing path in PHP 8.2-8.4 (it returns false), so the
+        // helper returns early without ever reaching unlink(). The
+        // contract being tested is just "no exception escapes".
+        xoops_remove_file_quietly("bad\0path");
+        $this->assertTrue(true, 'xoops_remove_file_quietly returned without throwing');
+    }
+
+    public function testXoopsRemoveFileQuietlyIsNoOpForMissingPath(): void
+    {
+        // A non-existent path must NOT emit a warning — only paths that
+        // still exist after a failed unlink() should. Wire up an error
+        // handler to assert no E_USER_WARNING fires.
+        $warningFired = false;
+        set_error_handler(static function (int $level) use (&$warningFired): bool {
+            if (E_USER_WARNING === $level) {
+                $warningFired = true;
+                return true;
+            }
+            return false;
+        });
+
+        try {
+            xoops_remove_file_quietly(sys_get_temp_dir() . '/xoops_definitely_missing_' . uniqid() . '.tmp');
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertFalse($warningFired, 'no warning should fire for an already-absent path');
+    }
+
+    public function testXoopsFileLabelStripsXoopsRootPrefix(): void
+    {
+        // xoops_file_label() keeps install-relative context (unlike
+        // xoops_safe_basename()) for atomic-write call sites that
+        // benefit from knowing WHICH file failed. Spot-check the
+        // strip-prefix branch and the basename fallback.
+        $absUnderRoot = rtrim(XOOPS_ROOT_PATH, '/\\') . '/uploads/foo.png';
+        $this->assertSame('uploads/foo.png', xoops_file_label($absUnderRoot));
+
+        $absOutside = sys_get_temp_dir() . '/foo.png';
+        $this->assertSame('foo.png', xoops_file_label($absOutside));
+    }
+}

--- a/tests/unit/htdocs/include/FileSafetyTest.php
+++ b/tests/unit/htdocs/include/FileSafetyTest.php
@@ -82,8 +82,8 @@ class FileSafetyTest extends TestCase
         // behavior. The helper wraps both in catch(\Throwable) for
         // forward-compat and userland error handlers that may throw.
         // The contract being tested is simply that no exception escapes.
+        $this->expectNotToPerformAssertions();
         xoops_remove_file_quietly("bad\0path");
-        $this->assertTrue(true, 'xoops_remove_file_quietly returned without throwing');
     }
 
     public function testXoopsRemoveFileQuietlyIsNoOpForMissingPath(): void
@@ -101,7 +101,9 @@ class FileSafetyTest extends TestCase
         });
 
         try {
-            xoops_remove_file_quietly(sys_get_temp_dir() . '/xoops_definitely_missing_' . uniqid() . '.tmp');
+            xoops_remove_file_quietly(
+                sys_get_temp_dir() . '/xoops_definitely_missing_' . bin2hex(random_bytes(16)) . '.tmp'
+            );
         } finally {
             restore_error_handler();
         }


### PR DESCRIPTION
  Covers the three helpers in htdocs/include/file_safety.php -
  xoops_safe_basename(), xoops_chmod_quietly(), xoops_remove_file_quietly() -
  against the null-byte case that motivated the defensive shape: basename()
  does not throw on "\0" in PHP 8.2-8.4 but chmod()/unlink() do, and the
  helpers must collapse both into a single E_USER_WARNING without propagating
  ValueError. Also pins the backslash-normalisation and XOOPS_ROOT_PATH
  stripping branches of xoops_file_label().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests to verify file-safety behaviors: null-byte paths collapse to a placeholder, Windows backslashes are normalized, ordinary forward-slash paths pass through unchanged, quiet permission change returns false and emits a single warning for invalid paths, quiet file removal does not throw and is a no-op for missing files, and file labels strip the root-prefix while preserving install-relative paths.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XOOPS/XoopsCore27/pull/53)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XOOPS/XoopsCore27/pull/53)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->