### PR TITLE
improve(core): consolidate theme-config normalisation across runtime readers

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -127,9 +127,12 @@ if [ -n "$added" ]; then
     # 11. New raw assignment to ->allowedThemes / ->defaultTheme from
     #     $xoopsConfig — must go through xoops_resolveThemeConfig() so
     #     the validated invariant set by common.php is preserved at
-    #     mid-request mutation points. Issue #45.
+    #     mid-request mutation points. The `->` prefix scopes the
+    #     pattern to property writes only; local variables named
+    #     allowedThemes / defaultTheme are exempt (they're already
+    #     downstream of a resolver call). Issue #45.
     hits=$(printf '%s\n' "$added" \
-        | grep -E '(allowedThemes|defaultTheme)[[:space:]]*=[[:space:]]*\$xoopsConfig\[' || true)
+        | grep -E -- '->[[:space:]]*(allowedThemes|defaultTheme)[[:space:]]*=[[:space:]]*\$xoopsConfig\[' || true)
     [ -n "$hits" ] && report "raw \$xoopsConfig theme-set assignment — use xoops_resolveThemeConfig() — issue #45" "$hits"
 
     # JSON_UNESCAPED_SLASHES sniff (previously rule 10) was removed:

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -115,6 +115,23 @@ if [ -n "$added" ]; then
     hits=$(printf '%s\n' "$added" | grep -E '//[[:space:]]*removed\b' || true)
     [ -n "$hits" ] && report "leftover '// removed' marker — delete the code, do not annotate it" "$hits"
 
+    # 10. Loose in_array() on theme_set_allowed — strict comparison is
+    #     required since include/common.php boundary-normalises the list
+    #     and theme directory names like "0" must not coerce to false in
+    #     loose comparisons. Issue #45.
+    hits=$(printf '%s\n' "$added" \
+        | grep -E "in_array[[:space:]]*\([^)]*(theme_set_allowed)" \
+        | grep -vE ",[[:space:]]*true[[:space:]]*\)" || true)
+    [ -n "$hits" ] && report "loose in_array on theme_set_allowed — use strict (third arg true) — issue #45" "$hits"
+
+    # 11. New raw assignment to ->allowedThemes / ->defaultTheme from
+    #     $xoopsConfig — must go through xoops_resolveThemeConfig() so
+    #     the validated invariant set by common.php is preserved at
+    #     mid-request mutation points. Issue #45.
+    hits=$(printf '%s\n' "$added" \
+        | grep -E '(allowedThemes|defaultTheme)[[:space:]]*=[[:space:]]*\$xoopsConfig\[' || true)
+    [ -n "$hits" ] && report "raw \$xoopsConfig theme-set assignment — use xoops_resolveThemeConfig() — issue #45" "$hits"
+
     # JSON_UNESCAPED_SLASHES sniff (previously rule 10) was removed:
     # the </script> breakout concern only applies inside HTML <script>
     # contexts, and the repo legitimately uses the flag elsewhere

--- a/htdocs/class/template.php
+++ b/htdocs/class/template.php
@@ -164,7 +164,10 @@ class XoopsTpl extends Smarty
         global $xoopsConfig;
 
         $template_set      = empty($template_set) ? $xoopsConfig['template_set'] : $template_set;
-        $theme_set         = empty($theme_set) ? $xoopsConfig['theme_set'] : $theme_set;
+        // Use === '' rather than empty() — a theme directory literally
+        // named "0" is legitimate, and empty('0') would silently swap
+        // it for the global. Issue #45 / R-063.
+        $theme_set         = (null === $theme_set || '' === $theme_set) ? $xoopsConfig['theme_set'] : $theme_set;
         if (class_exists('XoopsSystemCpanel', false)) {
             $cPrefix = 'cp-';
             $theme_set =  isset($xoopsConfig['cpanel']) ? $cPrefix . $xoopsConfig['cpanel'] : $cPrefix . 'default';

--- a/htdocs/class/theme.php
+++ b/htdocs/class/theme.php
@@ -62,9 +62,9 @@ class xos_opal_ThemeFactory
     {
         // Grab the theme folder from request vars if present
         if (empty($options['folderName'])) {
-            $req = Request::getString('xoops_theme_select', '', 'POST');
+            $req = xoops_validateThemeName(Request::getString('xoops_theme_select', '', 'POST'));
             if ($req === '') {
-                $req = Request::getString('xoops_theme_select', '', 'GET');
+                $req = xoops_validateThemeName(Request::getString('xoops_theme_select', '', 'GET'));
             }
             if ($req !== '' && $this->isThemeAllowed($req)) {
                 $options['folderName'] = $req;
@@ -72,11 +72,20 @@ class xos_opal_ThemeFactory
                     $_SESSION[$this->xoBundleIdentifier]['defaultTheme'] = $req;
                 }
             } elseif (isset($_SESSION[$this->xoBundleIdentifier]['defaultTheme'])) {
-                $options['folderName'] = $_SESSION[$this->xoBundleIdentifier]['defaultTheme'];
+                // Stale session theme names can outlive an admin change
+                // to the allowed list; validate AND check membership
+                // before reaching the path-construction code below.
+                $sessionTheme = xoops_validateThemeName((string) $_SESSION[$this->xoBundleIdentifier]['defaultTheme']);
+                $options['folderName'] = ($sessionTheme !== '' && $this->isThemeAllowed($sessionTheme))
+                    ? $sessionTheme
+                    : $this->defaultTheme;
             } elseif (empty($options['folderName']) || !$this->isThemeAllowed($options['folderName'])) {
                 $options['folderName'] = $this->defaultTheme;
             }
-            $GLOBALS['xoopsConfig']['theme_set'] = $options['folderName'];
+            // Pipe writes back to $GLOBALS['xoopsConfig'] through the
+            // validator so the boundary-normalised invariant set by
+            // common.php holds for every downstream reader.
+            $GLOBALS['xoopsConfig']['theme_set'] = xoops_validateThemeName((string) $options['folderName']) ?: 'default';
         }
         $testPath = isset($options['themesPath'])
             ? XOOPS_ROOT_PATH . '/' . $options['themesPath'] . '/' . $options['folderName']
@@ -107,7 +116,7 @@ class xos_opal_ThemeFactory
      */
     public function isThemeAllowed($name)
     {
-        return (empty($this->allowedThemes) || in_array($name, $this->allowedThemes));
+        return (empty($this->allowedThemes) || in_array($name, $this->allowedThemes, true));
     }
 }
 

