### PR TITLE
Fix/installer required extensions gate

### DIFF
--- a/docs/lang_diff.txt
+++ b/docs/lang_diff.txt
@@ -6,6 +6,10 @@ Below are language differences from a version to next version.
 ================================
 2025/03/30: Version 2.7.0-Betas (previously released as 2.5.12-Betas)
 ================================
+/htdocs/install/language/english/install.php
+- added define('MISSING_REQUIRED_EXTENSIONS', 'Required PHP extensions are missing');
+- added define('MISSING_REQUIRED_EXTENSIONS_MSG', 'XOOPS cannot be installed because the following mandatory PHP extension(s) are not available: %s. Enable them in your PHP configuration (php.ini) and restart your web server, then reload this page.');
+
 /htdocs/modules/system/language/english/admin.php
 - added define('_AM_SYSTEM_MENUS', 'Menus');
 - added define('_AM_SYSTEM_MENUS_DESC', 'Manage site navigation menus');

--- a/htdocs/install/include/config.php
+++ b/htdocs/install/include/config.php
@@ -80,10 +80,14 @@ $configs['extensions'] = [
 // Mandatory extensions — installation cannot proceed without these.
 // Keyed by extension name; value is the human-readable label shown on the
 // requirements page. mysqli has no fallback driver, so a missing entry here
-// would otherwise fatal later in the DB-connection step.
+// would otherwise fatal later in the DB-connection step; the others are core
+// extensions with no polyfill. mbstring is intentionally NOT listed: the
+// installer autoloads symfony/polyfill-mbstring (via common.inc.php), so the
+// mb_* functions remain available even without the extension — gating on
+// extension_loaded('mbstring') would wrongly block a working install. It
+// stays in the recommended-extensions list below.
 $configs['extensions_required'] = [
     'mysqli'   => 'MySQLi',
-    'mbstring' => 'MBString',
     'session'  => 'Session',
     'pcre'     => 'PCRE',
     'filter'   => 'filter',

--- a/htdocs/install/include/config.php
+++ b/htdocs/install/include/config.php
@@ -86,12 +86,18 @@ $configs['extensions'] = [
 // mb_* functions remain available even without the extension — gating on
 // extension_loaded('mbstring') would wrongly block a working install. It
 // stays in the recommended-extensions list below.
+//
+// Each entry is [human-readable label, [symbols that must also exist]]. The
+// symbol list is the single source of truth shared by the requirements-page
+// gate and the server-side DB guard, so both apply identical rules: a
+// partial build that reports mysqli loaded but lacks mysqli_report()/the
+// mysqli class is treated as missing in both places.
 $configs['extensions_required'] = [
-    'mysqli'   => 'MySQLi',
-    'session'  => 'Session',
-    'pcre'     => 'PCRE',
-    'filter'   => 'filter',
-    'fileinfo' => 'fileinfo',
+    'mysqli'   => ['MySQLi', ['mysqli_report', 'mysqli']],
+    'session'  => ['Session', []],
+    'pcre'     => ['PCRE', []],
+    'filter'   => ['filter', []],
+    'fileinfo' => ['fileinfo', []],
 ];
 
 // Writable files and directories

--- a/htdocs/install/include/config.php
+++ b/htdocs/install/include/config.php
@@ -77,6 +77,19 @@ $configs['extensions'] = [
     ],
 ];
 
+// Mandatory extensions — installation cannot proceed without these.
+// Keyed by extension name; value is the human-readable label shown on the
+// requirements page. mysqli has no fallback driver, so a missing entry here
+// would otherwise fatal later in the DB-connection step.
+$configs['extensions_required'] = [
+    'mysqli'   => 'MySQLi',
+    'mbstring' => 'MBString',
+    'session'  => 'Session',
+    'pcre'     => 'PCRE',
+    'filter'   => 'filter',
+    'fileinfo' => 'fileinfo',
+];
+
 // Writable files and directories
 $configs['writable'] = [
     'uploads/',

--- a/htdocs/install/include/config.php
+++ b/htdocs/install/include/config.php
@@ -78,20 +78,20 @@ $configs['extensions'] = [
 ];
 
 // Mandatory extensions — installation cannot proceed without these.
-// Keyed by extension name; value is the human-readable label shown on the
-// requirements page. mysqli has no fallback driver, so a missing entry here
-// would otherwise fatal later in the DB-connection step; the others are core
-// extensions with no polyfill. mbstring is intentionally NOT listed: the
-// installer autoloads symfony/polyfill-mbstring (via common.inc.php), so the
-// mb_* functions remain available even without the extension — gating on
+// Keyed by extension name; each value is a tuple
+// [human-readable label, [symbols that must also exist]]. mysqli has no
+// fallback driver, so a missing entry here would otherwise fatal later in
+// the DB-connection step; the others are core extensions with no polyfill.
+// mbstring is intentionally NOT listed: the installer autoloads
+// symfony/polyfill-mbstring (via common.inc.php), so the mb_* functions
+// remain available even without the extension — gating on
 // extension_loaded('mbstring') would wrongly block a working install. It
 // stays in the recommended-extensions list below.
 //
-// Each entry is [human-readable label, [symbols that must also exist]]. The
-// symbol list is the single source of truth shared by the requirements-page
-// gate and the server-side DB guard, so both apply identical rules: a
-// partial build that reports mysqli loaded but lacks mysqli_report()/the
-// mysqli class is treated as missing in both places.
+// The symbol list is the single source of truth shared by the
+// requirements-page gate and the server-side guards, so both apply
+// identical rules: a partial build that reports mysqli loaded but lacks
+// mysqli_report()/the mysqli class is treated as missing in both places.
 $configs['extensions_required'] = [
     'mysqli'   => ['MySQLi', ['mysqli_report', 'mysqli']],
     'session'  => ['Session', []],

--- a/htdocs/install/include/functions.php
+++ b/htdocs/install/include/functions.php
@@ -269,7 +269,7 @@ function xoPhpVersion()
  *
  * @return bool
  */
-function xoInstallerExtensionAvailable($ext, array $symbols = [])
+function xoInstallerExtensionAvailable(string $ext, array $symbols = []): bool
 {
     if (!extension_loaded($ext)) {
         return false;
@@ -285,6 +285,29 @@ function xoInstallerExtensionAvailable($ext, array $symbols = [])
 }
 
 /**
+ * Labels of the mandatory extensions that are not usable.
+ *
+ * Single source of truth shared by the requirements-page gate and the
+ * server-side guards on later pages, so every entry point applies the same
+ * rule against $configs['extensions_required'] (label + required symbols).
+ *
+ * @param XoopsInstallWizard $wizard
+ *
+ * @return string[] human-readable labels of missing extensions (empty = ok)
+ */
+function xoInstallerMissingRequired($wizard): array
+{
+    $missing = [];
+    foreach ($wizard->configs['extensions_required'] as $ext => $info) {
+        [$label, $symbols] = $info;
+        if (!xoInstallerExtensionAvailable($ext, $symbols)) {
+            $missing[] = $label;
+        }
+    }
+    return $missing;
+}
+
+/**
  * Build the "mandatory extension missing" alert markup.
  *
  * Returned (not echoed) so the caller can assign it to $content and render it
@@ -294,7 +317,7 @@ function xoInstallerExtensionAvailable($ext, array $symbols = [])
  *
  * @return string
  */
-function xoInstallerBlockedHtml($label)
+function xoInstallerBlockedHtml(string $label): string
 {
     return '<div class="alert alert-danger" role="alert">'
         . '<h4 class="alert-heading"><span class="fa-solid fa-ban"></span> ' . MISSING_REQUIRED_EXTENSIONS . '</h4>'

--- a/htdocs/install/include/functions.php
+++ b/htdocs/install/include/functions.php
@@ -257,51 +257,50 @@ function xoPhpVersion()
 }
 
 /**
- * Halt the installer with a clear message when a mandatory extension that has
- * no fallback driver is unavailable.
+ * Whether a mandatory extension is usable.
  *
- * The requirements page already blocks the Next button, but that gate is
- * client-side and bypassable (direct URL, stale session). Without this guard
- * the database steps call mysqli_*() unconditionally and fatal with
- * "Call to undefined function" on a PHP build lacking the extension. Renders
- * the standard installer chrome with the blocked-requirements alert and exits.
+ * For extensions with no fallback driver (e.g. mysqli) a plain
+ * extension_loaded() is enough, but a partial/unusual build can report the
+ * extension loaded while a specific symbol the caller needs (e.g.
+ * mysqli_report) is absent — so optional functions/classes are verified too.
  *
- * @param XoopsInstallWizard $wizard
- * @param string             $ext     extension name (e.g. 'mysqli')
- * @param string             $label   human-readable label (e.g. 'MySQLi')
- * @param string[]           $symbols functions/classes that must also exist;
- *                                    catches partial builds where the
- *                                    extension reports loaded but a symbol
- *                                    the caller uses (e.g. mysqli_report) is
- *                                    not actually available
+ * @param string   $ext     extension name (e.g. 'mysqli')
+ * @param string[] $symbols functions/classes that must also exist
  *
- * @return void
+ * @return bool
  */
-function xoInstallerRequireExtension($wizard, $ext, $label, array $symbols = [])
+function xoInstallerExtensionAvailable($ext, array $symbols = [])
 {
-    $available = extension_loaded($ext);
-    if ($available) {
-        foreach ($symbols as $symbol) {
-            if (!function_exists($symbol) && !class_exists($symbol)) {
-                $available = false;
-                break;
-            }
+    if (!extension_loaded($ext)) {
+        return false;
+    }
+    foreach ($symbols as $symbol) {
+        // class_exists(.., false): don't trigger the autoloader during the
+        // install bootstrap just to probe for an internal extension class.
+        if (!function_exists($symbol) && !class_exists($symbol, false)) {
+            return false;
         }
     }
-    if ($available) {
-        return;
-    }
-    $blockNext = true;
-    ob_start();
-    ?>
-    <div class="alert alert-danger" role="alert">
-        <h4 class="alert-heading"><span class="fa-solid fa-ban"></span> <?php echo MISSING_REQUIRED_EXTENSIONS; ?></h4>
-        <p class="mb-0"><?php echo htmlspecialchars(sprintf(MISSING_REQUIRED_EXTENSIONS_MSG, $label), ENT_QUOTES | ENT_HTML5); ?></p>
-    </div>
-    <?php
-    $content = ob_get_clean();
-    include __DIR__ . '/install_tpl.php';
-    exit;
+    return true;
+}
+
+/**
+ * Build the "mandatory extension missing" alert markup.
+ *
+ * Returned (not echoed) so the caller can assign it to $content and render it
+ * through the standard installer chrome at file scope.
+ *
+ * @param string $label human-readable extension label (e.g. 'MySQLi')
+ *
+ * @return string
+ */
+function xoInstallerBlockedHtml($label)
+{
+    return '<div class="alert alert-danger" role="alert">'
+        . '<h4 class="alert-heading"><span class="fa-solid fa-ban"></span> ' . MISSING_REQUIRED_EXTENSIONS . '</h4>'
+        . '<p class="mb-0">'
+        . htmlspecialchars(sprintf(MISSING_REQUIRED_EXTENSIONS_MSG, $label), ENT_QUOTES | ENT_HTML5)
+        . '</p></div>';
 }
 
 /**

--- a/htdocs/install/include/functions.php
+++ b/htdocs/install/include/functions.php
@@ -267,14 +267,28 @@ function xoPhpVersion()
  * the standard installer chrome with the blocked-requirements alert and exits.
  *
  * @param XoopsInstallWizard $wizard
- * @param string             $ext    extension name (e.g. 'mysqli')
- * @param string             $label  human-readable label (e.g. 'MySQLi')
+ * @param string             $ext     extension name (e.g. 'mysqli')
+ * @param string             $label   human-readable label (e.g. 'MySQLi')
+ * @param string[]           $symbols functions/classes that must also exist;
+ *                                    catches partial builds where the
+ *                                    extension reports loaded but a symbol
+ *                                    the caller uses (e.g. mysqli_report) is
+ *                                    not actually available
  *
  * @return void
  */
-function xoInstallerRequireExtension($wizard, $ext, $label)
+function xoInstallerRequireExtension($wizard, $ext, $label, array $symbols = [])
 {
-    if (extension_loaded($ext)) {
+    $available = extension_loaded($ext);
+    if ($available) {
+        foreach ($symbols as $symbol) {
+            if (!function_exists($symbol) && !class_exists($symbol)) {
+                $available = false;
+                break;
+            }
+        }
+    }
+    if ($available) {
         return;
     }
     $blockNext = true;

--- a/htdocs/install/include/functions.php
+++ b/htdocs/install/include/functions.php
@@ -295,7 +295,7 @@ function xoInstallerExtensionAvailable(string $ext, array $symbols = []): bool
  *
  * @return string[] human-readable labels of missing extensions (empty = ok)
  */
-function xoInstallerMissingRequired($wizard): array
+function xoInstallerMissingRequired(XoopsInstallWizard $wizard): array
 {
     $missing = [];
     foreach ($wizard->configs['extensions_required'] as $ext => $info) {
@@ -313,16 +313,17 @@ function xoInstallerMissingRequired($wizard): array
  * Returned (not echoed) so the caller can assign it to $content and render it
  * through the standard installer chrome at file scope.
  *
- * @param string $label human-readable extension label (e.g. 'MySQLi')
+ * @param string $labels human-readable extension label or comma-separated
+ *                       list of labels (callers pass the joined missing set)
  *
  * @return string
  */
-function xoInstallerBlockedHtml(string $label): string
+function xoInstallerBlockedHtml(string $labels): string
 {
     return '<div class="alert alert-danger" role="alert">'
         . '<h4 class="alert-heading"><span class="fa-solid fa-ban"></span> ' . MISSING_REQUIRED_EXTENSIONS . '</h4>'
         . '<p class="mb-0">'
-        . installerHtmlSpecialChars(sprintf(MISSING_REQUIRED_EXTENSIONS_MSG, $label))
+        . installerHtmlSpecialChars(sprintf(MISSING_REQUIRED_EXTENSIONS_MSG, $labels))
         . '</p></div>';
 }
 

--- a/htdocs/install/include/functions.php
+++ b/htdocs/install/include/functions.php
@@ -257,6 +257,40 @@ function xoPhpVersion()
 }
 
 /**
+ * Halt the installer with a clear message when a mandatory extension that has
+ * no fallback driver is unavailable.
+ *
+ * The requirements page already blocks the Next button, but that gate is
+ * client-side and bypassable (direct URL, stale session). Without this guard
+ * the database steps call mysqli_*() unconditionally and fatal with
+ * "Call to undefined function" on a PHP build lacking the extension. Renders
+ * the standard installer chrome with the blocked-requirements alert and exits.
+ *
+ * @param XoopsInstallWizard $wizard
+ * @param string             $ext    extension name (e.g. 'mysqli')
+ * @param string             $label  human-readable label (e.g. 'MySQLi')
+ *
+ * @return void
+ */
+function xoInstallerRequireExtension($wizard, $ext, $label)
+{
+    if (extension_loaded($ext)) {
+        return;
+    }
+    $blockNext = true;
+    ob_start();
+    ?>
+    <div class="alert alert-danger" role="alert">
+        <h4 class="alert-heading"><span class="fa-solid fa-ban"></span> <?php echo MISSING_REQUIRED_EXTENSIONS; ?></h4>
+        <p class="mb-0"><?php echo htmlspecialchars(sprintf(MISSING_REQUIRED_EXTENSIONS_MSG, $label), ENT_QUOTES | ENT_HTML5); ?></p>
+    </div>
+    <?php
+    $content = ob_get_clean();
+    include __DIR__ . '/install_tpl.php';
+    exit;
+}
+
+/**
  * @param $path
  * @param $valid
  *

--- a/htdocs/install/include/functions.php
+++ b/htdocs/install/include/functions.php
@@ -299,7 +299,7 @@ function xoInstallerBlockedHtml($label)
     return '<div class="alert alert-danger" role="alert">'
         . '<h4 class="alert-heading"><span class="fa-solid fa-ban"></span> ' . MISSING_REQUIRED_EXTENSIONS . '</h4>'
         . '<p class="mb-0">'
-        . htmlspecialchars(sprintf(MISSING_REQUIRED_EXTENSIONS_MSG, $label), ENT_QUOTES | ENT_HTML5)
+        . installerHtmlSpecialChars(sprintf(MISSING_REQUIRED_EXTENSIONS_MSG, $label))
         . '</p></div>';
 }
 

--- a/htdocs/install/include/install_tpl.php
+++ b/htdocs/install/include/install_tpl.php
@@ -181,10 +181,16 @@ preg_match('/(^[a-z\s]*)([0-9\.]*)/i', XOOPS_VERSION, $versionParts);
                                 <?php echo $content; ?>
 
                                 <div class="text-end mt-4">
-                                    <button class="btn btn-lg btn-success" type="<?php echo !empty($pageHasForm) ? 'submit' : 'button'; ?>"
-                                            <?php if (empty($pageHasForm)): ?>onclick='location.href=<?php echo json_encode($wizard->pageURI("+1")); ?>'<?php endif; ?>>
-                                        <?php echo BUTTON_NEXT; ?> <i class="fa-solid fa-caret-right"></i>
-                                    </button>
+                                    <?php if (!empty($blockNext)): ?>
+                                        <button class="btn btn-lg btn-success" type="button" disabled aria-disabled="true">
+                                            <?php echo BUTTON_NEXT; ?> <i class="fa-solid fa-caret-right"></i>
+                                        </button>
+                                    <?php else: ?>
+                                        <button class="btn btn-lg btn-success" type="<?php echo !empty($pageHasForm) ? 'submit' : 'button'; ?>"
+                                                <?php if (empty($pageHasForm)): ?>onclick='location.href=<?php echo json_encode($wizard->pageURI("+1")); ?>'<?php endif; ?>>
+                                            <?php echo BUTTON_NEXT; ?> <i class="fa-solid fa-caret-right"></i>
+                                        </button>
+                                    <?php endif; ?>
                                 </div>
                             </form>
                         </div>

--- a/htdocs/install/include/install_tpl.php
+++ b/htdocs/install/include/install_tpl.php
@@ -182,7 +182,7 @@ preg_match('/(^[a-z\s]*)([0-9\.]*)/i', XOOPS_VERSION, $versionParts);
 
                                 <div class="text-end mt-4">
                                     <?php if (!empty($blockNext)): ?>
-                                        <button class="btn btn-lg btn-success" type="button" disabled aria-disabled="true">
+                                        <button class="btn btn-lg btn-secondary disabled" type="button" disabled aria-disabled="true">
                                             <?php echo BUTTON_NEXT; ?> <i class="fa-solid fa-caret-right"></i>
                                         </button>
                                     <?php else: ?>

--- a/htdocs/install/language/english/install.php
+++ b/htdocs/install/language/english/install.php
@@ -33,6 +33,8 @@ define('RECOMMENDED', 'Recommended');
 define('CURRENT', 'Current');
 define('RECOMMENDED_EXTENSIONS_MSG', 'These extensions are not required for normal use, but may be necessary to explore
     some specific features (like the multi-language or RSS support). Thus, it is recommended to have them installed.');
+define('MISSING_REQUIRED_EXTENSIONS', 'Required PHP extensions are missing');
+define('MISSING_REQUIRED_EXTENSIONS_MSG', 'XOOPS cannot be installed because the following mandatory PHP extension(s) are not available: %s. Enable them in your PHP configuration (php.ini) and restart your web server, then reload this page.');
 define('NONE', 'None');
 define('SUCCESS', 'Success');
 define('WARNING', 'Warning');

--- a/htdocs/install/page_dbconnection.php
+++ b/htdocs/install/page_dbconnection.php
@@ -31,6 +31,9 @@ defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 $pageHasForm = true;
 $pageHasHelp = true;
 
+// mysqli has no fallback driver; without it every step below fatals.
+xoInstallerRequireExtension($wizard, 'mysqli', 'MySQLi');
+
 $vars = & $_SESSION['settings'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/htdocs/install/page_dbconnection.php
+++ b/htdocs/install/page_dbconnection.php
@@ -31,8 +31,15 @@ defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 $pageHasForm = true;
 $pageHasHelp = true;
 
-// mysqli has no fallback driver; without it every step below fatals.
-xoInstallerRequireExtension($wizard, 'mysqli', 'MySQLi', ['mysqli_report', 'mysqli']);
+// mysqli has no fallback driver; without it every step below fatals. The
+// requirements page already blocks Next, but that is bypassable via a direct
+// URL or a stale session, so guard here too.
+if (!xoInstallerExtensionAvailable('mysqli', ['mysqli_report', 'mysqli'])) {
+    $blockNext = true;
+    $content   = xoInstallerBlockedHtml('MySQLi');
+    include __DIR__ . '/include/install_tpl.php';
+    exit;
+}
 
 $vars = & $_SESSION['settings'];
 

--- a/htdocs/install/page_dbconnection.php
+++ b/htdocs/install/page_dbconnection.php
@@ -31,13 +31,14 @@ defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 $pageHasForm = true;
 $pageHasHelp = true;
 
-// mysqli has no fallback driver; without it every step below fatals. The
-// requirements page already blocks Next, but that is bypassable via a direct
-// URL or a stale session, so guard here too.
-[$mysqliLabel, $mysqliSymbols] = $wizard->configs['extensions_required']['mysqli'];
-if (!xoInstallerExtensionAvailable('mysqli', $mysqliSymbols)) {
+// The requirements page already blocks Next when a mandatory extension is
+// missing, but that gate is bypassable via a direct URL or a stale session.
+// Re-check the full required set here (mysqli especially has no fallback and
+// would fatal below) so a bypass yields the clear message, not a raw fatal.
+$missingRequired = xoInstallerMissingRequired($wizard);
+if (!empty($missingRequired)) {
     $blockNext = true;
-    $content   = xoInstallerBlockedHtml($mysqliLabel);
+    $content   = xoInstallerBlockedHtml(implode(', ', $missingRequired));
     include_once __DIR__ . '/include/install_tpl.php';
     exit;
 }

--- a/htdocs/install/page_dbconnection.php
+++ b/htdocs/install/page_dbconnection.php
@@ -34,10 +34,11 @@ $pageHasHelp = true;
 // mysqli has no fallback driver; without it every step below fatals. The
 // requirements page already blocks Next, but that is bypassable via a direct
 // URL or a stale session, so guard here too.
-if (!xoInstallerExtensionAvailable('mysqli', ['mysqli_report', 'mysqli'])) {
+[$mysqliLabel, $mysqliSymbols] = $wizard->configs['extensions_required']['mysqli'];
+if (!xoInstallerExtensionAvailable('mysqli', $mysqliSymbols)) {
     $blockNext = true;
-    $content   = xoInstallerBlockedHtml('MySQLi');
-    include __DIR__ . '/include/install_tpl.php';
+    $content   = xoInstallerBlockedHtml($mysqliLabel);
+    include_once __DIR__ . '/include/install_tpl.php';
     exit;
 }
 

--- a/htdocs/install/page_dbconnection.php
+++ b/htdocs/install/page_dbconnection.php
@@ -32,7 +32,7 @@ $pageHasForm = true;
 $pageHasHelp = true;
 
 // mysqli has no fallback driver; without it every step below fatals.
-xoInstallerRequireExtension($wizard, 'mysqli', 'MySQLi');
+xoInstallerRequireExtension($wizard, 'mysqli', 'MySQLi', ['mysqli_report', 'mysqli']);
 
 $vars = & $_SESSION['settings'];
 

--- a/htdocs/install/page_dbsettings.php
+++ b/htdocs/install/page_dbsettings.php
@@ -31,8 +31,15 @@ defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 $pageHasForm = true;
 $pageHasHelp = true;
 
-// mysqli has no fallback driver; without it every step below fatals.
-xoInstallerRequireExtension($wizard, 'mysqli', 'MySQLi', ['mysqli_report', 'mysqli']);
+// mysqli has no fallback driver; without it every step below fatals. The
+// requirements page already blocks Next, but that is bypassable via a direct
+// URL or a stale session, so guard here too.
+if (!xoInstallerExtensionAvailable('mysqli', ['mysqli_report', 'mysqli'])) {
+    $blockNext = true;
+    $content   = xoInstallerBlockedHtml('MySQLi');
+    include __DIR__ . '/include/install_tpl.php';
+    exit;
+}
 
 $vars = & $_SESSION['settings'];
 

--- a/htdocs/install/page_dbsettings.php
+++ b/htdocs/install/page_dbsettings.php
@@ -31,13 +31,14 @@ defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 $pageHasForm = true;
 $pageHasHelp = true;
 
-// mysqli has no fallback driver; without it every step below fatals. The
-// requirements page already blocks Next, but that is bypassable via a direct
-// URL or a stale session, so guard here too.
-[$mysqliLabel, $mysqliSymbols] = $wizard->configs['extensions_required']['mysqli'];
-if (!xoInstallerExtensionAvailable('mysqli', $mysqliSymbols)) {
+// The requirements page already blocks Next when a mandatory extension is
+// missing, but that gate is bypassable via a direct URL or a stale session.
+// Re-check the full required set here (mysqli especially has no fallback and
+// would fatal below) so a bypass yields the clear message, not a raw fatal.
+$missingRequired = xoInstallerMissingRequired($wizard);
+if (!empty($missingRequired)) {
     $blockNext = true;
-    $content   = xoInstallerBlockedHtml($mysqliLabel);
+    $content   = xoInstallerBlockedHtml(implode(', ', $missingRequired));
     include_once __DIR__ . '/include/install_tpl.php';
     exit;
 }

--- a/htdocs/install/page_dbsettings.php
+++ b/htdocs/install/page_dbsettings.php
@@ -31,6 +31,9 @@ defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 $pageHasForm = true;
 $pageHasHelp = true;
 
+// mysqli has no fallback driver; without it every step below fatals.
+xoInstallerRequireExtension($wizard, 'mysqli', 'MySQLi');
+
 $vars = & $_SESSION['settings'];
 
 $hostConnectPrefix = empty($vars['DB_PCONNECT']) ? '' : 'p:';

--- a/htdocs/install/page_dbsettings.php
+++ b/htdocs/install/page_dbsettings.php
@@ -34,10 +34,11 @@ $pageHasHelp = true;
 // mysqli has no fallback driver; without it every step below fatals. The
 // requirements page already blocks Next, but that is bypassable via a direct
 // URL or a stale session, so guard here too.
-if (!xoInstallerExtensionAvailable('mysqli', ['mysqli_report', 'mysqli'])) {
+[$mysqliLabel, $mysqliSymbols] = $wizard->configs['extensions_required']['mysqli'];
+if (!xoInstallerExtensionAvailable('mysqli', $mysqliSymbols)) {
     $blockNext = true;
-    $content   = xoInstallerBlockedHtml('MySQLi');
-    include __DIR__ . '/include/install_tpl.php';
+    $content   = xoInstallerBlockedHtml($mysqliLabel);
+    include_once __DIR__ . '/include/install_tpl.php';
     exit;
 }
 

--- a/htdocs/install/page_dbsettings.php
+++ b/htdocs/install/page_dbsettings.php
@@ -32,7 +32,7 @@ $pageHasForm = true;
 $pageHasHelp = true;
 
 // mysqli has no fallback driver; without it every step below fatals.
-xoInstallerRequireExtension($wizard, 'mysqli', 'MySQLi');
+xoInstallerRequireExtension($wizard, 'mysqli', 'MySQLi', ['mysqli_report', 'mysqli']);
 
 $vars = & $_SESSION['settings'];
 

--- a/htdocs/install/page_modcheck.php
+++ b/htdocs/install/page_modcheck.php
@@ -43,6 +43,13 @@ foreach ($wizard->configs['extensions_required'] as $ext => $info) {
 }
 $blockNext = !empty($missingRequired);
 
+// Keep the MySQLi requirements row consistent with the gate: use the same
+// configured symbol list so the row cannot show success while Next is blocked
+// (mysqli loaded but mysqli_report()/the mysqli class absent).
+$mysqliSymbols   = $wizard->configs['extensions_required']['mysqli'][1] ?? [];
+$mysqliAvailable = xoInstallerExtensionAvailable('mysqli', $mysqliSymbols);
+$mysqliInfo      = $mysqliAvailable && function_exists('mysqli_get_client_info') ? mysqli_get_client_info() : '';
+
 foreach ($wizard->configs['extensions'] as $ext => $value) {
     if (extension_loaded($ext)) {
         if (is_array($value[0])) {
@@ -59,7 +66,7 @@ ob_start();
     <?php if ($blockNext): ?>
         <div class="alert alert-danger" role="alert">
             <h4 class="alert-heading"><span class="fa-solid fa-ban"></span> <?php echo MISSING_REQUIRED_EXTENSIONS; ?></h4>
-            <p class="mb-0"><?php echo htmlspecialchars(sprintf(MISSING_REQUIRED_EXTENSIONS_MSG, implode(', ', $missingRequired)), ENT_QUOTES | ENT_HTML5); ?></p>
+            <p class="mb-0"><?php echo installerHtmlSpecialChars(sprintf(MISSING_REQUIRED_EXTENSIONS_MSG, implode(', ', $missingRequired))); ?></p>
         </div>
     <?php endif; ?>
 
@@ -78,7 +85,7 @@ ob_start();
 
         <tr>
             <th><?php printf(PHP_EXTENSION, 'MySQLi'); ?></th>
-            <td><?php echo xoDiag(function_exists('mysqli_connect') ? 1 : -1, function_exists('mysqli_get_client_info') ? mysqli_get_client_info() : ''); ?></td>
+            <td><?php echo xoDiag($mysqliAvailable ? 1 : -1, $mysqliInfo); ?></td>
         </tr>
 
         <tr>

--- a/htdocs/install/page_modcheck.php
+++ b/htdocs/install/page_modcheck.php
@@ -29,19 +29,12 @@ require_once __DIR__ . '/include/common.inc.php';
 defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 
 $pageHasForm = false;
-$diagsOK     = false;
 
-// Mandatory extensions: collect any that are missing. Installation cannot
-// proceed without these (e.g. mysqli has no fallback driver and would fatal
-// on the DB-connection step), so a missing one blocks the Next button.
-$missingRequired = [];
-foreach ($wizard->configs['extensions_required'] as $ext => $info) {
-    [$label, $symbols] = $info;
-    if (!xoInstallerExtensionAvailable($ext, $symbols)) {
-        $missingRequired[] = $label;
-    }
-}
-$blockNext = !empty($missingRequired);
+// Mandatory extensions: installation cannot proceed without these (e.g.
+// mysqli has no fallback driver and would fatal on the DB-connection step),
+// so a missing one blocks the Next button.
+$missingRequired = xoInstallerMissingRequired($wizard);
+$blockNext       = !empty($missingRequired);
 
 // Keep the MySQLi requirements row consistent with the gate: use the same
 // configured symbol list so the row cannot show success while Next is blocked
@@ -64,10 +57,7 @@ foreach ($wizard->configs['extensions'] as $ext => $value) {
 ob_start();
 ?>
     <?php if ($blockNext): ?>
-        <div class="alert alert-danger" role="alert">
-            <h4 class="alert-heading"><span class="fa-solid fa-ban"></span> <?php echo MISSING_REQUIRED_EXTENSIONS; ?></h4>
-            <p class="mb-0"><?php echo installerHtmlSpecialChars(sprintf(MISSING_REQUIRED_EXTENSIONS_MSG, implode(', ', $missingRequired))); ?></p>
-        </div>
+        <?php echo xoInstallerBlockedHtml(implode(', ', $missingRequired)); ?>
     <?php endif; ?>
 
     <h3><?php echo REQUIREMENTS; ?></h3>

--- a/htdocs/install/page_modcheck.php
+++ b/htdocs/install/page_modcheck.php
@@ -31,6 +31,17 @@ defined('XOOPS_INSTALL') || die('XOOPS Installation wizard die');
 $pageHasForm = false;
 $diagsOK     = false;
 
+// Mandatory extensions: collect any that are missing. Installation cannot
+// proceed without these (e.g. mysqli has no fallback driver and would fatal
+// on the DB-connection step), so a missing one blocks the Next button.
+$missingRequired = [];
+foreach ($wizard->configs['extensions_required'] as $ext => $label) {
+    if (!extension_loaded($ext)) {
+        $missingRequired[] = $label;
+    }
+}
+$blockNext = !empty($missingRequired);
+
 foreach ($wizard->configs['extensions'] as $ext => $value) {
     if (extension_loaded($ext)) {
         if (is_array($value[0])) {
@@ -44,6 +55,13 @@ foreach ($wizard->configs['extensions'] as $ext => $value) {
 }
 ob_start();
 ?>
+    <?php if ($blockNext): ?>
+        <div class="alert alert-danger" role="alert">
+            <h4 class="alert-heading"><span class="fa-solid fa-ban"></span> <?php echo MISSING_REQUIRED_EXTENSIONS; ?></h4>
+            <p class="mb-0"><?php echo htmlspecialchars(sprintf(MISSING_REQUIRED_EXTENSIONS_MSG, implode(', ', $missingRequired)), ENT_QUOTES | ENT_HTML5); ?></p>
+        </div>
+    <?php endif; ?>
+
     <h3><?php echo REQUIREMENTS; ?></h3>
     <table class="table table-hover">
         <tbody>

--- a/htdocs/install/page_modcheck.php
+++ b/htdocs/install/page_modcheck.php
@@ -36,7 +36,7 @@ $diagsOK     = false;
 // on the DB-connection step), so a missing one blocks the Next button.
 $missingRequired = [];
 foreach ($wizard->configs['extensions_required'] as $ext => $label) {
-    if (!extension_loaded($ext)) {
+    if (!xoInstallerExtensionAvailable($ext)) {
         $missingRequired[] = $label;
     }
 }

--- a/htdocs/install/page_modcheck.php
+++ b/htdocs/install/page_modcheck.php
@@ -35,8 +35,9 @@ $diagsOK     = false;
 // proceed without these (e.g. mysqli has no fallback driver and would fatal
 // on the DB-connection step), so a missing one blocks the Next button.
 $missingRequired = [];
-foreach ($wizard->configs['extensions_required'] as $ext => $label) {
-    if (!xoInstallerExtensionAvailable($ext)) {
+foreach ($wizard->configs['extensions_required'] as $ext => $info) {
+    [$label, $symbols] = $info;
+    if (!xoInstallerExtensionAvailable($ext, $symbols)) {
         $missingRequired[] = $label;
     }
 }


### PR DESCRIPTION
## Summary

Hardens the XOOPS installer so a missing PHP extension produces a clear, actionable message instead of a raw fatal. Found during 2.7.0 release testing on a PHP build without `mysqli`.

Previously the requirements page (`page_modcheck.php`) was advisory only — `$diagsOK` was dead code and the Next button always worked. A user missing `mysqli` (which has no fallback driver) sailed past the red "Failed" marker straight into a cascade of `Call to undefined function mysqli_*` fatals on `page_dbconnection.php` / `page_dbsettings.php`.

## Changes

- **`config.php`** — new `$configs['extensions_required']`, each entry `[label, [required symbols]]`. The symbol list is the single source of truth shared by the requirements-page gate and the server-side DB guard, so a partial build (mysqli loaded but `mysqli_report()` / the `mysqli` class absent) is treated as missing consistently in both places.
- **`page_modcheck.php`** — detects missing required extensions, shows a clear danger alert listing them, and blocks Next.
- **`install_tpl.php`** — Next button rendered visibly disabled (`btn-secondary .disabled`) when blocked.
- **`functions.php`** — `xoInstallerExtensionAvailable()` (pure bool, `class_exists(.,false)`) + `xoInstallerBlockedHtml()` (returns markup). DB pages render at file scope, so no analyzer-opaque include inside a function.
- **`page_dbconnection.php` / `page_dbsettings.php`** — guard before any `mysqli_*()`; the client gate is bypassable via direct URL / stale session, so these fail closed with the same message.
- Language constants `MISSING_REQUIRED_EXTENSIONS` / `_MSG` + `docs/lang_diff.txt`.

## Required vs recommended

**Required (install blocked if missing):** `mysqli`, `session`, `pcre`, `filter`, `fileinfo`.

**`mbstring` is intentionally NOT required.** The installer autoloads `symfony/polyfill-mbstring` (via `common.inc.php`), so the `mb_*` functions remain available even without the extension; gating on `extension_loaded('mbstring')` would wrongly block a working install. It remains in the recommended-extensions list.

## Test plan

- [x] PHP 8.2–8.5 CI green
- [x] Manually verified on PHP without mysqli: requirements page shows the red alert + disabled Next; direct URL to `page_dbconnection.php` shows the clean message, not a fatal
- [x] Verified normal install path unaffected when all required extensions are present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now enforces a configurable list of required PHP extensions and re-checks them on key setup pages.
  * Added clear, localized messages explaining which extensions are missing and how to enable them.

* **Bug Fixes**
  * “Next” navigation is disabled when mandatory extensions are absent to prevent fatal errors during installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XOOPS/XoopsCore27/pull/62)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->