### PR TITLE
2.7.1 updates

### DIFF
--- a/docs/lang_diff.txt
+++ b/docs/lang_diff.txt
@@ -4,14 +4,17 @@ LANGUAGE DIFFERENCES
 Below are language differences from a version to next version.
 
 ================================
+2026/05/17: Version 2.7.1-Betas
+================================
+/htdocs/modules/system/language/english/admin/blocksadmin.php
+- added define('_AM_SYSTEM_BLOCKS_INVALID_CLONE', 'Invalid block parameters.');
+
+================================
 2025/03/30: Version 2.7.0-Betas (previously released as 2.5.12-Betas)
 ================================
 /htdocs/install/language/english/install.php
 - added define('MISSING_REQUIRED_EXTENSIONS', 'Required PHP extensions are missing');
 - added define('MISSING_REQUIRED_EXTENSIONS_MSG', 'XOOPS cannot be installed because the following mandatory PHP extension(s) are not available: %s. Enable them in your PHP configuration (php.ini) and restart your web server, then reload this page.');
-
-/htdocs/modules/system/language/english/admin/blocksadmin.php
-- added define('_AM_SYSTEM_BLOCKS_INVALIDCLONE', 'Invalid block parameters.');
 
 /htdocs/modules/system/language/english/admin.php
 - added define('_AM_SYSTEM_MENUS', 'Menus');

--- a/htdocs/include/version.php
+++ b/htdocs/include/version.php
@@ -32,4 +32,4 @@ if (file_exists($licenseFile)) {
 /**
  *  Define XOOPS version
  */
-define('XOOPS_VERSION', 'XOOPS 2.7.0');
+define('XOOPS_VERSION', 'XOOPS 2.7.1-Beta1');

--- a/htdocs/modules/debugbar/class/DebugbarLogger.php
+++ b/htdocs/modules/debugbar/class/DebugbarLogger.php
@@ -361,6 +361,9 @@ class DebugbarLogger
             return;
         }
 
+        $helper = Helper::getInstance();
+        $helper->loadLanguage('main');
+
         // Normalize values for display
         foreach ($data as $k => $v) {
             if ($v === '') {

--- a/htdocs/modules/system/admin/blocksadmin/main.php
+++ b/htdocs/modules/system/admin/blocksadmin/main.php
@@ -315,7 +315,7 @@ switch ($op) {
                     || false !== strpos($clone_dirname, '\\')
                     || false !== strpos($clone_dirname, '..')
                     || false !== strpos($clone_dirname, "\0"))) {
-                redirect_header('admin.php?fct=blocksadmin', 3, _AM_SYSTEM_BLOCKS_INVALIDCLONE);
+                redirect_header('admin.php?fct=blocksadmin', 3, _AM_SYSTEM_BLOCKS_INVALID_CLONE);
             }
             // func_file is the block PHP file under modules/<dirname>/blocks/
             // (a subdirectory is allowed - some modules nest block files);
@@ -328,12 +328,12 @@ switch ($op) {
                         || false !== strpos($clone_path, '\\')
                         || false !== strpos($clone_path, "\0")
                         || str_starts_with($clone_path, '/'))) {
-                    redirect_header('admin.php?fct=blocksadmin', 3, _AM_SYSTEM_BLOCKS_INVALIDCLONE);
+                    redirect_header('admin.php?fct=blocksadmin', 3, _AM_SYSTEM_BLOCKS_INVALID_CLONE);
                 }
             }
             foreach ([$clone_show_func, $clone_edit_func] as $clone_func) {
                 if ($clone_func !== '' && !preg_match('/^[A-Za-z_]\w*$/', $clone_func)) {
-                    redirect_header('admin.php?fct=blocksadmin', 3, _AM_SYSTEM_BLOCKS_INVALIDCLONE);
+                    redirect_header('admin.php?fct=blocksadmin', 3, _AM_SYSTEM_BLOCKS_INVALID_CLONE);
                 }
             }
 

--- a/htdocs/modules/system/language/english/admin/blocksadmin.php
+++ b/htdocs/modules/system/language/english/admin/blocksadmin.php
@@ -88,4 +88,4 @@ define('_AM_SYSTEM_BLOCKS_TIPS', '<ul>
 define('_AM_SYSTEM_BLOCKS_FOOTER_LEFT', 'Footer Left');
 define('_AM_SYSTEM_BLOCKS_FOOTER_CENTER', 'Footer Center');
 define('_AM_SYSTEM_BLOCKS_FOOTER_RIGHT', 'Footer Right');
-define('_AM_SYSTEM_BLOCKS_INVALIDCLONE', 'Invalid block parameters.');
+define('_AM_SYSTEM_BLOCKS_INVALID_CLONE', 'Invalid block parameters.');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -387,8 +387,10 @@ if (!defined('XOOPS_THEME_PATH')) {
 }
 
 // XOOPS version + cache path (needed by Frameworks)
+// Source the real version.php so VersionTest exercises the shipped value
+// rather than a duplicated literal that silently drifts on each bump.
 if (!defined('XOOPS_VERSION')) {
-    define('XOOPS_VERSION', 'XOOPS 2.7.0-RC1');
+    require_once XOOPS_ROOT_PATH . '/include/version.php';
 }
 if (!defined('XOOPS_CACHE_PATH')) {
     define('XOOPS_CACHE_PATH', XOOPS_VAR_PATH . '/caches/xoops_cache');

--- a/tests/unit/htdocs/include/VersionTest.php
+++ b/tests/unit/htdocs/include/VersionTest.php
@@ -41,8 +41,9 @@ class VersionTest extends TestCase
 
     public function testXoopsVersionValue()
     {
-        // Verify the version starts with the expected major.minor.patch
-        $this->assertStringStartsWith('XOOPS 2.7.0', XOOPS_VERSION, 'Version should start with XOOPS 2.7.0');
+        // Verify the version starts with the expected major.minor line
+        // (kept at 2.7. so patch/pre-release bumps within the line don't churn this test)
+        $this->assertStringStartsWith('XOOPS 2.7.', XOOPS_VERSION, 'Version should start with XOOPS 2.7.');
     }
 
     public function testXoopsVersionContainsXoopsPrefix()


### PR DESCRIPTION
## Summary by Sourcery

Update language constants and version metadata for the 2.7.1 beta release.

Bug Fixes:
- Align block cloning validation to use the correct INVALID_CLONE language constant instead of the deprecated name.
- Ensure Debugbar logger loads its language file before normalizing Smarty data.

Enhancements:
- Bump core XOOPS version string to 2.7.1-Beta1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated to version 2.7.1-Beta1

* **Bug Fixes**
  * Corrected block cloning validation message constant naming in the system blocks admin module

* **Tests**
  * Updated test bootstrap to dynamically load version from configuration
  * Relaxed version assertion to support patch-level updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XOOPS/XoopsCore27/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->