### PR TITLE
fix(ci): changelog workflow must open a PR, not push to protected master

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,13 +12,14 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: write          # push the automation branch
+  pull-requests: write     # open/update the changelog PR
 
 concurrency:
   # Fixed group (not keyed by ref): release-tag and manual-dispatch runs
-  # both push the default branch. Queue them (cancel-in-progress: false) so
-  # each run finishes and persists its CHANGELOG.md instead of a later run
-  # cancelling an in-flight one mid-push.
+  # both target the same automation branch / PR. Queue them
+  # (cancel-in-progress: false) so each run finishes and updates the PR
+  # instead of a later run cancelling an in-flight one mid-update.
   group: changelog
   cancel-in-progress: false
 
@@ -54,18 +55,27 @@ jobs:
       - name: Verify changelog was generated at the repo root
         run: test -s CHANGELOG.md
 
-      - name: Commit CHANGELOG.md if changed
-        run: |
-          # Stage first, then compare the index to HEAD. Plain
-          # `git diff --quiet` ignores untracked files, so on the first
-          # run (CHANGELOG.md brand-new) it falsely reported "no change"
-          # and the file was never committed. --cached sees new files too.
-          git add CHANGELOG.md
-          if git diff --cached --quiet -- CHANGELOG.md; then
-            echo "CHANGELOG.md unchanged — nothing to commit."
-            exit 0
-          fi
-          git config user.name  "xoops-ci"
-          git config user.email "ci@xoops.org"
-          git commit -m "docs(changelog): regenerate CHANGELOG.md [skip ci]"
-          git push origin HEAD:${{ github.event.repository.default_branch }}
+      - name: Open/update changelog pull request
+        # master is protected (changes must go through a PR), so the bot
+        # cannot push directly. Push a fixed automation branch and let this
+        # action open or update the PR; it no-ops when nothing changed.
+        # Pinned to a commit SHA (supply-chain hardening); comment tracks the tag.
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ github.event.repository.default_branch }}
+          branch: automation/update-changelog
+          delete-branch: true
+          add-paths: CHANGELOG.md
+          commit-message: "docs(changelog): regenerate CHANGELOG.md"
+          committer: "xoops-ci <ci@xoops.org>"
+          author: "xoops-ci <ci@xoops.org>"
+          title: "docs(changelog): regenerate CHANGELOG.md"
+          body: |
+            Regenerated `CHANGELOG.md` from the commit history via
+            `git-cliff` (config: `cliff.toml`).
+
+            Opened by the **Changelog** workflow — `master` is protected
+            (changes must go through a PR), so the generated file is
+            delivered this way instead of a direct push. Safe to merge
+            once green; it only touches `CHANGELOG.md`.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -62,6 +62,12 @@ jobs:
         # Pinned to a commit SHA (supply-chain hardening); comment tracks the tag.
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          # Intentional: GITHUB_TOKEN-created PRs do not trigger CI/Sonar
+          # (GitHub recursion-prevention). That is fine here — master's
+          # ruleset requires only 1 approving review, not status checks, and
+          # CI on a generated CHANGELOG.md is low value. A maintainer reviews
+          # and merges the changelog PR. Do not swap in a PAT/App token just
+          # to run checks — it adds a managed elevated secret for no benefit.
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ github.event.repository.default_branch }}
           branch: automation/update-changelog


### PR DESCRIPTION
## Why this PR exists

PR #67 was **merged at commit `b01d9c77a`** — the commit-detection fix — **before** the follow-up redesign commit (`d6a8476c0`) was added. So `master`'s `changelog.yml` still does `git push origin HEAD:master`, which the branch ruleset rejects (*"Changes must be made through a pull request"*). The redesign never reached `master`; the **Changelog** workflow keeps failing on the final push.

This PR brings that redesign to `master` (cherry-pick of `d6a8476c0` onto current `master`).

## What it does

Replaces the direct-push step with **`peter-evans/create-pull-request`** (SHA-pinned, `# v8.1.1`):

- git-cliff generation + `test -s` verification steps unchanged.
- Pushes a fixed `automation/update-changelog` branch and opens/updates a PR; no-ops when nothing changed.
- Adds `pull-requests: write`. No direct write to protected `master`; same PR-only governance as the rest of the repo.
- All three actions remain SHA-pinned (`actions/checkout` v6.0.2 / Node 24, `orhun/git-cliff-action` v4.8.0 composite, `peter-evans/create-pull-request` v8.1.1).

## Prerequisite (repo setting)

**Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** must be ON, or the PR-open step fails with a permissions error.

## Test plan

- [ ] Confirm the GHA "create and approve pull requests" setting is ON
- [ ] Merge this PR
- [ ] Run **Actions → Changelog → Run workflow** (workflow_dispatch)
- [ ] Confirm: no ruleset rejection; a PR from `automation/update-changelog` is opened with `CHANGELOG.md` (no direct push to master)
- [ ] Merge that PR; re-run and confirm clean no-op when unchanged