### PR TITLE
test(editor): isolate the TinyMCE7 language test

### DIFF
--- a/docs/changelog.270.txt
+++ b/docs/changelog.270.txt
@@ -20,6 +20,7 @@ Installer:
 
 Tests:
 - add unit coverage for the installer required-extension helpers (mamba) in #63
+- harden XoopsFormTinymce7 language test with process isolation and a defined() guard so the editor-language constant cannot leak between tests
 
 Forms and templates:
 - fix TinyMCE 7 language handling to preserve case-sensitive locale codes such as zh_TW

--- a/tests/unit/htdocs/class/xoopseditor/tinymce7/XoopsFormTinymce7Test.php
+++ b/tests/unit/htdocs/class/xoopseditor/tinymce7/XoopsFormTinymce7Test.php
@@ -35,12 +35,16 @@ class XoopsFormTinymce7Test extends TestCase
 
         define('_XOOPS_EDITOR_TINYMCE7_LANGUAGE', 'zh_TW');
 
-        // Anonymous subclass with an empty constructor: skips the heavy
-        // parent constructor (which builds a TinyMCE editor) without
+        // Anonymous subclass: skip the heavy parent constructor without
         // reflection. getLanguage() only needs $this->language (unset here)
         // and the constant, so this faithfully exercises the target path.
         $editor = new class extends \XoopsFormTinymce7 {
-            public function __construct() {}
+            public function __construct()
+            {
+                // Intentionally empty: bypass XoopsFormTinymce7::__construct(),
+                // which builds a full TinyMCE editor and is irrelevant to
+                // getLanguage().
+            }
         };
 
         self::assertSame('zh_TW', $editor->getLanguage());

--- a/tests/unit/htdocs/class/xoopseditor/tinymce7/XoopsFormTinymce7Test.php
+++ b/tests/unit/htdocs/class/xoopseditor/tinymce7/XoopsFormTinymce7Test.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace xoopseditor\tinymce7;
 
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
@@ -14,13 +16,28 @@ require_once XOOPS_ROOT_PATH . '/class/xoopseditor/tinymce7/formtinymce.php';
  */
 class XoopsFormTinymce7Test extends TestCase
 {
+    /**
+     * getLanguage() must return the configured editor locale verbatim
+     * (e.g. zh_TW), not lower-cased — TinyMCE 7 language packs are
+     * case-sensitive.
+     *
+     * Runs in a separate process: the test has to define() the global
+     * _XOOPS_EDITOR_TINYMCE7_LANGUAGE constant, and a PHP constant cannot
+     * be unset — without isolation it would leak into every later test in
+     * the run and make execution order significant.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
     public function testGetLanguagePreservesConfiguredLocaleCase(): void
     {
+        if (defined('_XOOPS_EDITOR_TINYMCE7_LANGUAGE')) {
+            self::markTestSkipped('_XOOPS_EDITOR_TINYMCE7_LANGUAGE already defined; cannot exercise the configured-locale path in isolation.');
+        }
+
         define('_XOOPS_EDITOR_TINYMCE7_LANGUAGE', 'zh_TW');
 
-        $reflection = new ReflectionClass(\XoopsFormTinymce7::class);
-        $editor = $reflection->newInstanceWithoutConstructor();
+        $editor = (new ReflectionClass(\XoopsFormTinymce7::class))->newInstanceWithoutConstructor();
 
-        $this->assertSame('zh_TW', $editor->getLanguage());
+        self::assertSame('zh_TW', $editor->getLanguage());
     }
 }

--- a/tests/unit/htdocs/class/xoopseditor/tinymce7/XoopsFormTinymce7Test.php
+++ b/tests/unit/htdocs/class/xoopseditor/tinymce7/XoopsFormTinymce7Test.php
@@ -7,7 +7,6 @@ namespace xoopseditor\tinymce7;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
-use ReflectionClass;
 
 require_once XOOPS_ROOT_PATH . '/class/xoopseditor/tinymce7/formtinymce.php';
 
@@ -36,7 +35,13 @@ class XoopsFormTinymce7Test extends TestCase
 
         define('_XOOPS_EDITOR_TINYMCE7_LANGUAGE', 'zh_TW');
 
-        $editor = (new ReflectionClass(\XoopsFormTinymce7::class))->newInstanceWithoutConstructor();
+        // Anonymous subclass with an empty constructor: skips the heavy
+        // parent constructor (which builds a TinyMCE editor) without
+        // reflection. getLanguage() only needs $this->language (unset here)
+        // and the constant, so this faithfully exercises the target path.
+        $editor = new class extends \XoopsFormTinymce7 {
+            public function __construct() {}
+        };
 
         self::assertSame('zh_TW', $editor->getLanguage());
     }


### PR DESCRIPTION
## Summary

Follow-up to #72. The test it added `define()`s the global `_XOOPS_EDITOR_TINYMCE7_LANGUAGE` constant. A PHP constant cannot be unset, so in the shared PHPUnit process it leaks into every subsequent test and makes execution order significant (latent flakiness).

- `#[RunInSeparateProcess]` + `#[PreserveGlobalState(false)]` so the constant is confined to a child process.
- `defined()` guard → `markTestSkipped` if it's already set (no fatal redefine).
- Changelog line under Tests.

Test-only; no production code change. The reflection `newInstanceWithoutConstructor()` is intentionally kept (legitimate for unit-testing a legacy class; the corresponding SonarCloud rule is being scoped out of `tests/**` in #74).

## Out of scope (tracked separately)

The `getLanguage()` **fallback** branch (no `_XOOPS_EDITOR_TINYMCE7_LANGUAGE` set) still builds TinyMCE 3-style codes like `zh-tw_utf8`, which never match TinyMCE 7 packs. Fixing it correctly needs a design decision on the supported TinyMCE 7 locale set + the `_LANGCODE` mapping, and the bundled TinyMCE 7 currently ships no language packs to validate against. Filed as a separate issue rather than guessed here.

## Test plan

- [ ] CI green (the test now runs isolated)
- [ ] Confirm the test still passes and does not affect other tests' ordering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Hardened a unit test to run in isolation, added a guard to skip when the editor language is already set, and adjusted how the test instantiates the subject to avoid global-state leaks.

* **Chores**
  * Updated the changelog to document the test hardening.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XOOPS/XoopsCore27/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->