### PR TITLE
fix(installer): guard optional function calls that fatal on PHP 8.2

### DIFF
--- a/htdocs/install/page_modcheck.php
+++ b/htdocs/install/page_modcheck.php
@@ -59,7 +59,7 @@ ob_start();
 
         <tr>
             <th><?php printf(PHP_EXTENSION, 'MySQLi'); ?></th>
-            <td><?php echo xoDiag(function_exists('mysqli_connect') ? 1 : -1, @mysqli_get_client_info()); ?></td>
+            <td><?php echo xoDiag(function_exists('mysqli_connect') ? 1 : -1, function_exists('mysqli_get_client_info') ? @mysqli_get_client_info() : ''); ?></td>
         </tr>
 
         <tr>

--- a/htdocs/install/page_modcheck.php
+++ b/htdocs/install/page_modcheck.php
@@ -59,7 +59,7 @@ ob_start();
 
         <tr>
             <th><?php printf(PHP_EXTENSION, 'MySQLi'); ?></th>
-            <td><?php echo xoDiag(function_exists('mysqli_connect') ? 1 : -1, function_exists('mysqli_get_client_info') ? @mysqli_get_client_info() : ''); ?></td>
+            <td><?php echo xoDiag(function_exists('mysqli_connect') ? 1 : -1, function_exists('mysqli_get_client_info') ? mysqli_get_client_info() : ''); ?></td>
         </tr>
 
         <tr>

--- a/htdocs/xoops_lib/modules/protector/class/protector.php
+++ b/htdocs/xoops_lib/modules/protector/class/protector.php
@@ -62,7 +62,8 @@ class Protector
         $this->mydirname = 'protector';
 
         // Preferences from configs/cache
-        $this->_conf_serialized = @file_get_contents($this->get_filepath4confighcache());
+        $confcache = $this->get_filepath4confighcache();
+        $this->_conf_serialized = is_file($confcache) ? (string)file_get_contents($confcache) : '';
         $this->_conf            = @unserialize($this->_conf_serialized, ['allowed_classes' => false]);
         if (empty($this->_conf)) {
             $this->_conf = [];


### PR DESCRIPTION
Two unrelated installer-time crashes share the same root cause: PHP's @ operator does not suppress 'undefined function' fatal errors, and XOOPS's custom error handler ignores @ for warnings, so both spots logged or fataled on environments where the called function or backing file was absent.

- install/page_modcheck.php: @mysqli_get_client_info() crashed the requirements page when the mysqli extension was not loaded, hiding the very diagnostic meant to surface that condition. Guard with function_exists() and pass an empty info string when missing; xoDiag() still reports MySQLi as missing via the existing function_exists('mysqli_connect') flag.

- xoops_lib/modules/protector/class/protector.php: the constructor read its configcache via @file_get_contents() before the cache was ever written. On a fresh install the cache file does not exist until postcheck_functions.php calls updateConfFromDb(), and every page in between logged a warning to log.txt because XoopsLogger's error handler does not honour @. Guard with is_file() and treat a missing cache as an empty serialized payload; subsequent unserialize/empty checks already handle that shape.

Reported against PHP 8.2.31 / MySQL 5.7.44 / Apache 2.4.66 on Windows during 2.7.0 install testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of installer requirements detection.
  * Enhanced stability of system configuration loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XOOPS/XoopsCore27/pull/60)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->