### PR TITLE
fix(theme/default): keep inline rich text baseline aligned

### DIFF
--- a/htdocs/modules/system/themes/default/css/reset.css
+++ b/htdocs/modules/system/themes/default/css/reset.css
@@ -20,6 +20,9 @@ table, caption, tbody, tfoot, thead, tr, th, td {
     font-style:         inherit;
     font-size:             100%;
     font-family:         inherit;
+    }
+
+table, caption, tbody, tfoot, thead, tr, th, td {
     vertical-align:     top;
     }
 /* remember to define focus styles! */


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure inline rich text keeps its baseline alignment by no longer applying top vertical alignment globally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted CSS selector organization for improved code consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/XOOPS/XoopsCore27/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->