--- a/htdocs/class/theme.php
+++ b/htdocs/class/theme.php
@@ -60,8 +60,11 @@ class xos_opal_ThemeFactory
      */
     public function createInstance($options = [], $initArgs = [])
     {
-        // Grab the theme folder from request vars if present
-        if (empty($options['folderName'])) {
+        // Grab the theme folder from request vars if present.
+        // Use === '' rather than empty() — a theme directory literally
+        // named "0" is legitimate (legacy XOOPS supports all-numeric
+        // theme names), and empty('0') === true would silently drop it.
+        if (!isset($options['folderName']) || $options['folderName'] === '') {
             $req = xoops_validateThemeName(Request::getString('xoops_theme_select', '', 'POST'));
             if ($req === '') {
                 $req = xoops_validateThemeName(Request::getString('xoops_theme_select', '', 'GET'));
@@ -75,18 +78,39 @@ class xos_opal_ThemeFactory
                 // Stale session theme names can outlive an admin change
                 // to the allowed list; validate AND check membership
                 // before reaching the path-construction code below.
-                $sessionTheme = xoops_validateThemeName((string) $_SESSION[$this->xoBundleIdentifier]['defaultTheme']);
+                // xoops_validateThemeValue() — scalar-gated; a session
+                // poisoned with an array / object never reaches the
+                // (string) cast (which would emit a warning AND let
+                // "Array" pass the path-safety check downstream).
+                $sessionTheme = xoops_validateThemeValue($_SESSION[$this->xoBundleIdentifier]['defaultTheme']);
                 $options['folderName'] = ($sessionTheme !== '' && $this->isThemeAllowed($sessionTheme))
                     ? $sessionTheme
                     : $this->defaultTheme;
-            } elseif (empty($options['folderName']) || !$this->isThemeAllowed($options['folderName'])) {
+            } elseif (!isset($options['folderName']) || $options['folderName'] === '' || !$this->isThemeAllowed($options['folderName'])) {
                 $options['folderName'] = $this->defaultTheme;
             }
-            // Pipe writes back to $GLOBALS['xoopsConfig'] through the
-            // validator so the boundary-normalised invariant set by
-            // common.php holds for every downstream reader.
-            $GLOBALS['xoopsConfig']['theme_set'] = xoops_validateThemeName((string) $options['folderName']) ?: 'default';
         }
+        // Validate $options['folderName'] AND the defaultTheme property
+        // unconditionally, after every resolution branch. Two paths
+        // bypass the inner-if block above and could still produce an
+        // unsafe path segment:
+        //   - A non-standard caller may have supplied a poisoned
+        //     folderName directly (skipping the empty()-branch).
+        //   - $this->defaultTheme is a public property; any caller
+        //     can overwrite it before createInstance() runs.
+        // xoops_validateThemeValue() — scalar gate + path/HTML validate
+        // in one call; rejects array / object / resource at the source
+        // so the (string) cast never sees them. Explicit '' === checks
+        // rather than the ?: Elvis operator, because xoops_validateThemeName('0')
+        // returns '0' (valid), but '0' ?: $fallback evaluates as
+        // $fallback — PHP treats '0' as falsy (R-063 / base.md).
+        $fallbackTheme = xoops_validateThemeValue($this->defaultTheme);
+        if ($fallbackTheme === '') {
+            $fallbackTheme = 'default';
+        }
+        $folderName = xoops_validateThemeValue($options['folderName'] ?? '');
+        $options['folderName'] = $folderName !== '' ? $folderName : $fallbackTheme;
+        $GLOBALS['xoopsConfig']['theme_set'] = $options['folderName'];
         $testPath = isset($options['themesPath'])
             ? XOOPS_ROOT_PATH . '/' . $options['themesPath'] . '/' . $options['folderName']
             : XOOPS_THEME_PATH . '/' . $options['folderName'];

--- a/htdocs/class/xoopsform/formselecttheme.php
+++ b/htdocs/class/xoopsform/formselecttheme.php
@@ -42,9 +42,9 @@ class XoopsFormSelectTheme extends XoopsFormSelect
         if ($theme_set_allowed === false) {
             $this->addOptionArray(XoopsLists::getThemesList());
         } else {
-            $theme_arr = $GLOBALS['xoopsConfig']['theme_set_allowed'];
-            foreach (array_keys($theme_arr) as $i) {
-                $this->addOption($theme_arr[$i], $theme_arr[$i]);
+            $themeConfig = xoops_resolveThemeConfig($GLOBALS['xoopsConfig'] ?? []);
+            foreach ($themeConfig['theme_set_allowed'] as $theme) {
+                $this->addOption($theme, $theme);
             }
         }
     }

--- a/htdocs/class/xoopskernel.php
+++ b/htdocs/class/xoopskernel.php
@@ -188,13 +188,14 @@ class xos_kernel_Xoops2
      */
     public function themeSelect()
     {
-        // xoops_getConfigOption() has its own cache layer, separate from
-        // $xoopsConfig, so the boundary normalise in common.php does
-        // NOT reach this code path. Resolve via the helper at the call
-        // site, and validate submitted / session values before strict
-        // membership checks — stale session theme names can outlive an
-        // admin change to the allowed list.
-        $allowedThemes = xoops_resolveThemeConfig([
+        // Prefer the already-boundary-normalised runtime config so any
+        // var/configs/xoopsconfig.php override survives — those overrides
+        // never reach the XoopsConfigHandler cache that backs
+        // xoops_getConfigOption(). Fall back to the cache only for
+        // partial-init paths that may run before common.php has hydrated
+        // $GLOBALS['xoopsConfig']. The helper is idempotent, so re-resolving
+        // an already-normalised pair is a no-op.
+        $allowedThemes = xoops_resolveThemeConfig($GLOBALS['xoopsConfig'] ?? [
             'theme_set'         => xoops_getConfigOption('theme_set'),
             'theme_set_allowed' => xoops_getConfigOption('theme_set_allowed'),
         ])['theme_set_allowed'];
@@ -210,9 +211,10 @@ class xos_kernel_Xoops2
                 exit;
             }
         } else {
-            $sessionTheme = isset($_SESSION['xoopsUserTheme'])
-                ? xoops_validateThemeName((string) $_SESSION['xoopsUserTheme'])
-                : '';
+            // xoops_validateThemeValue() — scalar gate + path/HTML
+            // validate; a session poisoned with an array / object is
+            // rejected here without ever reaching the (string) cast.
+            $sessionTheme = xoops_validateThemeValue($_SESSION['xoopsUserTheme'] ?? '');
             if ($sessionTheme !== '' && in_array($sessionTheme, $allowedThemes, true)) {
                 xoops_setConfigOption('theme_set', $sessionTheme);
             }

--- a/htdocs/class/xoopskernel.php
+++ b/htdocs/class/xoopskernel.php
@@ -188,8 +188,19 @@ class xos_kernel_Xoops2
      */
     public function themeSelect()
     {
-        $themeSelect = \Xmf\Request::getString('xoops_theme_select', '', 'POST');
-        if ($themeSelect !== '' && in_array($themeSelect, xoops_getConfigOption('theme_set_allowed'))) {
+        // xoops_getConfigOption() has its own cache layer, separate from
+        // $xoopsConfig, so the boundary normalise in common.php does
+        // NOT reach this code path. Resolve via the helper at the call
+        // site, and validate submitted / session values before strict
+        // membership checks — stale session theme names can outlive an
+        // admin change to the allowed list.
+        $allowedThemes = xoops_resolveThemeConfig([
+            'theme_set'         => xoops_getConfigOption('theme_set'),
+            'theme_set_allowed' => xoops_getConfigOption('theme_set_allowed'),
+        ])['theme_set_allowed'];
+
+        $themeSelect = xoops_validateThemeName(\Xmf\Request::getString('xoops_theme_select', '', 'POST'));
+        if ($themeSelect !== '' && in_array($themeSelect, $allowedThemes, true)) {
             xoops_setConfigOption('theme_set', $themeSelect);
             $_SESSION['xoopsUserTheme'] = $themeSelect;
 
@@ -198,8 +209,13 @@ class xos_kernel_Xoops2
                 header('Location: ' . $redirectUrl, true, 303);
                 exit;
             }
-        } elseif (!empty($_SESSION['xoopsUserTheme']) && in_array($_SESSION['xoopsUserTheme'], xoops_getConfigOption('theme_set_allowed'))) {
-            xoops_setConfigOption('theme_set', $_SESSION['xoopsUserTheme']);
+        } else {
+            $sessionTheme = isset($_SESSION['xoopsUserTheme'])
+                ? xoops_validateThemeName((string) $_SESSION['xoopsUserTheme'])
+                : '';
+            if ($sessionTheme !== '' && in_array($sessionTheme, $allowedThemes, true)) {
+                xoops_setConfigOption('theme_set', $sessionTheme);
+            }
         }
     }
 

--- a/htdocs/header.php
+++ b/htdocs/header.php
@@ -44,8 +44,9 @@ if (isset($GLOBALS['xoopsOption']['template_main'])) {
 
 $xoopsThemeFactory                = null;
 $xoopsThemeFactory                = new xos_opal_ThemeFactory();
-$xoopsThemeFactory->allowedThemes = $xoopsConfig['theme_set_allowed'];
-$xoopsThemeFactory->defaultTheme  = $xoopsConfig['theme_set'];
+$themeConfig                      = xoops_resolveThemeConfig($xoopsConfig);
+$xoopsThemeFactory->allowedThemes = $themeConfig['theme_set_allowed'];
+$xoopsThemeFactory->defaultTheme  = $themeConfig['theme_set'];
 
 /**
  * @var xos_opal_Theme

--- a/htdocs/include/checklogin.php
+++ b/htdocs/include/checklogin.php
@@ -65,8 +65,10 @@ if (false !== $user) {
     $_SESSION                    = [];
     $_SESSION['xoopsUserId']     = $user->getVar('uid');
     $_SESSION['xoopsUserGroups'] = $user->getGroups();
-    $user_theme                  = $user->getVar('theme');
-    if (in_array($user_theme, $xoopsConfig['theme_set_allowed'])) {
+    // Read raw via 'n' format — getVar()'s default 's' escapes '&' to
+    // '&amp;', which the validator's HTML guard would reject.
+    $user_theme                  = xoops_validateThemeName((string) $user->getVar('theme', 'n'));
+    if ($user_theme !== '' && in_array($user_theme, $xoopsConfig['theme_set_allowed'], true)) {
         $_SESSION['xoopsUserTheme'] = $user_theme;
     }
     $xoopsPreload = XoopsPreload::getInstance();

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -122,6 +122,14 @@ if (file_exists($file = $GLOBALS['xoops']->path('var/configs/xoopsconfig.php')))
     trigger_error('File Path Error: ' . 'var/configs/xoopsconfig.php' . ' does not exist.');
 }
 
+// Boundary normalise theme_set / theme_set_allowed once, so every
+// downstream reader (header.php, site-closed.php, editors, theme
+// factory, the legacy CSS path helpers) sees a validated current
+// theme and a validated allowed list. xoops_getConfigOption() has its
+// own cache and is NOT covered here — the few callers that go through
+// that path must use xoops_resolveThemeConfig() at the call site.
+$xoopsConfig = array_replace($xoopsConfig, xoops_resolveThemeConfig($xoopsConfig));
+
 /**
  * clickjack protection - Add option to HTTP header restricting using site in an iframe
  */
@@ -262,8 +270,12 @@ if (!empty($_SESSION['xoopsUserId'])) {
             $_SESSION['xoopsUserGroups'] = $xoopsUser->getGroups();
         }
         if (is_object($rememberClaims)) {   // only do during a 'remember me' login
-            $user_theme = $xoopsUser->getVar('theme');
-            if ($user_theme != $xoopsConfig['theme_set'] && in_array($user_theme, $xoopsConfig['theme_set_allowed'])) {
+            // Read raw via 'n' format — getVar()'s default 's' escapes '&'
+            // to '&amp;', which the validator's HTML guard would reject.
+            $user_theme = xoops_validateThemeName((string) $xoopsUser->getVar('theme', 'n'));
+            if ($user_theme !== '' && $user_theme !== $xoopsConfig['theme_set']
+                && in_array($user_theme, $xoopsConfig['theme_set_allowed'], true)
+            ) {
                 $_SESSION['xoopsUserTheme'] = $user_theme;
             }
             // update our remember me cookie

--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -17,6 +17,8 @@
 
 defined('XOOPS_ROOT_PATH') || exit('Restricted access');
 
+require_once XOOPS_ROOT_PATH . '/include/theme_config.php';
+
 /** @var \XoopsNotificationHandler $notification_handler */
 
 /**
@@ -886,8 +888,14 @@ function xoops_getenv($key)
  */
 function xoops_getcss($theme = '')
 {
-    if ($theme == '') {
-        $theme = $GLOBALS['xoopsConfig']['theme_set'];
+    // Defence in depth — the boundary normalise in common.php already
+    // resolves $xoopsConfig['theme_set'], but $theme is a public
+    // parameter and may be passed raw by future callers. Validate so a
+    // tainted value (path separator, null byte, ..) cannot reach the
+    // <link href=> attribute or filesystem checks below.
+    $theme = xoops_validateThemeName((string) $theme);
+    if ($theme === '') {
+        $theme = xoops_resolveThemeConfig($GLOBALS['xoopsConfig'] ?? [])['theme_set'];
     }
     $uagent  = xoops_getenv('HTTP_USER_AGENT');
     $str_css = 'styleNN.css';

--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -890,10 +890,12 @@ function xoops_getcss($theme = '')
 {
     // Defence in depth — the boundary normalise in common.php already
     // resolves $xoopsConfig['theme_set'], but $theme is a public
-    // parameter and may be passed raw by future callers. Validate so a
-    // tainted value (path separator, null byte, ..) cannot reach the
-    // <link href=> attribute or filesystem checks below.
-    $theme = xoops_validateThemeName((string) $theme);
+    // parameter and may be passed raw by future callers.
+    // xoops_validateThemeValue() handles the scalar gate + validate so
+    // an array / object input never reaches the (string) cast (which
+    // would emit a conversion warning on PHP 8.x AND let "Array" pass
+    // the path-safety check).
+    $theme = xoops_validateThemeValue($theme);
     if ($theme === '') {
         $theme = xoops_resolveThemeConfig($GLOBALS['xoopsConfig'] ?? [])['theme_set'];
     }

--- a/htdocs/include/site-closed.php
+++ b/htdocs/include/site-closed.php
@@ -39,8 +39,9 @@ if (!$allowed) {
     require_once $GLOBALS['xoops']->path('class/theme.php');
     $xoopsThemeFactory                = null;
     $xoopsThemeFactory                = new xos_opal_ThemeFactory();
-    $xoopsThemeFactory->allowedThemes = $xoopsConfig['theme_set_allowed'];
-    $xoopsThemeFactory->defaultTheme  = $xoopsConfig['theme_set'];
+    $themeConfig                      = xoops_resolveThemeConfig($xoopsConfig);
+    $xoopsThemeFactory->allowedThemes = $themeConfig['theme_set_allowed'];
+    $xoopsThemeFactory->defaultTheme  = $themeConfig['theme_set'];
     $xoTheme                          = $xoopsThemeFactory->createInstance(
         [
             'plugins' => [],

--- a/htdocs/include/site-closed.php
+++ b/htdocs/include/site-closed.php
@@ -47,6 +47,13 @@ if (!$allowed) {
             'plugins' => [],
         ],
     );
+    // Re-resolve to capture any factory-driven fallback (e.g. the
+    // pre-flight theme was structurally valid but theme.tpl / theme.html
+    // wasn't present on disk, so createInstance wrote 'default' back to
+    // $GLOBALS['xoopsConfig']['theme_set']). The template assigns below
+    // use the post-factory value so the rendered closed-site page is
+    // consistent with the theme the factory actually picked.
+    $themeConfig = xoops_resolveThemeConfig($xoopsConfig);
     $xoTheme->addScript(
         '/include/xoops.js',
         [
@@ -56,9 +63,9 @@ if (!$allowed) {
     $xoopsTpl = $xoTheme->template;
     $xoopsTpl->assign(
         [
-            'xoops_theme'       => $xoopsConfig['theme_set'],
-            'xoops_imageurl'    => XOOPS_THEME_URL . '/' . $xoopsConfig['theme_set'] . '/',
-            'xoops_themecss'    => xoops_getcss($xoopsConfig['theme_set']),
+            'xoops_theme'       => $themeConfig['theme_set'],
+            'xoops_imageurl'    => XOOPS_THEME_URL . '/' . $themeConfig['theme_set'] . '/',
+            'xoops_themecss'    => xoops_getcss($themeConfig['theme_set']),
             'xoops_requesturi'  => htmlspecialchars($_SERVER['REQUEST_URI'], ENT_QUOTES | ENT_HTML5),
             'xoops_sitename'    => htmlspecialchars($xoopsConfig['sitename'], ENT_QUOTES | ENT_HTML5),
             'xoops_slogan'      => htmlspecialchars($xoopsConfig['slogan'], ENT_QUOTES | ENT_HTML5),

--- a/htdocs/include/theme_config.php
+++ b/htdocs/include/theme_config.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Side-effect-free theme-config helpers.
+ *
+ * Single source of truth for normalising the two theme entries in
+ * $xoopsConfig:
+ *
+ *  - xoops_validateThemeName()  — fail-empty validation of one theme
+ *                                  directory name (path + HTML safety)
+ *  - xoops_resolveThemeConfig() — returns a normalised pair
+ *                                  ['theme_set' => string,
+ *                                   'theme_set_allowed' => list<string>]
+ *
+ * Why this file exists: prior to issue #45, only the System theme-switch
+ * block (b_system_themes_show) normalised these values; every other
+ * runtime reader trusted the raw config entries. A corrupted xoops_config
+ * row (mid-upgrade state, direct override in xoopsconfig.php, manual
+ * edit) could feed unvalidated strings straight into <link href=>
+ * attributes, theme-factory folder paths, and in_array() membership
+ * checks. Consolidating the normalisation here lets common.php apply it
+ * once at the config-merge boundary and lets every decision-point caller
+ * (login, remember-me, theme selector, factory) reach the same answer.
+ *
+ * Validation contract: fail-empty. xoops_validateThemeName() returns ''
+ * for any rejected input — never raises, never sanitises by stripping.
+ * XOOPS theme discovery (XoopsLists::getDirListAsArray) and the theme
+ * factory accept arbitrary directory names including spaces and
+ * non-ASCII characters, so the validator does NOT enforce a
+ * conservative [A-Za-z0-9_.-] alphabet (which would silently drop
+ * legitimate `My Theme` / `テーマ` directories). Instead two safety
+ * classes are enforced:
+ *
+ *  - Path safety: reject empty, leading dot, path separators (/, \),
+ *    null bytes, and `..` appearing as a path segment.
+ *  - HTML safety: reject the five HTML metacharacters (< > & " ').
+ *    No legitimate theme directory contains those, and rejecting them
+ *    at the boundary lets the option label and screenshot URL be
+ *    embedded without per-renderer escaping logic.
+ *
+ * Each function is wrapped in a function_exists() guard so the file is
+ * safe to require_once multiple times across mixed load orders (the
+ * helpers are referenced from include/common.php before functions.php
+ * has finished loading on some preload paths).
+ *
+ * You may not change or alter any portion of this comment or credits
+ * of supporting developers from this source code or any supporting source code
+ * which is considered copyrighted (c) material of the original comment or credit authors.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @category     kernel
+ * @package      core
+ * @author       XOOPS Development Team
+ * @copyright    (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license      GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @link         https://xoops.org
+ * @since        2.7.0
+ */
+
+defined('XOOPS_ROOT_PATH') || exit('Restricted access');
+
+if (!function_exists('xoops_validateThemeName')) {
+    /**
+     * Validate a theme directory name for path AND HTML safety.
+     *
+     * Returns the trimmed input when it passes both safety classes,
+     * '' otherwise. Spaces and non-ASCII characters are preserved
+     * unchanged — XOOPS theme discovery accepts them.
+     *
+     * @param string $name Untrusted theme directory name.
+     * @return string Trimmed valid name, or '' on any rejection.
+     */
+    function xoops_validateThemeName(string $name): string
+    {
+        $name = trim($name);
+        if (
+            '' === $name
+            || str_starts_with($name, '.')
+            || str_contains($name, '/')
+            || str_contains($name, '\\')
+            || str_contains($name, "\0")
+            || preg_match('~(?:^|[\\\\/])\.\.(?:[\\\\/]|$)~', $name)
+            || preg_match('/[<>"\'&]/', $name)
+        ) {
+            return '';
+        }
+
+        return $name;
+    }
+}
+
+if (!function_exists('xoops_resolveThemeConfig')) {
+    /**
+     * Resolve the safe (current, allowed) theme pair from $xoopsConfig.
+     *
+     * - Casts and validates each value through xoops_validateThemeName().
+     * - Treats a string theme_set_allowed as pipe-separated (defends
+     *   against direct overrides in mainfile.php / xoopsconfig.php).
+     * - Skips non-scalar entries (object / array / null / resource)
+     *   without casting, so a corrupted xoops_config row cannot trigger
+     *   an Error or string-conversion Warning.
+     * - Falls back to 'default' when no usable current theme survives.
+     * - Falls back to [$currentTheme] when no usable allowed theme
+     *   survives.
+     * - Ensures $currentTheme is in the allowed list (otherwise the
+     *   rendered <select>'s `selected` value would not match any of
+     *   its <option>s, and runtime membership checks would reject the
+     *   active theme).
+     *
+     * @param array<string, mixed> $xoopsConfig Raw config map; only
+     *                                          theme_set and
+     *                                          theme_set_allowed are
+     *                                          read.
+     * @return array{theme_set: string, theme_set_allowed: list<string>}
+     */
+    function xoops_resolveThemeConfig(array $xoopsConfig): array
+    {
+        $rawCurrentTheme = $xoopsConfig['theme_set'] ?? 'default';
+        $currentTheme    = is_string($rawCurrentTheme)
+            ? xoops_validateThemeName($rawCurrentTheme)
+            : '';
+        if ('' === $currentTheme) {
+            $currentTheme = 'default';
+        }
+
+        $rawAllowedThemes = $xoopsConfig['theme_set_allowed'] ?? [];
+        if (is_string($rawAllowedThemes)) {
+            // Filter on empty-string explicitly — default array_filter()
+            // drops any falsy entry, including a theme literally named "0".
+            $rawAllowedThemes = array_filter(
+                array_map('trim', explode('|', $rawAllowedThemes)),
+                static fn(string $theme): bool => '' !== $theme
+            );
+        } elseif (!is_array($rawAllowedThemes)) {
+            $rawAllowedThemes = [];
+        }
+        $allowedThemes = array_values(array_filter(
+            array_map(
+                static fn($name): string => is_scalar($name)
+                    ? xoops_validateThemeName((string) $name)
+                    : '',
+                $rawAllowedThemes
+            ),
+            static fn(string $name): bool => '' !== $name
+        ));
+        if ([] === $allowedThemes) {
+            $allowedThemes = [$currentTheme];
+        }
+        if (!in_array($currentTheme, $allowedThemes, true)) {
+            array_unshift($allowedThemes, $currentTheme);
+        }
+
+        return [
+            'theme_set'         => $currentTheme,
+            'theme_set_allowed' => array_values(array_unique($allowedThemes)),
+        ];
+    }
+}

--- a/htdocs/include/theme_config.php
+++ b/htdocs/include/theme_config.php
@@ -9,7 +9,7 @@
  *                                  directory name (path + HTML safety)
  *  - xoops_resolveThemeConfig() — returns a normalised pair
  *                                  ['theme_set' => string,
- *                                   'theme_set_allowed' => list<string>]
+ *                                   'theme_set_allowed' => string[]]
  *
  * Why this file exists: prior to issue #45, only the System theme-switch
  * block (b_system_themes_show) normalised these values; every other
@@ -90,6 +90,31 @@ if (!function_exists('xoops_validateThemeName')) {
     }
 }
 
+if (!function_exists('xoops_validateThemeValue')) {
+    /**
+     * Scalar-gated wrapper around xoops_validateThemeName().
+     *
+     * Returns the validated theme name when the input is scalar
+     * (int / float / bool / string), '' otherwise. Use this at every
+     * boundary where the input may not be a string — session payloads,
+     * public properties, raw $options arrays from non-standard callers,
+     * legacy xoops_config rows. The unguarded `(string) $array` cast
+     * would emit a conversion warning on PHP 8.x AND silently produce
+     * the literal string "Array", which then passes the path-safety
+     * check in xoops_validateThemeName() and reaches the theme path
+     * logic.
+     *
+     * @param mixed $value Untrusted value, scalar or otherwise.
+     * @return string Validated theme name, or '' on rejection.
+     */
+    function xoops_validateThemeValue(mixed $value): string
+    {
+        return is_scalar($value)
+            ? xoops_validateThemeName((string) $value)
+            : '';
+    }
+}
+
 if (!function_exists('xoops_resolveThemeConfig')) {
     /**
      * Resolve the safe (current, allowed) theme pair from $xoopsConfig.
@@ -112,14 +137,15 @@ if (!function_exists('xoops_resolveThemeConfig')) {
      *                                          theme_set and
      *                                          theme_set_allowed are
      *                                          read.
-     * @return array{theme_set: string, theme_set_allowed: list<string>}
+     * @return array{theme_set: string, theme_set_allowed: string[]}
      */
     function xoops_resolveThemeConfig(array $xoopsConfig): array
     {
-        $rawCurrentTheme = $xoopsConfig['theme_set'] ?? 'default';
-        $currentTheme    = is_string($rawCurrentTheme)
-            ? xoops_validateThemeName($rawCurrentTheme)
-            : '';
+        // xoops_validateThemeValue() handles the is_scalar gate and
+        // delegates to xoops_validateThemeName() — accepts int, float,
+        // bool, string (all-numeric "0" survives via the int form);
+        // rejects array / object / resource without casting.
+        $currentTheme = xoops_validateThemeValue($xoopsConfig['theme_set'] ?? 'default');
         if ('' === $currentTheme) {
             $currentTheme = 'default';
         }
@@ -136,12 +162,7 @@ if (!function_exists('xoops_resolveThemeConfig')) {
             $rawAllowedThemes = [];
         }
         $allowedThemes = array_values(array_filter(
-            array_map(
-                static fn($name): string => is_scalar($name)
-                    ? xoops_validateThemeName((string) $name)
-                    : '',
-                $rawAllowedThemes
-            ),
+            array_map('xoops_validateThemeValue', $rawAllowedThemes),
             static fn(string $name): bool => '' !== $name
         ));
         if ([] === $allowedThemes) {

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -670,105 +670,17 @@ function b_system_themes_show($options)
         $options[2] = 6; // default visible theme rows
     }
 
-    // Defensive: if xoops_config rows for theme_set / theme_set_allowed
-    // are missing, unreadable, or contain unexpected values, neither
-    // this block nor the theme rendering chain that triggered it
-    // should fatal. The two helpers below are defined as local closures
-    // so they don't pollute the global namespace (the previous extraction
-    // to top-level system* functions risked collisions in a codebase that
-    // already uses several `system_*` and `system*` helper names) while
-    // still keeping the per-function cognitive complexity low (Sonar
-    // treats closures as separate units, so their bodies don't bubble
-    // back into the parent's complexity score).
-
-    // Validate a theme directory name for path AND HTML safety.
-    //
-    // XOOPS theme discovery (XoopsLists::getDirListAsArray) and the theme
-    // factory accept arbitrary directory names — including spaces and
-    // non-ASCII characters. The validator therefore intentionally does
-    // NOT enforce a conservative `[A-Za-z0-9_.-]` alphabet (which would
-    // silently drop legitimate `My Theme` / `テーマ` directories) and
-    // enforces two safety classes instead:
-    //
-    //  - Path safety: reject empty, leading dot, path separators (/, \),
-    //    null bytes, and `..` appearing as a path segment.
-    //  - HTML safety: reject the five HTML metacharacters (< > & " ').
-    //    No legitimate theme directory contains those, and rejecting
-    //    them at the boundary lets the option label and screenshot URL
-    //    be embedded without per-renderer escaping logic (XoopsFormSelect
-    //    renderers diverge: Bootstrap3/4/5 + Legacy render labels raw,
-    //    Tailwind escapes them — pre-escaping in the caller would
-    //    double-escape under Tailwind).
-    //
-    // Names that fail validation return ''. Surviving names are trimmed
-    // but otherwise not rewritten — `My Theme` and non-ASCII names keep
-    // their original form.
-    $validateThemeName = static function (string $name): string {
-        $name = trim($name);
-        if (
-            '' === $name
-            || str_starts_with($name, '.')
-            || str_contains($name, '/')
-            || str_contains($name, '\\')
-            || str_contains($name, "\0")
-            || preg_match('~(?:^|[\\\\/])\.\.(?:[\\\\/]|$)~', $name)
-            || preg_match('/[<>"\'&]/', $name)
-        ) {
-            return '';
-        }
-
-        return $name;
-    };
-
-    // Resolve the safe (current, allowed) theme pair from $xoopsConfig.
-    //
-    // - Casts and validates each value through $validateThemeName.
-    // - Treats a string theme_set_allowed as pipe-separated (defends
-    //   against direct overrides in mainfile.php / xoopsconfig.php).
-    // - Skips non-scalar entries (object / array / null / resource)
-    //   without casting, so a corrupted xoops_config row cannot trigger
-    //   an Error or string-conversion Warning.
-    // - Falls back to 'default' if no usable current theme survived.
-    // - Falls back to [$currentTheme] if no usable allowed theme survived.
-    // - Ensures $currentTheme is in the allowed list (otherwise the
-    //   rendered <select>'s `selected` value would not match any of
-    //   its <option>s).
-    $resolveConfig = static function (array $xoopsConfig) use ($validateThemeName): array {
-        $rawCurrentTheme = $xoopsConfig['theme_set'] ?? 'default';
-        $currentTheme    = is_string($rawCurrentTheme) ? $validateThemeName($rawCurrentTheme) : '';
-        if ('' === $currentTheme) {
-            $currentTheme = 'default';
-        }
-
-        $rawAllowedThemes = $xoopsConfig['theme_set_allowed'] ?? [];
-        if (is_string($rawAllowedThemes)) {
-            // Filter on empty-string explicitly — default array_filter()
-            // drops any falsy entry, including a theme literally named "0".
-            $rawAllowedThemes = array_filter(
-                array_map('trim', explode('|', $rawAllowedThemes)),
-                static fn(string $theme): bool => '' !== $theme
-            );
-        } elseif (!is_array($rawAllowedThemes)) {
-            $rawAllowedThemes = [];
-        }
-        $allowedThemes = array_values(array_filter(
-            array_map(
-                static fn($name): string => is_scalar($name) ? $validateThemeName((string) $name) : '',
-                $rawAllowedThemes
-            ),
-            static fn(string $name): bool => '' !== $name
-        ));
-        if ([] === $allowedThemes) {
-            $allowedThemes = [$currentTheme];
-        }
-        if (!in_array($currentTheme, $allowedThemes, true)) {
-            array_unshift($allowedThemes, $currentTheme);
-        }
-
-        return [$currentTheme, array_values(array_unique($allowedThemes))];
-    };
-
-    [$currentTheme, $allowedThemes] = $resolveConfig($xoopsConfig);
+    // Defensive normalisation now lives in include/theme_config.php as
+    // xoops_validateThemeName() + xoops_resolveThemeConfig(). Both are
+    // already required transitively (functions.php -> theme_config.php).
+    // The block keeps using them at the call site even though
+    // common.php boundary-normalises the same values — explicit calls
+    // here document intent and survive any future caller that hits the
+    // block from a context where common.php has been bypassed (CLI
+    // entry, partial init).
+    $themeConfig   = xoops_resolveThemeConfig($xoopsConfig);
+    $currentTheme  = $themeConfig['theme_set'];
+    $allowedThemes = $themeConfig['theme_set_allowed'];
 
     $selectSize = ($options[0] == 1) ? 1 : (int) $options[2];
     $select = new XoopsFormSelect('', 'xoops_theme_select', $currentTheme, $selectSize);

--- a/tests/unit/htdocs/include/ThemeConfigTest.php
+++ b/tests/unit/htdocs/include/ThemeConfigTest.php
@@ -20,9 +20,47 @@ require_once XOOPS_ROOT_PATH . '/include/theme_config.php';
  * allowed list, and a totally-corrupted config falls back to 'default'.
  */
 #[CoversFunction('xoops_validateThemeName')]
+#[CoversFunction('xoops_validateThemeValue')]
 #[CoversFunction('xoops_resolveThemeConfig')]
 class ThemeConfigTest extends TestCase
 {
+    #[Test]
+    public function validateValuePassesScalarStringThrough(): void
+    {
+        $this->assertSame('default', xoops_validateThemeValue('default'));
+    }
+
+    #[Test]
+    public function validateValueCoercesScalarNonStringTypes(): void
+    {
+        // int, float, bool — anything is_scalar — coerce via string cast
+        // and validate. The "0" theme directory survives via the int form.
+        $this->assertSame('0', xoops_validateThemeValue(0));
+        $this->assertSame('1', xoops_validateThemeValue(true));
+        $this->assertSame('1.5', xoops_validateThemeValue(1.5));
+    }
+
+    #[Test]
+    public function validateValueRejectsNonScalarsWithoutWarning(): void
+    {
+        // Without the scalar gate, `(string) []` would emit a Warning
+        // AND return the literal string "Array", which then passes the
+        // path-safety check in xoops_validateThemeName(). The gate
+        // returns '' for every non-scalar shape.
+        $this->assertSame('', xoops_validateThemeValue([]));
+        $this->assertSame('', xoops_validateThemeValue(['nested']));
+        $this->assertSame('', xoops_validateThemeValue((object) ['a' => 1]));
+        $this->assertSame('', xoops_validateThemeValue(null));
+    }
+
+    #[Test]
+    public function validateValueAppliesPathSafetyToCoercedString(): void
+    {
+        // Once coerced, the normal validator rules apply.
+        $this->assertSame('', xoops_validateThemeValue('../etc'));
+        $this->assertSame('', xoops_validateThemeValue("evil\0null"));
+    }
+
     #[Test]
     public function validateRejectsEmptyString(): void
     {
@@ -192,13 +230,28 @@ class ThemeConfigTest extends TestCase
     }
 
     #[Test]
-    public function resolveSkipsNonStringCurrentTheme(): void
+    public function resolveSkipsNonScalarCurrentTheme(): void
     {
         $result = xoops_resolveThemeConfig([
             'theme_set'         => ['array', 'value'],
             'theme_set_allowed' => ['xswatch5'],
         ]);
         $this->assertSame('default', $result['theme_set']);
+    }
+
+    #[Test]
+    public function resolveAcceptsScalarCurrentTheme(): void
+    {
+        // Codex #4 — a legacy xoops_config row may return an int for
+        // theme_set when the directory name is all-numeric ("0").
+        // is_scalar coerces those via the validator so a numeric
+        // theme directory survives identically to the string form.
+        $result = xoops_resolveThemeConfig([
+            'theme_set'         => 0,
+            'theme_set_allowed' => ['0', 'default'],
+        ]);
+        $this->assertSame('0', $result['theme_set']);
+        $this->assertContains('0', $result['theme_set_allowed']);
     }
 
     #[Test]

--- a/tests/unit/htdocs/include/ThemeConfigTest.php
+++ b/tests/unit/htdocs/include/ThemeConfigTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once XOOPS_ROOT_PATH . '/include/theme_config.php';
+
+/**
+ * Coverage for xoops_validateThemeName() and xoops_resolveThemeConfig()
+ * in htdocs/include/theme_config.php. The helpers consolidate the
+ * defensive normalisation previously inlined in
+ * b_system_themes_show() so that every runtime reader of
+ * theme_set / theme_set_allowed shares one source of truth.
+ *
+ * Validation contract is fail-empty: invalid names return '', invalid
+ * config entries are dropped, current theme always survives in the
+ * allowed list, and a totally-corrupted config falls back to 'default'.
+ */
+#[CoversFunction('xoops_validateThemeName')]
+#[CoversFunction('xoops_resolveThemeConfig')]
+class ThemeConfigTest extends TestCase
+{
+    #[Test]
+    public function validateRejectsEmptyString(): void
+    {
+        $this->assertSame('', xoops_validateThemeName(''));
+    }
+
+    #[Test]
+    public function validateTrimsSurroundingWhitespace(): void
+    {
+        $this->assertSame('default', xoops_validateThemeName('  default  '));
+    }
+
+    #[Test]
+    public function validateRejectsLeadingDot(): void
+    {
+        $this->assertSame('', xoops_validateThemeName('.hidden'));
+        $this->assertSame('', xoops_validateThemeName('..'));
+    }
+
+    #[Test]
+    public function validateRejectsForwardSlash(): void
+    {
+        $this->assertSame('', xoops_validateThemeName('foo/bar'));
+    }
+
+    #[Test]
+    public function validateRejectsBackslash(): void
+    {
+        $this->assertSame('', xoops_validateThemeName('foo\\bar'));
+    }
+
+    #[Test]
+    public function validateRejectsNullByte(): void
+    {
+        $this->assertSame('', xoops_validateThemeName("foo\0bar"));
+    }
+
+    #[Test]
+    public function validateRejectsParentDirSegment(): void
+    {
+        $this->assertSame('', xoops_validateThemeName('foo/../bar'));
+        $this->assertSame('', xoops_validateThemeName('foo\\..\\bar'));
+    }
+
+    #[Test]
+    public function validateRejectsHtmlMetacharacters(): void
+    {
+        $this->assertSame('', xoops_validateThemeName('foo<bar'));
+        $this->assertSame('', xoops_validateThemeName('foo>bar'));
+        $this->assertSame('', xoops_validateThemeName('foo&bar'));
+        $this->assertSame('', xoops_validateThemeName('foo"bar'));
+        $this->assertSame('', xoops_validateThemeName("foo'bar"));
+    }
+
+    #[Test]
+    public function validateAcceptsThemeNamedZero(): void
+    {
+        $this->assertSame('0', xoops_validateThemeName('0'));
+    }
+
+    #[Test]
+    public function validateAcceptsSpaces(): void
+    {
+        $this->assertSame('My Theme', xoops_validateThemeName('My Theme'));
+    }
+
+    #[Test]
+    public function validateAcceptsNonAsciiNames(): void
+    {
+        $this->assertSame('テーマ', xoops_validateThemeName('テーマ'));
+        $this->assertSame('주제', xoops_validateThemeName('주제'));
+    }
+
+    #[Test]
+    public function resolveFallsBackToDefaultOnFullyMissingConfig(): void
+    {
+        $result = xoops_resolveThemeConfig([]);
+        $this->assertSame('default', $result['theme_set']);
+        $this->assertSame(['default'], $result['theme_set_allowed']);
+    }
+
+    #[Test]
+    public function resolveSplitsPipeStringAllowedList(): void
+    {
+        $result = xoops_resolveThemeConfig([
+            'theme_set'         => 'default',
+            'theme_set_allowed' => 'default|xswatch5|xtailwind2',
+        ]);
+        $this->assertSame(
+            ['default', 'xswatch5', 'xtailwind2'],
+            $result['theme_set_allowed']
+        );
+    }
+
+    #[Test]
+    public function resolveSkipsNonScalarAllowedEntries(): void
+    {
+        $result = xoops_resolveThemeConfig([
+            'theme_set'         => 'default',
+            'theme_set_allowed' => ['default', ['nested'], (object) ['x' => 1], null, 'xswatch5'],
+        ]);
+        $this->assertSame(['default', 'xswatch5'], $result['theme_set_allowed']);
+    }
+
+    #[Test]
+    public function resolveDropsInvalidAllowedNames(): void
+    {
+        $result = xoops_resolveThemeConfig([
+            'theme_set'         => 'default',
+            'theme_set_allowed' => ['default', '../etc', 'foo<script>', "evil\0null", 'xswatch5'],
+        ]);
+        $this->assertSame(['default', 'xswatch5'], $result['theme_set_allowed']);
+    }
+
+    #[Test]
+    public function resolveRetainsThemeNamedZero(): void
+    {
+        $result = xoops_resolveThemeConfig([
+            'theme_set'         => '0',
+            'theme_set_allowed' => ['0', 'default'],
+        ]);
+        $this->assertSame('0', $result['theme_set']);
+        $this->assertSame(['0', 'default'], $result['theme_set_allowed']);
+    }
+
+    #[Test]
+    public function resolveSplitsPipeStringRetainingZero(): void
+    {
+        $result = xoops_resolveThemeConfig([
+            'theme_set'         => '0',
+            'theme_set_allowed' => '0|default',
+        ]);
+        $this->assertSame(['0', 'default'], $result['theme_set_allowed']);
+    }
+
+    #[Test]
+    public function resolveInjectsCurrentThemeWhenValidButAbsent(): void
+    {
+        $result = xoops_resolveThemeConfig([
+            'theme_set'         => 'mytheme',
+            'theme_set_allowed' => ['default', 'xswatch5'],
+        ]);
+        $this->assertSame('mytheme', $result['theme_set']);
+        $this->assertSame(['mytheme', 'default', 'xswatch5'], $result['theme_set_allowed']);
+    }
+
+    #[Test]
+    public function resolveFallsCurrentBackToDefaultWhenCorrupted(): void
+    {
+        $result = xoops_resolveThemeConfig([
+            'theme_set'         => '../etc/passwd',
+            'theme_set_allowed' => ['default', 'xswatch5'],
+        ]);
+        $this->assertSame('default', $result['theme_set']);
+        $this->assertContains('default', $result['theme_set_allowed']);
+    }
+
+    #[Test]
+    public function resolveFallsAllowedToCurrentWhenAllInvalid(): void
+    {
+        $result = xoops_resolveThemeConfig([
+            'theme_set'         => 'default',
+            'theme_set_allowed' => ['../etc', "evil\0null", ['nested']],
+        ]);
+        $this->assertSame('default', $result['theme_set']);
+        $this->assertSame(['default'], $result['theme_set_allowed']);
+    }
+
+    #[Test]
+    public function resolveSkipsNonStringCurrentTheme(): void
+    {
+        $result = xoops_resolveThemeConfig([
+            'theme_set'         => ['array', 'value'],
+            'theme_set_allowed' => ['xswatch5'],
+        ]);
+        $this->assertSame('default', $result['theme_set']);
+    }
+
+    #[Test]
+    public function resolveDedupesAllowedList(): void
+    {
+        $result = xoops_resolveThemeConfig([
+            'theme_set'         => 'default',
+            'theme_set_allowed' => ['default', 'xswatch5', 'default', 'xswatch5'],
+        ]);
+        $this->assertSame(['default', 'xswatch5'], $result['theme_set_allowed']);
+    }
+
+    #[Test]
+    public function resolveTreatsNonArrayNonStringAllowedAsEmpty(): void
+    {
+        $result = xoops_resolveThemeConfig([
+            'theme_set'         => 'default',
+            'theme_set_allowed' => 42,
+        ]);
+        $this->assertSame(['default'], $result['theme_set_allowed']);
+    }
+}


### PR DESCRIPTION
## Summary

Single source of truth for `theme_set` / `theme_set_allowed` validation so every runtime reader — header render, login, remember-me, theme factory, `xoops_getcss`, the System theme block, and the kernel theme switcher — sees the same fail-empty contract.

Closes #45.

Extends the closure-based defence PR #44 added to the System theme block into a process-wide guarantee, and plugs three real session-trust / path-construction leaks the issue's table didn't enumerate.

## What this PR does

### 1. Two new helpers in `htdocs/include/theme_config.php`

```php
xoops_validateThemeName(string $name): string
xoops_resolveThemeConfig(array $xoopsConfig): array
```

- `xoops_validateThemeName` — fail-empty path + HTML safety check (rejects path separators, null bytes, leading dot, `..` segments, `< > & " '`). Spaces and non-ASCII names pass through unchanged so legitimate `My Theme` and CJK theme directories keep working.
- `xoops_resolveThemeConfig` — returns `['theme_set' => string, 'theme_set_allowed' => list<string>]` with non-scalar entries dropped, pipe-string allowed lists split, current theme injected into the allowed list when valid but absent, and `'default'` as the universal fallback.

Required transitively via `include/functions.php`.

### 2. Boundary normalise in `include/common.php`

Immediately after the file+DB config merge, `$xoopsConfig` is `array_replace`d with the resolved pair. Plain reads of those keys in code loaded afterwards (`header.php`, `site-closed.php`, the editors, the CSS URL helpers, the smarty resource plugin) are then **safe-by-invariant** — no per-call-site sweep needed for cosmetic reads.

### 3. Decision-point callers normalize explicitly

Six callers go through the resolver at the call site, even where the boundary normalise already covers them, so the intent is obvious and the code survives any future caller that hits the path without going through `common.php` (CLI entry, partial init):

- `htdocs/include/checklogin.php`
- `htdocs/include/common.php` remember-me branch
- `htdocs/include/site-closed.php`
- `htdocs/header.php`
- `htdocs/class/xoopsform/formselecttheme.php`
- `htdocs/modules/system/blocks/system_blocks.php`

### 4. Kernel theme switcher (separate cache layer)

`xoops_getConfigOption('theme_set'*)` reads through `XoopsConfigHandler`'s in-memory cache, which is **not** covered by the boundary normalise. `xos_kernel_Xoops2::themeSelect()` now:

- Resolves at the call site.
- Validates the submitted theme name AND the session-stored theme name before strict-membership checks.
- Uses `in_array(..., true)` so a theme literally named `0` doesn't coerce to false against arbitrary allowed entries.

### 5. `htdocs/class/theme.php` hardening (three real bugs)

- **Session-trust branch.** `$_SESSION[$this->xoBundleIdentifier]['defaultTheme']` in `createInstance()` was previously assigned to `$options['folderName']` without any validation or membership check, then used as a path segment when constructing `$testPath`. A stale session value (admin removed the theme from the allowed list, manually-poisoned session) reached `file_exists()` unvalidated. Now validated AND required to pass `isThemeAllowed()` before assignment.
- **Mid-request writes.** The two writes to `$GLOBALS['xoopsConfig']['theme_set']` inside `createInstance()` are piped through `xoops_validateThemeName()` so the boundary invariant set by `common.php` holds for every downstream reader.
- **Loose `in_array`.** `isThemeAllowed()` now uses `in_array(..., true)` — a theme literally named `0` no longer matches every allowed entry.

### 6. `xoops_getcss()` defence in depth

Validates its `$theme` parameter and falls back via the resolver when empty, so a future caller passing raw input cannot reach the `<link href=>` attribute or filesystem checks unvalidated.

### 7. Pre-commit regression sniffs

Two new sniffs in `.githooks/pre-commit`:

- Loose `in_array(..., $xoopsConfig['theme_set_allowed'])` — strict comparison required.
- Raw assignment `$xoopsThemeFactory->allowedThemes = $xoopsConfig['theme_set_allowed']` — must go through the resolver.

### 8. Tests

`tests/unit/htdocs/include/ThemeConfigTest.php` covers the full validation matrix:

- Rejection cases (empty, leading dot, `/`, `\`, null byte, parent-dir segment, HTML metachars).
- Theme literally named `0`.
- Spaces and non-ASCII (CJK).
- Pipe-string `theme_set_allowed` splitting.
- Non-scalar allowed entries filtered out.
- Current theme injected when valid but absent from allowed list.
- Corrupted current theme falls back to `default`.
- Allowed list deduped.
- Non-array, non-string `theme_set_allowed` treated as empty.

## Files changed (12)

**New (2)**
- `htdocs/include/theme_config.php`
- `tests/unit/htdocs/include/ThemeConfigTest.php`

**Modified (10)**
- `htdocs/include/common.php`
- `htdocs/include/functions.php`
- `htdocs/include/checklogin.php`
- `htdocs/include/site-closed.php`
- `htdocs/header.php`
- `htdocs/class/theme.php`
- `htdocs/class/xoopsform/formselecttheme.php`
- `htdocs/class/xoopskernel.php`
- `htdocs/modules/system/blocks/system_blocks.php`
- `.githooks/pre-commit`

## Out of scope

Same exclusions the issue called out — admin-side theme-list editors (the saved-value path) and directory-name regex vs on-disk existence checks are not addressed here.

## Test plan

- [ ] CI green: PHPUnit + PHPStan + Psalm gates.
- [ ] `ThemeConfigTest` covers all 22 cases listed above.
- [ ] Manual: install with `default` + one custom theme; switch via the System block; log out / in; verify `xoopsUserTheme` round-trips.
- [ ] Manual: corrupt `xoops_config.theme_set_allowed` with a non-string row; visit any page — front + admin must still render with the `default` fallback (no fatal, no warning).
- [ ] Manual: visit the site with `?xoops_theme_select=../etc/passwd` — must be rejected at the factory, fall back to default.
- [ ] Manual: log in with a `users.theme` value of `My Theme` (with space) — must round-trip through `checklogin.php` and `common.php` remember-me.
- [ ] `bash .githooks/pre-commit` against a synthetic staged change that re-introduces a loose `in_array` on `theme_set_allowed` — must reject.

## References

- PR #44 — the block-level closure this consolidates.
- Issue #45 — original report and table of raw read sites.
- CodeRabbit r3181806248 — surfaced the cross-file inconsistency on PR #44.

## Summary by Sourcery

Centralize theme configuration normalization and harden theme selection across the runtime to enforce consistent, validated theme_set and theme_set_allowed usage.

Bug Fixes:
- Prevent unsafe theme names from reaching filesystem paths, session-driven theme selection, and HTML output by validating and normalizing theme configuration at all decision points.
- Fix loose in_array checks in theme allowance logic so themes named "0" no longer match unintended entries and stale session themes cannot bypass the allowed list.

Enhancements:
- Introduce shared helpers to validate theme names and resolve theme_set/theme_set_allowed, and apply them at the configuration boundary and key runtime call sites including header, login, remember-me, and theme selectors.
- Align theme factory, kernel theme switcher, and form theme selector with the centralized theme configuration helpers for consistent behavior and safer defaults across the application.

Tests:
- Add ThemeConfigTest to cover the validation and normalization behavior of the new theme configuration helpers, including edge cases and corrupted configuration inputs.

Chores:
- Extend the pre-commit hook to flag loose in_array checks on theme_set_allowed and raw assignments to the theme factory's allowedThemes, enforcing the new normalization patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized theme validation and config normalization helpers added.

* **Bug Fixes**
  * Stricter theme name/value validation and safer handling across initialization, login, session, template selection, and asset lookup.
  * Enforced strict allowed-theme matching and consistent fallback/default behavior, preserving valid edge-case names like "0".

* **Tests**
  * Comprehensive unit tests for theme validation and config resolution.

* **Chores**
  * Enhanced pre-commit lint checks for staged PHP changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XOOPS/XoopsCore27/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->