### PR TITLE
docs(changelog): record installer extension-guard fixes for 2.7.0 Final

### DIFF
--- a/docs/changelog.270.txt
+++ b/docs/changelog.270.txt
@@ -14,6 +14,13 @@ Documentation:
 Security hardening:
 - harden upgrade/checkmainfile.php mainfile include with realpath() and boundary check (mamba) in #54
 
+Installer:
+- fix installer: guard optional function calls that fatal on PHP 8.2 - mysqli_get_client_info() and the Protector config cache (mamba) in #60
+- fix installer: block installation with a clear message when a mandatory PHP extension (mysqli, session, pcre, filter, fileinfo) is missing, instead of a raw fatal; full required-extension guards on the DB steps too (mamba) in #62
+
+Tests:
+- add unit coverage for the installer required-extension helpers (mamba) in #63
+
 ===================================
 2.7.0 RC5                    2026-04-22
 ===================================


### PR DESCRIPTION
## Summary

Records today's merged installer hardening in `docs/changelog.270.txt` under the **2.7.0 Final** section (new **Installer** and **Tests** subsections):

- **#60** — guard optional function calls that fatal on PHP 8.2 (`mysqli_get_client_info()`, Protector config cache)
- **#62** — block installation with a clear message when a mandatory PHP extension (mysqli, session, pcre, filter, fileinfo) is missing, instead of a raw fatal; full required-extension guards on the DB steps
- **#63** — unit coverage for the installer required-extension helpers

Docs-only; no code changes. Follows the file's existing `- text (author) in #NN` convention.

## Test plan

- [x] Entries placed under the correct (`2.7.0 Final`) section
- [x] PR references match merged work (#60, #62, #63)
- [ ] N/A — documentation only