### PR TITLE
chore(sonar): scope S115/S3011 out of test sources

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,3 +17,15 @@ sonar.php.version=8.2
 
 # Exclude vendored, installer, user-data, and build-artifact trees from analysis.
 sonar.exclusions=htdocs/xoops_lib/vendor/**,htdocs/class/libraries/vendor/**,htdocs/install/**,htdocs/xoops_data/**,extras/**,build/**
+
+# Production code-smell rules that do not apply to test code:
+#  - S115: tests must define() XOOPS core constants by their exact names,
+#    which use a leading underscore (e.g. _INSTALL_CHARSET) — the name is
+#    dictated by the code under test and cannot be renamed.
+#  - S3011: using reflection to bypass a constructor/visibility is standard,
+#    safe practice when unit-testing legacy classes.
+sonar.issue.ignore.multicriteria=e1,e2
+sonar.issue.ignore.multicriteria.e1.ruleKey=php:S115
+sonar.issue.ignore.multicriteria.e1.resourceKey=tests/**/*
+sonar.issue.ignore.multicriteria.e2.ruleKey=php:S3011
+sonar.issue.ignore.multicriteria.e2.resourceKey=tests/**/*


### PR DESCRIPTION
## Summary

SonarCloud "Code Analysis" keeps failing on **test-only** PRs (e.g. #72) for two findings that are systemic false positives in XOOPS test code:

| Rule | Why it's a false positive in `tests/**` |
|---|---|
| `php:S115` (constant naming) | Tests must `define()` XOOPS core constants by their **exact** names, which use a leading underscore (`_INSTALL_CHARSET`, `_XOOPS_EDITOR_TINYMCE7_LANGUAGE`, …). The name is dictated by the code under test — it cannot be renamed. |
| `php:S3011` (accessibility bypass) | Using reflection to bypass a constructor/visibility is standard, safe practice when unit-testing legacy classes. |

`sonar.tests=tests` only separates test code for coverage/duplication — SonarCloud still applies production code-smell rules to it. This scopes the two rules out of `tests/**` via `sonar.issue.ignore.multicriteria`. **Production analysis is unchanged** (rules still enforced on `htdocs/**`).

Prevents the recurring gate failure on every test PR (including the existing `InstallerRequiredExtensionsTest`, which defines `_INSTALL_CHARSET`).

## Test plan

- [ ] Merge; confirm SonarCloud Code Analysis no longer reports S115/S3011 on test files
- [ ] Confirm production (`htdocs/**`) still reports S115/S3011 normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality analysis configuration to exclude specific rules from test file scans, improving the relevance of quality reports by reducing analysis noise in test code.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XOOPS/XoopsCore27/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->