### PR TITLE
fix: preserve TinyMCE 7 language locale casing

### DIFF
--- a/docs/changelog.270.txt
+++ b/docs/changelog.270.txt
@@ -21,6 +21,9 @@ Installer:
 Tests:
 - add unit coverage for the installer required-extension helpers (mamba) in #63
 
+Forms and templates:
+- fix TinyMCE 7 language handling to preserve case-sensitive locale codes such as zh_TW
+
 ===================================
 2.7.0 RC5                    2026-04-22
 ===================================

--- a/htdocs/class/xoopseditor/tinymce7/formtinymce.php
+++ b/htdocs/class/xoopseditor/tinymce7/formtinymce.php
@@ -97,7 +97,7 @@ class XoopsFormTinymce7 extends XoopsEditor
             return $this->language;
         }
         if (defined('_XOOPS_EDITOR_TINYMCE7_LANGUAGE')) {
-            $this->language = strtolower(constant('_XOOPS_EDITOR_TINYMCE7_LANGUAGE'));
+            $this->language = constant('_XOOPS_EDITOR_TINYMCE7_LANGUAGE');
         } else {
             $this->language = str_replace('_', '-', strtolower(_LANGCODE));
             if (strtolower(_CHARSET) === 'utf-8') {

--- a/tests/unit/htdocs/class/xoopseditor/tinymce7/XoopsFormTinymce7Test.php
+++ b/tests/unit/htdocs/class/xoopseditor/tinymce7/XoopsFormTinymce7Test.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace xoopseditor\tinymce7;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+require_once XOOPS_ROOT_PATH . '/class/xoopseditor/tinymce7/formtinymce.php';
+
+/**
+ * Unit tests for XoopsFormTinymce7.
+ */
+class XoopsFormTinymce7Test extends TestCase
+{
+    public function testGetLanguagePreservesConfiguredLocaleCase(): void
+    {
+        define('_XOOPS_EDITOR_TINYMCE7_LANGUAGE', 'zh_TW');
+
+        $reflection = new ReflectionClass(\XoopsFormTinymce7::class);
+        $editor = $reflection->newInstanceWithoutConstructor();
+
+        $this->assertSame('zh_TW', $editor->getLanguage());
+    }
+}


### PR DESCRIPTION
## Summary
- Preserve the configured TinyMCE 7 language code casing in `getLanguage()`
- Add coverage for case-sensitive locale codes such as `zh_TW`
- Document the fix in the 2.7.0 changelog

## Testing
- `phpunit --configuration phpunit.xml.dist --stderr unit/htdocs/class/xoopseditor/tinymce7/XoopsFormTinymce7Test.php`
- Full suite run currently has one unrelated failure: `kernel\XoopsMemberHandlerTest::testGetUserCachesSeparateIds`

Fixes #71 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TinyMCE 7 to properly preserve case-sensitive locale codes during language configuration. Previously, locale codes were being incorrectly converted to lowercase, preventing proper language and regional settings for affected locales like `zh_TW`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XOOPS/XoopsCore27/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->