### PR TITLE
feat(form): add XoopsFormTabTray tabbed widget + themed renderers

### DIFF
--- a/htdocs/class/xoopsform/formtabtray.php
+++ b/htdocs/class/xoopsform/formtabtray.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * XOOPS form element - tabbed group of elements
+ *
+ * You may not change or alter any portion of this comment or credits
+ * of supporting developers from this source code or any supporting source code
+ * which is considered copyrighted (c) material of the original comment or credit authors.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @link      https://xoops.org
+ */
+
+defined('XOOPS_ROOT_PATH') || exit('Restricted access');
+
+require_once __DIR__ . '/renderer/XoopsFormTabRendererInterface.php';
+
+/**
+ * A tabbed group of form elements.
+ *
+ * Like {@link XoopsFormElementTray} this is a container element: you add it to a
+ * form with $form->addElement($tabTray), and the elements you place inside it
+ * stay part of the owning form, so "required" handling and the form's generated
+ * client-side validation work across every tab automatically.
+ *
+ * Usage:
+ * <code>
+ * $tabs = new XoopsFormTabTray('', 'mytabs');
+ * $tabs->addTab(_MD_CONTENT);
+ * $tabs->addElement(new XoopsFormText(...), true);
+ * $tabs->addTab(_MD_META);
+ * $tabs->addElement(new XoopsFormText(...));
+ * $form->addElement($tabs);
+ * </code>
+ *
+ * Presentation is delegated: when the active renderer implements
+ * {@link XoopsFormTabRendererInterface} that renderer produces the markup
+ * (allowing Bootstrap/Tailwind/etc. tab styles); otherwise the element emits a
+ * framework-neutral fallback whose panes are only collapsed once JavaScript adds
+ * the `js-xoops-tabs` hook — so with scripting disabled every pane stays visible
+ * and the form remains fully usable.
+ */
+class XoopsFormTabTray extends XoopsFormElement
+{
+    /**
+     * Tab panes: each entry is ['title' => string, 'elements' => XoopsFormElement[]].
+     *
+     * @var array
+     */
+    private $_tabs = [];
+
+    /**
+     * Flat list of every child element, in add order (mirrors XoopsFormElementTray
+     * so getElements() can be returned by reference for the owning form).
+     *
+     * @var XoopsFormElement[]
+     */
+    private $_elements = [];
+
+    /**
+     * Required child elements, bubbled up to the owning form.
+     *
+     * @var XoopsFormElement[]
+     */
+    public $_required = [];
+
+    /**
+     * Index of the tab currently receiving addElement(); -1 until the first tab.
+     *
+     * @var int
+     */
+    private $_currentTab = -1;
+
+    /**
+     * Process-wide counter giving each rendered tray a unique DOM id even when
+     * the element has no name.
+     *
+     * @var int
+     */
+    private static $idSeq = 0;
+
+    /**
+     * Emit the shared fallback CSS/JS only once per request.
+     *
+     * @var bool
+     */
+    protected static $assetsRendered = false;
+
+    /**
+     * Constructor.
+     *
+     * @param string $caption caption for the group (often empty for tabs)
+     * @param string $name    element name, used as a DOM id prefix when present
+     */
+    public function __construct($caption = '', $name = '')
+    {
+        $this->setName($name);
+        $this->setCaption($caption);
+    }
+
+    /**
+     * This element contains other elements.
+     *
+     * @return bool true
+     */
+    public function isContainer()
+    {
+        return true;
+    }
+
+    /**
+     * Are there any required elements anywhere in the tabs?
+     *
+     * @return bool
+     */
+    public function isRequired()
+    {
+        return !empty($this->_required);
+    }
+
+    /**
+     * Start a new tab pane. Elements added afterwards belong to it until the
+     * next addTab() call.
+     *
+     * @param string $title tab label
+     *
+     * @return int the new tab's index
+     */
+    public function addTab($title)
+    {
+        $this->_tabs[]     = ['title' => (string) $title, 'elements' => []];
+        $this->_currentTab = count($this->_tabs) - 1;
+
+        return $this->_currentTab;
+    }
+
+    /**
+     * Add an element to the current tab. If no tab has been started yet, an
+     * untitled one is created so the element is never lost.
+     *
+     * @param XoopsFormElement $formElement element to add
+     * @param bool             $required    mark the element required?
+     */
+    public function addElement(XoopsFormElement $formElement, $required = false)
+    {
+        if ($this->_currentTab < 0) {
+            $this->addTab('');
+        }
+        $this->_tabs[$this->_currentTab]['elements'][] = $formElement;
+        $this->_elements[]                             = $formElement;
+
+        if (!$formElement->isContainer()) {
+            if ($required) {
+                $formElement->_required = true;
+                $this->_required[]      = $formElement;
+            }
+        } else {
+            $required_elements = $formElement->getRequired();
+            $count             = count($required_elements);
+            for ($i = 0; $i < $count; ++$i) {
+                $this->_required[] = &$required_elements[$i];
+            }
+        }
+    }
+
+    /**
+     * Get the required elements (by reference, so the owning form can merge them).
+     *
+     * @return XoopsFormElement[]
+     */
+    public function &getRequired()
+    {
+        return $this->_required;
+    }
+
+    /**
+     * Get the tab panes for a renderer to lay out.
+     *
+     * @return array list of ['title' => string, 'elements' => XoopsFormElement[]]
+     */
+    public function getTabs()
+    {
+        return $this->_tabs;
+    }
+
+    /**
+     * Get the child elements. With $recurse, nested containers are flattened so
+     * the owning form sees every leaf element (for validation JS, etc.).
+     *
+     * @param bool $recurse flatten nested containers?
+     *
+     * @return XoopsFormElement[]
+     */
+    public function &getElements($recurse = false)
+    {
+        if (!$recurse) {
+            return $this->_elements;
+        }
+
+        $ret   = [];
+        $count = count($this->_elements);
+        for ($i = 0; $i < $count; ++$i) {
+            if (!$this->_elements[$i]->isContainer()) {
+                $ret[] = &$this->_elements[$i];
+            } else {
+                $elements = &$this->_elements[$i]->getElements(true);
+                $count2   = count($elements);
+                for ($j = 0; $j < $count2; ++$j) {
+                    $ret[] = &$elements[$j];
+                }
+                unset($elements);
+            }
+        }
+
+        return $ret;
+    }
+
+    /**
+     * Render the tabbed group. Delegates to a tab-aware renderer when one is
+     * active; otherwise emits the self-contained fallback.
+     *
+     * @return string
+     */
+    public function render()
+    {
+        $renderer = XoopsFormRenderer::getInstance()->get();
+        if ($renderer instanceof XoopsFormTabRendererInterface) {
+            return $renderer->renderFormTabTray($this);
+        }
+
+        return $this->renderFallback();
+    }
+
+    /**
+     * Framework-neutral rendering used when the active renderer has no tab
+     * support. Panes are hidden only under the JS-added `js-xoops-tabs` hook, so
+     * the form degrades to all-panes-visible without JavaScript.
+     *
+     * @return string
+     */
+    protected function renderFallback()
+    {
+        $base   = $this->getName();
+        $id     = 'xoops_tabs_' . ('' !== $base ? preg_replace('/[^a-z0-9]+/i', '', $base) . '_' : '') . ++self::$idSeq;
+        $hidden = '';
+        $nav    = '';
+        $panes  = '';
+
+        foreach ($this->_tabs as $k => $tab) {
+            $active = (0 === $k) ? ' xoops-tab-active' : '';
+            $nav   .= '<li class="xoops-tab' . $active . '"><a href="#' . $id . '_' . $k . '" data-xoops-tab="' . $k . '">'
+                    . htmlspecialchars((string) $tab['title'], ENT_QUOTES | ENT_HTML5) . '</a></li>';
+
+            $rows = '';
+            foreach ($tab['elements'] as $ele) {
+                if ($ele->isHidden()) {
+                    $hidden .= $ele->render();
+                    continue;
+                }
+                $rows .= $this->renderRow($ele);
+            }
+            $panes .= '<fieldset class="xoops-tabpane' . $active . '" id="' . $id . '_' . $k . '">'
+                    . '<table class="outer" cellspacing="1">' . $rows . '</table></fieldset>';
+        }
+
+        return '<div class="xoops-tabs" id="' . $id . '"><ul class="xoops-tabnav">' . $nav . '</ul>'
+            . $panes . '</div>' . $hidden . $this->renderTabAssets();
+    }
+
+    /**
+     * Render one caption/control row for a visible element.
+     *
+     * @param XoopsFormElement $ele element to render
+     *
+     * @return string
+     */
+    protected function renderRow(XoopsFormElement $ele)
+    {
+        $ret     = '<tr valign="top" align="left"><td class="head">';
+        $caption = $ele->getCaption();
+        if ('' !== $caption) {
+            $ret .= '<div class="xoops-form-element-caption' . ($ele->isRequired() ? '-required' : '') . '">'
+                  . '<span class="caption-text">' . $caption . '</span>';
+            if ($ele->isRequired()) {
+                $ret .= '<span class="caption-marker">*</span>';
+            }
+            $ret .= '</div>';
+        }
+        $desc = $ele->getDescription();
+        if ('' !== $desc) {
+            $ret .= '<div class="xoops-form-element-help">' . $desc . '</div>';
+        }
+        $ret .= '</td><td class="even">' . $ele->render() . '</td></tr>';
+
+        return $ret;
+    }
+
+    /**
+     * Inline CSS + vanilla-JS tab switcher for the fallback, emitted once per
+     * request. The script adds `js-xoops-tabs`, under which inactive panes are
+     * hidden; without JavaScript no pane is ever hidden.
+     *
+     * @return string
+     */
+    protected function renderTabAssets()
+    {
+        if (self::$assetsRendered) {
+            return '';
+        }
+        self::$assetsRendered = true;
+
+        $css = '<style>'
+             . '.xoops-tabnav{list-style:none;margin:0;padding:0;display:flex;flex-wrap:wrap;gap:2px;border-bottom:1px solid #ccc}'
+             . '.xoops-tabnav li a{display:block;padding:6px 14px;text-decoration:none;border:1px solid transparent;border-bottom:none}'
+             . '.xoops-tabnav li.xoops-tab-active a{border-color:#ccc;background:#fff;font-weight:bold;border-radius:4px 4px 0 0}'
+             . '.xoops-tabpane{border:1px solid #ccc;border-top:none;padding:10px;margin:0 0 10px}'
+             . '.js-xoops-tabs .xoops-tabpane:not(.xoops-tab-active){display:none}'
+             . '</style>';
+
+        $js = '<script>(function(){'
+            . "var roots=document.querySelectorAll('.xoops-tabs');"
+            . 'Array.prototype.forEach.call(roots,function(root){'
+            . "root.classList.add('js-xoops-tabs');"
+            . "var links=root.querySelectorAll('.xoops-tabnav a');"
+            . 'Array.prototype.forEach.call(links,function(link){'
+            . "link.addEventListener('click',function(e){"
+            . 'e.preventDefault();'
+            . "var k=link.getAttribute('data-xoops-tab');"
+            . "Array.prototype.forEach.call(root.querySelectorAll('.xoops-tabnav li'),function(li){li.classList.remove('xoops-tab-active');});"
+            . "link.parentNode.classList.add('xoops-tab-active');"
+            . "Array.prototype.forEach.call(root.querySelectorAll('.xoops-tabpane'),function(p){p.classList.remove('xoops-tab-active');});"
+            . "var pane=document.getElementById(root.id+'_'+k);"
+            . "if(pane){pane.classList.add('xoops-tab-active');}"
+            . '});});});'
+            . '})();</script>';
+
+        return $css . $js;
+    }
+}

--- a/htdocs/class/xoopsform/formtabtray.php
+++ b/htdocs/class/xoopsform/formtabtray.php
@@ -257,9 +257,15 @@ class XoopsFormTabTray extends XoopsFormElement
         $panes  = '';
 
         foreach ($this->_tabs as $k => $tab) {
-            $active = (0 === $k) ? ' xoops-tab-active' : '';
-            $nav   .= '<li class="xoops-tab' . $active . '"><a href="#' . $id . '_' . $k . '" data-xoops-tab="' . $k . '">'
-                    . htmlspecialchars((string) $tab['title'], ENT_QUOTES | ENT_HTML5) . '</a></li>';
+            $isActive = (0 === $k);
+            $active   = $isActive ? ' xoops-tab-active' : '';
+            $paneId   = $id . '_' . $k;
+            $tabId    = $id . '_tab_' . $k;
+
+            $nav .= '<li class="xoops-tab' . $active . '" role="presentation">'
+                  . '<a id="' . $tabId . '" href="#' . $paneId . '" data-xoops-tab="' . $k . '"'
+                  . ' role="tab" aria-controls="' . $paneId . '" aria-selected="' . ($isActive ? 'true' : 'false') . '">'
+                  . htmlspecialchars((string) $tab['title'], ENT_QUOTES | ENT_HTML5) . '</a></li>';
 
             $rows = '';
             foreach ($tab['elements'] as $ele) {
@@ -269,11 +275,12 @@ class XoopsFormTabTray extends XoopsFormElement
                 }
                 $rows .= $this->renderRow($ele);
             }
-            $panes .= '<fieldset class="xoops-tabpane' . $active . '" id="' . $id . '_' . $k . '">'
+            $panes .= '<fieldset class="xoops-tabpane' . $active . '" id="' . $paneId . '"'
+                    . ' role="tabpanel" aria-labelledby="' . $tabId . '">'
                     . '<table class="outer" cellspacing="1">' . $rows . '</table></fieldset>';
         }
 
-        return '<div class="xoops-tabs" id="' . $id . '"><ul class="xoops-tabnav">' . $nav . '</ul>'
+        return '<div class="xoops-tabs" id="' . $id . '"><ul class="xoops-tabnav" role="tablist">' . $nav . '</ul>'
             . $panes . '</div>' . $hidden . $this->renderTabAssets();
     }
 
@@ -337,7 +344,9 @@ class XoopsFormTabTray extends XoopsFormElement
             . 'e.preventDefault();'
             . "var k=link.getAttribute('data-xoops-tab');"
             . "Array.prototype.forEach.call(root.querySelectorAll('.xoops-tabnav li'),function(li){li.classList.remove('xoops-tab-active');});"
+            . "Array.prototype.forEach.call(root.querySelectorAll('.xoops-tabnav a'),function(a){a.setAttribute('aria-selected','false');});"
             . "link.parentNode.classList.add('xoops-tab-active');"
+            . "link.setAttribute('aria-selected','true');"
             . "Array.prototype.forEach.call(root.querySelectorAll('.xoops-tabpane'),function(p){p.classList.remove('xoops-tab-active');});"
             . "var pane=document.getElementById(root.id+'_'+k);"
             . "if(pane){pane.classList.add('xoops-tab-active');}"

--- a/htdocs/class/xoopsform/formtabtray.php
+++ b/htdocs/class/xoopsform/formtabtray.php
@@ -250,7 +250,7 @@ class XoopsFormTabTray extends XoopsFormElement
      */
     protected function renderFallback()
     {
-        $base   = $this->getName();
+        $base   = $this->getName(false);
         $id     = 'xoops_tabs_' . ('' !== $base ? preg_replace('/[^a-z0-9]+/i', '', $base) . '_' : '') . ++self::$idSeq;
         $hidden = '';
         $nav    = '';

--- a/htdocs/class/xoopsform/formtabtray.php
+++ b/htdocs/class/xoopsform/formtabtray.php
@@ -82,6 +82,13 @@ class XoopsFormTabTray extends XoopsFormElement
     private $_currentTab = -1;
 
     /**
+     * Index of the tab that should be shown first when rendered.
+     *
+     * @var int
+     */
+    private $_activeTab = 0;
+
+    /**
      * Process-wide counter giving each rendered tray a unique DOM id even when
      * the element has no name.
      *
@@ -104,6 +111,9 @@ class XoopsFormTabTray extends XoopsFormElement
      */
     public function __construct($caption = '', $name = '')
     {
+        // XoopsFormElement::__construct() is a guard that exit()s to prevent
+        // instantiating the base class, so containers set name/caption directly
+        // (matching XoopsFormElementTray) rather than chaining to the parent.
         $this->setName($name);
         $this->setCaption($caption);
     }
@@ -194,6 +204,31 @@ class XoopsFormTabTray extends XoopsFormElement
     }
 
     /**
+     * Get the index of the active tab.
+     *
+     * @return int
+     */
+    public function getActiveTab()
+    {
+        return $this->_activeTab;
+    }
+
+    /**
+     * Set the index of the active tab. The value is clamped to the range of
+     * existing tabs so an out-of-range index can never leave every pane hidden.
+     *
+     * @param int $index tab index
+     *
+     * @return void
+     */
+    public function setActiveTab($index)
+    {
+        $index = (int) $index;
+        $count = count($this->_tabs);
+        $this->_activeTab = ($count > 0) ? max(0, min($index, $count - 1)) : 0;
+    }
+
+    /**
      * Get the child elements. With $recurse, nested containers are flattened so
      * the owning form sees every leaf element (for validation JS, etc.).
      *
@@ -257,14 +292,15 @@ class XoopsFormTabTray extends XoopsFormElement
         $panes  = '';
 
         foreach ($this->_tabs as $k => $tab) {
-            $isActive = (0 === $k);
+            $isActive = ($this->_activeTab === $k);
             $active   = $isActive ? ' xoops-tab-active' : '';
             $paneId   = $id . '_' . $k;
             $tabId    = $id . '_tab_' . $k;
 
             $nav .= '<li class="xoops-tab' . $active . '" role="presentation">'
                   . '<a id="' . $tabId . '" href="#' . $paneId . '" data-xoops-tab="' . $k . '"'
-                  . ' role="tab" aria-controls="' . $paneId . '" aria-selected="' . ($isActive ? 'true' : 'false') . '">'
+                  . ' role="tab" aria-controls="' . $paneId . '" aria-selected="' . ($isActive ? 'true' : 'false') . '"'
+                  . ' title="' . htmlspecialchars((string) $tab['title'], ENT_QUOTES | ENT_HTML5) . '">'
                   . htmlspecialchars((string) $tab['title'], ENT_QUOTES | ENT_HTML5) . '</a></li>';
 
             $rows = '';
@@ -337,6 +373,7 @@ class XoopsFormTabTray extends XoopsFormElement
         $js = '<script>(function(){'
             . "var roots=document.querySelectorAll('.xoops-tabs');"
             . 'Array.prototype.forEach.call(roots,function(root){'
+            . "if(root.classList.contains('js-xoops-tabs')){return;}"
             . "root.classList.add('js-xoops-tabs');"
             . "var links=root.querySelectorAll('.xoops-tabnav a');"
             . 'Array.prototype.forEach.call(links,function(link){'

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap3.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap3.php
@@ -8,6 +8,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+require_once __DIR__ . '/XoopsFormTabRendererInterface.php';
+
 /**
  * Bootstrap3 style form renderer
  *
@@ -17,8 +19,14 @@
  * @copyright 2000-2026 XOOPS Project (https://xoops.org)
  * @license   GNU GPL 2.0 or later (https://www.gnu.org/licenses/gpl-2.0.html)
  */
-class XoopsFormRendererBootstrap3 implements XoopsFormRendererInterface
+class XoopsFormRendererBootstrap3 implements XoopsFormRendererInterface, XoopsFormTabRendererInterface
 {
+    /**
+     * Counter giving each rendered tab tray a unique DOM id.
+     *
+     * @var int
+     */
+    protected static $tabSeq = 0;
     /**
      * Render support for XoopsFormButton
      *
@@ -750,6 +758,12 @@ EOJS;
                 continue;
             }
 
+            if ($element instanceof XoopsFormTabTray) {
+                // tabs own their layout; render full width rather than in a label/value row
+                $ret .= '<div class="form-group">' . $element->render() . '</div>';
+                continue;
+            }
+
             $ret .= '<div class="form-group">';
             if (($caption = $element->getCaption()) != '') {
                 $ret .= '<label for="' . $element->getName() . '" class="col-md-2 control-label">'
@@ -791,5 +805,82 @@ EOJS;
     {
         $class = ($class != '') ? preg_replace('/[^A-Za-z0-9\s\s_-]/i', '', $class) : '';
         $form->addElement('<div class="col-sm-12 ' . $class . '">' . $extra . '</div>');
+    }
+
+    /**
+     * Render support for XoopsFormTabTray using Bootstrap 3 nav-tabs.
+     *
+     * @param XoopsFormTabTray $element the tab tray to render
+     *
+     * @return string rendered HTML
+     */
+    public function renderFormTabTray(XoopsFormTabTray $element): string
+    {
+        $base = $element->getName(false);
+        $id   = 'xo-tabs-' . ('' !== $base ? preg_replace('/[^A-Za-z0-9]+/', '', $base) . '-' : '') . ++self::$tabSeq;
+
+        $nav     = '<ul class="nav nav-tabs" role="tablist" id="' . $id . '">';
+        $content = '<div class="tab-content" id="' . $id . '-content">';
+        $hidden  = '';
+
+        foreach ($element->getTabs() as $k => $tab) {
+            $tabId      = $id . '-tab-' . $k;
+            $paneId     = $id . '-pane-' . $k;
+            $isActive   = ($element->getActiveTab() === $k);
+            $navActive  = $isActive ? ' active' : '';
+            $paneActive = $isActive ? ' active' : '';
+            $selected   = $isActive ? 'true' : 'false';
+
+            $nav .= '<li role="presentation" class="' . $navActive . '">'
+                . '<a href="#' . $paneId . '" aria-controls="' . $paneId . '" role="tab" data-toggle="tab" id="' . $tabId . '" aria-selected="' . $selected . '"'
+                . ' title="' . htmlspecialchars((string) $tab['title'], ENT_QUOTES | ENT_HTML5) . '">'
+                . htmlspecialchars((string) $tab['title'], ENT_QUOTES | ENT_HTML5) . '</a></li>';
+
+            $rows = '';
+            foreach ($tab['elements'] as $ele) {
+                if ($ele->isHidden()) {
+                    $hidden .= $ele->render();
+                    continue;
+                }
+                $rows .= $this->renderTabPaneRow($ele);
+            }
+
+            $content .= '<div role="tabpanel" class="tab-pane' . $paneActive . '" id="' . $paneId . '" aria-labelledby="' . $tabId . '">'
+                . $rows . '</div>';
+        }
+
+        $nav     .= '</ul>';
+        $content .= '</div>';
+
+        return $nav . $content . $hidden;
+    }
+
+    /**
+     * Render a single element row inside a tab pane, matching the Bootstrap 3
+     * row layout used by {@see renderThemeForm()}.
+     *
+     * @param XoopsFormElement $element element to render
+     *
+     * @return string
+     */
+    protected function renderTabPaneRow(XoopsFormElement $element)
+    {
+        $ret = '<div class="form-group">';
+        if (($caption = $element->getCaption()) != '') {
+            $ret .= '<label for="' . $element->getName() . '" class="col-sm-2 control-label">'
+                . $caption
+                . ($element->isRequired() ? '<span class="xo-caption-required">*</span>' : '')
+                . '</label>';
+        } else {
+            $ret .= '<div class="col-sm-2"> </div>';
+        }
+        $ret .= '<div class="col-sm-10">';
+        $ret .= $element->render();
+        if (($desc = $element->getDescription()) != '') {
+            $ret .= '<p class="help-block">' . $desc . '</p>';
+        }
+        $ret .= '</div></div>';
+
+        return $ret;
     }
 }

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap3.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap3.php
@@ -774,7 +774,7 @@ EOJS;
                 $ret .= '<div class="col-md-2"> </div>';
             }
             $ret .= '<div class="col-md-10">';
-            $ret .= $element->render();
+            $ret .= (string) $element->render();
             if (($desc = $element->getDescription()) != '') {
                 $ret .= '<p class="help-block">' . $desc . '</p>';
             }
@@ -875,7 +875,7 @@ EOJS;
             $ret .= '<div class="col-sm-2"> </div>';
         }
         $ret .= '<div class="col-sm-10">';
-        $ret .= $element->render();
+        $ret .= (string) $element->render();
         if (($desc = $element->getDescription()) != '') {
             $ret .= '<p class="help-block">' . $desc . '</p>';
         }

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap4.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap4.php
@@ -8,6 +8,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+require_once __DIR__ . '/XoopsFormTabRendererInterface.php';
+
 /**
  * Bootstrap4 style form renderer
  *
@@ -18,8 +20,14 @@
  * @copyright 2000-2026 XOOPS Project (https://xoops.org)
  * @license   GNU GPL 2.0 or later (https://www.gnu.org/licenses/gpl-2.0.html)
  */
-class XoopsFormRendererBootstrap4 implements XoopsFormRendererInterface
+class XoopsFormRendererBootstrap4 implements XoopsFormRendererInterface, XoopsFormTabRendererInterface
 {
+    /**
+     * Counter giving each rendered tab tray a unique DOM id.
+     *
+     * @var int
+     */
+    protected static $tabSeq = 0;
     /**
      * Render support for XoopsFormButton
      *
@@ -757,6 +765,12 @@ EOJS;
                 continue;
             }
 
+            if ($element instanceof XoopsFormTabTray) {
+                // tabs own their layout; render full width rather than in a label/value row
+                $ret .= '<div class="form-group">' . $element->render() . '</div>';
+                continue;
+            }
+
             $ret .= '<div class="form-group row">';
             if (($caption = $element->getCaption()) != '') {
                 $ret .= '<label for="' . $element->getName() . '" class="col-xs-12 col-sm-2 col-form-label text-sm-right">'
@@ -798,5 +812,83 @@ EOJS;
     {
         $class = ($class != '') ? preg_replace('/[^A-Za-z0-9\s\s_-]/i', '', $class) : '';
         $form->addElement('<div class="col-md-12 ' . $class . '">' . $extra . '</div>');
+    }
+
+    /**
+     * Render support for XoopsFormTabTray using Bootstrap 4 nav-tabs.
+     *
+     * @param XoopsFormTabTray $element the tab tray to render
+     *
+     * @return string rendered HTML
+     */
+    public function renderFormTabTray(XoopsFormTabTray $element): string
+    {
+        $base = $element->getName(false);
+        $id   = 'xo-tabs-' . ('' !== $base ? preg_replace('/[^A-Za-z0-9]+/', '', $base) . '-' : '') . ++self::$tabSeq;
+
+        $nav     = '<ul class="nav nav-tabs" role="tablist" id="' . $id . '">';
+        $content = '<div class="tab-content" id="' . $id . '-content">';
+        $hidden  = '';
+
+        foreach ($element->getTabs() as $k => $tab) {
+            $tabId      = $id . '-tab-' . $k;
+            $paneId     = $id . '-pane-' . $k;
+            $isActive   = ($element->getActiveTab() === $k);
+            $navActive  = $isActive ? ' active' : '';
+            $paneActive = $isActive ? ' show active' : '';
+            $selected   = $isActive ? 'true' : 'false';
+
+            $nav .= '<li class="nav-item" role="presentation">'
+                . '<a class="nav-link' . $navActive . '" id="' . $tabId . '" data-toggle="tab" href="#'
+                . $paneId . '" role="tab" aria-controls="' . $paneId . '" aria-selected="' . $selected . '"'
+                . ' title="' . htmlspecialchars((string) $tab['title'], ENT_QUOTES | ENT_HTML5) . '">'
+                . htmlspecialchars((string) $tab['title'], ENT_QUOTES | ENT_HTML5) . '</a></li>';
+
+            $rows = '';
+            foreach ($tab['elements'] as $ele) {
+                if ($ele->isHidden()) {
+                    $hidden .= $ele->render();
+                    continue;
+                }
+                $rows .= $this->renderTabPaneRow($ele);
+            }
+
+            $content .= '<div class="tab-pane fade' . $paneActive . '" id="' . $paneId . '" role="tabpanel" aria-labelledby="'
+                . $tabId . '">' . $rows . '</div>';
+        }
+
+        $nav     .= '</ul>';
+        $content .= '</div>';
+
+        return $nav . $content . $hidden;
+    }
+
+    /**
+     * Render a single element row inside a tab pane, matching the Bootstrap 4
+     * row layout used by {@see renderThemeForm()}.
+     *
+     * @param XoopsFormElement $element element to render
+     *
+     * @return string
+     */
+    protected function renderTabPaneRow(XoopsFormElement $element)
+    {
+        $ret = '<div class="form-group row">';
+        if (($caption = $element->getCaption()) != '') {
+            $ret .= '<label for="' . $element->getName() . '" class="col-12 col-sm-2 col-form-label text-sm-right">'
+                . $caption
+                . ($element->isRequired() ? '<span class="xo-caption-required">*</span>' : '')
+                . '</label>';
+        } else {
+            $ret .= '<div class="col-12 col-sm-2"> </div>';
+        }
+        $ret .= '<div class="col-12 col-sm-10">';
+        $ret .= $element->render();
+        if (($desc = $element->getDescription()) != '') {
+            $ret .= '<small class="form-text text-muted">' . $desc . '</small>';
+        }
+        $ret .= '</div></div>';
+
+        return $ret;
     }
 }

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap4.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap4.php
@@ -781,7 +781,7 @@ EOJS;
                 $ret .= '<div class="col-xs-12 col-sm-2"> </div>';
             }
             $ret .= '<div class="col-xs-12 col-sm-10">';
-            $ret .= $element->render();
+            $ret .= (string) $element->render();
             if (($desc = $element->getDescription()) != '') {
                 $ret .= '<p class="form-text text-muted">' . $desc . '</p>';
             }
@@ -883,7 +883,7 @@ EOJS;
             $ret .= '<div class="col-12 col-sm-2"> </div>';
         }
         $ret .= '<div class="col-12 col-sm-10">';
-        $ret .= $element->render();
+        $ret .= (string) $element->render();
         if (($desc = $element->getDescription()) != '') {
             $ret .= '<small class="form-text text-muted">' . $desc . '</small>';
         }

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php
@@ -782,7 +782,7 @@ EOJS;
                 $ret .= '<div class="col-12 col-sm-2"> </div>';
             }
             $ret .= '<div class="col-12 col-sm-10">';
-            $ret .= $element->render();
+            $ret .= (string) $element->render();
             if (($desc = $element->getDescription()) != '') {
                 $ret .= '<div class="form-text">' . $desc . '</div>';
             }
@@ -875,7 +875,7 @@ EOJS;
             $ret .= '<div class="col-12 col-sm-2"> </div>';
         }
         $ret .= '<div class="col-12 col-sm-10">';
-        $ret .= $element->render();
+        $ret .= (string) $element->render();
         if (($desc = $element->getDescription()) != '') {
             $ret .= '<div class="form-text">' . $desc . '</div>';
         }

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php
@@ -772,19 +772,19 @@ EOJS;
                 continue;
             }
 
-            $ret .= '<div class="form-group row">';
+            $ret .= '<div class="row mb-3">';
             if (($caption = $element->getCaption()) != '') {
-                $ret .= '<label for="' . $element->getName() . '" class="col-xs-12 col-sm-2 col-form-label text-sm-end">'
+                $ret .= '<label for="' . $element->getName() . '" class="col-12 col-sm-2 col-form-label text-sm-end">'
                     . $element->getCaption()
                     . ($element->isRequired() ? '<span class="xo-caption-required">*</span>' : '')
                     . '</label>';
             } else {
-                $ret .= '<div class="col-xs-12 col-sm-2"> </div>';
+                $ret .= '<div class="col-12 col-sm-2"> </div>';
             }
-            $ret .= '<div class="col-xs-12 col-sm-10">';
+            $ret .= '<div class="col-12 col-sm-10">';
             $ret .= $element->render();
             if (($desc = $element->getDescription()) != '') {
-                $ret .= '<p class="form-text text-muted">' . $desc . '</p>';
+                $ret .= '<div class="form-text">' . $desc . '</div>';
             }
             $ret .= '</div>';
             $ret .= '</div>';

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php
@@ -8,6 +8,8 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  */
 
+require_once __DIR__ . '/XoopsFormTabRendererInterface.php';
+
 /**
  * Bootstrap5 style form renderer
  *
@@ -18,8 +20,15 @@
  * @copyright 2000-2026 XOOPS Project (https://xoops.org)
  * @license   GNU GPL 2.0 or later (https://www.gnu.org/licenses/gpl-2.0.html)
  */
-class XoopsFormRendererBootstrap5 implements XoopsFormRendererInterface
+class XoopsFormRendererBootstrap5 implements XoopsFormRendererInterface, XoopsFormTabRendererInterface
 {
+    /**
+     * Counter giving each rendered tab tray a unique DOM id.
+     *
+     * @var int
+     */
+    protected static $tabSeq = 0;
+
     /**
      * Render support for XoopsFormButton
      *
@@ -757,6 +766,12 @@ EOJS;
                 continue;
             }
 
+            if ($element instanceof XoopsFormTabTray) {
+                // tabs own their layout; render full width rather than in a label/value row
+                $ret .= '<div class="mb-3">' . $element->render() . '</div>';
+                continue;
+            }
+
             $ret .= '<div class="form-group row">';
             if (($caption = $element->getCaption()) != '') {
                 $ret .= '<label for="' . $element->getName() . '" class="col-xs-12 col-sm-2 col-form-label text-sm-end">'
@@ -781,6 +796,89 @@ EOJS;
         $ret .= $hidden;
         $ret .= '</form></div>';
         $ret .= $form->renderValidationJS(true);
+
+        return $ret;
+    }
+
+    /**
+     * Render support for XoopsFormTabTray using Bootstrap 5 nav-tabs.
+     *
+     * Emits native Bootstrap markup (data-bs-toggle="tab"), so tab switching is
+     * handled by the theme's bundled Bootstrap JS/CSS — no inline script needed.
+     * Fields keep the same row layout as the rest of a Bootstrap 5 form, and
+     * because the elements stay in the owning form their required handling and
+     * client-side validation continue to work across every tab.
+     *
+     * @param XoopsFormTabTray $element the tab tray to render
+     *
+     * @return string rendered HTML
+     */
+    public function renderFormTabTray(XoopsFormTabTray $element)
+    {
+        $base = $element->getName();
+        $id   = 'xo-tabs-' . ('' !== $base ? preg_replace('/[^A-Za-z0-9]+/', '', $base) . '-' : '') . ++self::$tabSeq;
+
+        $nav     = '<ul class="nav nav-tabs" role="tablist" id="' . $id . '">';
+        $content = '<div class="tab-content" id="' . $id . '-content">';
+        $hidden  = '';
+
+        foreach ($element->getTabs() as $k => $tab) {
+            $tabId      = $id . '-tab-' . $k;
+            $paneId     = $id . '-pane-' . $k;
+            $isActive   = (0 === $k);
+            $navActive  = $isActive ? ' active' : '';
+            $paneActive = $isActive ? ' show active' : '';
+            $selected   = $isActive ? 'true' : 'false';
+
+            $nav .= '<li class="nav-item" role="presentation">'
+                . '<button class="nav-link' . $navActive . '" id="' . $tabId . '" data-bs-toggle="tab" data-bs-target="#'
+                . $paneId . '" type="button" role="tab" aria-controls="' . $paneId . '" aria-selected="' . $selected . '">'
+                . htmlspecialchars((string) $tab['title'], ENT_QUOTES | ENT_HTML5) . '</button></li>';
+
+            $rows = '';
+            foreach ($tab['elements'] as $ele) {
+                if ($ele->isHidden()) {
+                    $hidden .= $ele->render();
+                    continue;
+                }
+                $rows .= $this->renderTabPaneRow($ele);
+            }
+
+            $content .= '<div class="tab-pane fade' . $paneActive . '" id="' . $paneId . '" role="tabpanel" aria-labelledby="'
+                . $tabId . '" tabindex="0">' . $rows . '</div>';
+        }
+
+        $nav     .= '</ul>';
+        $content .= '</div>';
+
+        return $nav . $content . $hidden;
+    }
+
+    /**
+     * Render a single element row inside a tab pane, matching the Bootstrap 5
+     * row layout used by {@see renderThemeForm()}.
+     *
+     * @param XoopsFormElement $element element to render
+     *
+     * @return string
+     */
+    protected function renderTabPaneRow(XoopsFormElement $element)
+    {
+        $ret = '<div class="form-group row">';
+        if (($caption = $element->getCaption()) != '') {
+            $ret .= '<label for="' . $element->getName() . '" class="col-xs-12 col-sm-2 col-form-label text-sm-end">'
+                . $caption
+                . ($element->isRequired() ? '<span class="xo-caption-required">*</span>' : '')
+                . '</label>';
+        } else {
+            $ret .= '<div class="col-xs-12 col-sm-2"> </div>';
+        }
+        $ret .= '<div class="col-xs-12 col-sm-10">';
+        $ret .= $element->render();
+        if (($desc = $element->getDescription()) != '') {
+            $ret .= '<p class="form-text text-muted">' . $desc . '</p>';
+        }
+        $ret .= '</div></div>';
 
         return $ret;
     }

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php
@@ -825,14 +825,15 @@ EOJS;
         foreach ($element->getTabs() as $k => $tab) {
             $tabId      = $id . '-tab-' . $k;
             $paneId     = $id . '-pane-' . $k;
-            $isActive   = (0 === $k);
+            $isActive   = ($element->getActiveTab() === $k);
             $navActive  = $isActive ? ' active' : '';
             $paneActive = $isActive ? ' show active' : '';
             $selected   = $isActive ? 'true' : 'false';
 
             $nav .= '<li class="nav-item" role="presentation">'
                 . '<button class="nav-link' . $navActive . '" id="' . $tabId . '" data-bs-toggle="tab" data-bs-target="#'
-                . $paneId . '" type="button" role="tab" aria-controls="' . $paneId . '" aria-selected="' . $selected . '">'
+                . $paneId . '" type="button" role="tab" aria-controls="' . $paneId . '" aria-selected="' . $selected . '"'
+                . ' title="' . htmlspecialchars((string) $tab['title'], ENT_QUOTES | ENT_HTML5) . '">'
                 . htmlspecialchars((string) $tab['title'], ENT_QUOTES | ENT_HTML5) . '</button></li>';
 
             $rows = '';

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php
@@ -815,7 +815,7 @@ EOJS;
      */
     public function renderFormTabTray(XoopsFormTabTray $element): string
     {
-        $base = $element->getName();
+        $base = $element->getName(false);
         $id   = 'xo-tabs-' . ('' !== $base ? preg_replace('/[^A-Za-z0-9]+/', '', $base) . '-' : '') . ++self::$tabSeq;
 
         $nav     = '<ul class="nav nav-tabs" role="tablist" id="' . $id . '">';

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererBootstrap5.php
@@ -864,19 +864,19 @@ EOJS;
      */
     protected function renderTabPaneRow(XoopsFormElement $element)
     {
-        $ret = '<div class="form-group row">';
+        $ret = '<div class="row mb-3">';
         if (($caption = $element->getCaption()) != '') {
-            $ret .= '<label for="' . $element->getName() . '" class="col-xs-12 col-sm-2 col-form-label text-sm-end">'
+            $ret .= '<label for="' . $element->getName() . '" class="col-12 col-sm-2 col-form-label text-sm-end">'
                 . $caption
                 . ($element->isRequired() ? '<span class="xo-caption-required">*</span>' : '')
                 . '</label>';
         } else {
-            $ret .= '<div class="col-xs-12 col-sm-2"> </div>';
+            $ret .= '<div class="col-12 col-sm-2"> </div>';
         }
-        $ret .= '<div class="col-xs-12 col-sm-10">';
+        $ret .= '<div class="col-12 col-sm-10">';
         $ret .= $element->render();
         if (($desc = $element->getDescription()) != '') {
-            $ret .= '<p class="form-text text-muted">' . $desc . '</p>';
+            $ret .= '<div class="form-text">' . $desc . '</div>';
         }
         $ret .= '</div></div>';
 

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererTailwind.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererTailwind.php
@@ -1154,8 +1154,11 @@ EOJS;
         $hidden = '';
 
         foreach ($element->getTabs() as $k => $tab) {
+            $tabId   = $id . '-tab-' . $k;
+            $paneId  = $id . '-pane-' . $k;
             $checked = (0 === $k) ? ' checked="checked"' : '';
-            $ret    .= '<input type="radio" name="' . $this->esc($group) . '" role="tab" class="tab"'
+            $ret    .= '<input type="radio" id="' . $this->esc($tabId) . '" name="' . $this->esc($group) . '"'
+                . ' role="tab" class="tab" aria-controls="' . $this->esc($paneId) . '"'
                 . ' aria-label="' . $this->esc((string) $tab['title']) . '"' . $checked . ' />';
 
             $rows = '';
@@ -1167,7 +1170,8 @@ EOJS;
                 $rows .= $this->renderThemeFormField($ele);
             }
 
-            $ret .= '<div role="tabpanel" class="tab-content border-base-300 bg-base-100 p-4">' . $rows . '</div>';
+            $ret .= '<div role="tabpanel" id="' . $this->esc($paneId) . '" aria-labelledby="' . $this->esc($tabId) . '"'
+                . ' class="tab-content border-base-300 bg-base-100 p-4">' . $rows . '</div>';
         }
 
         $ret .= '</div>' . $hidden;

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererTailwind.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererTailwind.php
@@ -19,6 +19,8 @@
 
 defined('XOOPS_ROOT_PATH') || exit('Restricted access');
 
+require_once __DIR__ . '/XoopsFormTabRendererInterface.php';
+
 /**
  * Tailwind CSS + DaisyUI form renderer
  *
@@ -39,8 +41,15 @@ defined('XOOPS_ROOT_PATH') || exit('Restricted access');
  * @link      https://xoops.org
  * @see       https://daisyui.com/components/
  */
-class XoopsFormRendererTailwind implements XoopsFormRendererInterface
+class XoopsFormRendererTailwind implements XoopsFormRendererInterface, XoopsFormTabRendererInterface
 {
+    /**
+     * Counter giving each rendered tab tray a unique DOM id / radio group.
+     *
+     * @var int
+     */
+    protected static $tabSeq = 0;
+
     /** @var string Reusable class string for small neutral buttons */
     private const BTN_NEUTRAL_SM = 'btn btn-neutral btn-sm';
 
@@ -1064,6 +1073,11 @@ EOJS;
                 $hidden .= $this->renderElementHtml($element);
                 continue;
             }
+            if ($element instanceof XoopsFormTabTray) {
+                // tabs own their layout; render full width rather than in a label/value grid row
+                $ret .= '<div class="mb-4">' . $element->render() . '</div>';
+                continue;
+            }
             $ret .= $this->renderThemeFormField($element);
         }
         if (count($form->getRequired()) > 0) {
@@ -1113,6 +1127,52 @@ EOJS;
             . $descHtml
             . '</div>'
             . '</div>';
+    }
+
+    /**
+     * Render support for XoopsFormTabTray using DaisyUI tabs.
+     *
+     * Uses DaisyUI's radio-input tab pattern, which is CSS-only: tab switching
+     * needs no JavaScript, so the form works even with scripting disabled. The
+     * radio group name is internal (`__xotab_…`) and carries no field data, so
+     * the harmless extra POST key is ignored by handlers. Field rows reuse the
+     * same DaisyUI layout as the rest of the form, and because the elements stay
+     * in the owning form their required handling and client-side validation keep
+     * working across every tab.
+     *
+     * @param XoopsFormTabTray $element the tab tray to render
+     *
+     * @return string rendered HTML
+     */
+    public function renderFormTabTray(XoopsFormTabTray $element)
+    {
+        $base  = $element->getName(false);
+        $id    = 'xo-tabs-' . ('' !== $base ? preg_replace('/[^A-Za-z0-9]+/', '', $base) . '-' : '') . ++self::$tabSeq;
+        $group = '__xotab_' . $id;
+
+        $ret    = '<div role="tablist" class="tabs tabs-bordered" id="' . $this->esc($id) . '">';
+        $hidden = '';
+
+        foreach ($element->getTabs() as $k => $tab) {
+            $checked = (0 === $k) ? ' checked="checked"' : '';
+            $ret    .= '<input type="radio" name="' . $this->esc($group) . '" role="tab" class="tab"'
+                . ' aria-label="' . $this->esc((string) $tab['title']) . '"' . $checked . ' />';
+
+            $rows = '';
+            foreach ($tab['elements'] as $ele) {
+                if ($ele->isHidden()) {
+                    $hidden .= $this->renderElementHtml($ele);
+                    continue;
+                }
+                $rows .= $this->renderThemeFormField($ele);
+            }
+
+            $ret .= '<div role="tabpanel" class="tab-content border-base-300 bg-base-100 p-4">' . $rows . '</div>';
+        }
+
+        $ret .= '</div>' . $hidden;
+
+        return $ret;
     }
 
     /**

--- a/htdocs/class/xoopsform/renderer/XoopsFormRendererTailwind.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormRendererTailwind.php
@@ -1156,10 +1156,10 @@ EOJS;
         foreach ($element->getTabs() as $k => $tab) {
             $tabId   = $id . '-tab-' . $k;
             $paneId  = $id . '-pane-' . $k;
-            $checked = (0 === $k) ? ' checked="checked"' : '';
+            $checked = ($element->getActiveTab() === $k) ? ' checked="checked"' : '';
             $ret    .= '<input type="radio" id="' . $this->esc($tabId) . '" name="' . $this->esc($group) . '"'
                 . ' role="tab" class="tab" aria-controls="' . $this->esc($paneId) . '"'
-                . ' aria-label="' . $this->esc((string) $tab['title']) . '"' . $checked . ' />';
+                . ' aria-label="' . $this->esc((string) $tab['title']) . '"' . $checked . ' title="' . $this->esc((string) $tab['title']) . '" />';
 
             $rows = '';
             foreach ($tab['elements'] as $ele) {

--- a/htdocs/class/xoopsform/renderer/XoopsFormTabRendererInterface.php
+++ b/htdocs/class/xoopsform/renderer/XoopsFormTabRendererInterface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * XOOPS form tab renderer interface
+ *
+ * You may not change or alter any portion of this comment or credits
+ * of supporting developers from this source code or any supporting source code
+ * which is considered copyrighted (c) material of the original comment or credit authors.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @link      https://xoops.org
+ */
+
+defined('XOOPS_ROOT_PATH') || exit('Restricted access');
+
+/**
+ * Optional, additive companion to {@link XoopsFormRendererInterface}.
+ *
+ * A renderer MAY implement this interface to emit themed (Bootstrap, Tailwind,
+ * …) markup for {@link XoopsFormTabTray}. It is intentionally kept separate from
+ * XoopsFormRendererInterface so that adding tab support is a purely additive
+ * change: the core contract and every existing third-party renderer stay
+ * source-compatible. XoopsFormTabTray detects support with `instanceof`; when a
+ * renderer does not implement this interface the element falls back to its own
+ * framework-neutral, progressively-enhanced output.
+ *
+ * Who calls it: XoopsFormTabTray::render().
+ */
+interface XoopsFormTabRendererInterface
+{
+    /**
+     * Render a tabbed group of form elements.
+     *
+     * @param XoopsFormTabTray $element the tab tray to render
+     *
+     * @return string rendered HTML
+     */
+    public function renderFormTabTray(XoopsFormTabTray $element);
+}

--- a/htdocs/class/xoopsformloader.php
+++ b/htdocs/class/xoopsformloader.php
@@ -20,6 +20,7 @@ xoops_load('XoopsThemeForm');
 xoops_load('XoopsSimpleForm');
 xoops_load('XoopsFormElement');
 xoops_load('XoopsFormElementTray');
+xoops_load('XoopsFormTabTray');
 xoops_load('XoopsFormLabel');
 xoops_load('XoopsFormCheckBox');
 xoops_load('XoopsFormPassword');

--- a/htdocs/class/xoopsload.php
+++ b/htdocs/class/xoopsload.php
@@ -217,6 +217,7 @@ class XoopsLoad
             'xoopsformtextarea'          => XOOPS_ROOT_PATH . '/class/xoopsform/formtextarea.php',
             'xoopsformdhtmltextarea'     => XOOPS_ROOT_PATH . '/class/xoopsform/formdhtmltextarea.php',
             'xoopsformelementtray'       => XOOPS_ROOT_PATH . '/class/xoopsform/formelementtray.php',
+            'xoopsformtabtray'           => XOOPS_ROOT_PATH . '/class/xoopsform/formtabtray.php',
             'xoopsthemeform'             => XOOPS_ROOT_PATH . '/class/xoopsform/themeform.php',
             'xoopssimpleform'            => XOOPS_ROOT_PATH . '/class/xoopsform/simpleform.php',
             'xoopsformtextdateselect'    => XOOPS_ROOT_PATH . '/class/xoopsform/formtextdateselect.php',

--- a/htdocs/class/xoopsload.php
+++ b/htdocs/class/xoopsload.php
@@ -230,6 +230,7 @@ class XoopsLoad
             'xoopsformcalendar'          => XOOPS_ROOT_PATH . '/class/xoopsform/formcalendar.php',
             'xoopsformrenderer'          => XOOPS_ROOT_PATH . '/class/xoopsform/renderer/XoopsFormRenderer.php',
             'xoopsformrendererinterface' => XOOPS_ROOT_PATH . '/class/xoopsform/renderer/XoopsFormRendererInterface.php',
+            'xoopsformtabrendererinterface' => XOOPS_ROOT_PATH . '/class/xoopsform/renderer/XoopsFormTabRendererInterface.php',
             'xoopsformrendererlegacy'    => XOOPS_ROOT_PATH . '/class/xoopsform/renderer/XoopsFormRendererLegacy.php',
             'xoopsformrendererbootstrap3' => XOOPS_ROOT_PATH . '/class/xoopsform/renderer/XoopsFormRendererBootstrap3.php',
             'xoopsformrendererbootstrap4' => XOOPS_ROOT_PATH . '/class/xoopsform/renderer/XoopsFormRendererBootstrap4.php',

--- a/tests/unit/htdocs/class/xoopsforms/XoopsFormTabTrayTest.php
+++ b/tests/unit/htdocs/class/xoopsforms/XoopsFormTabTrayTest.php
@@ -16,6 +16,8 @@ xoops_load('XoopsFormHidden');
 xoops_load('XoopsFormRenderer');
 xoops_load('XoopsFormRendererInterface');
 xoops_load('XoopsFormRendererLegacy');
+xoops_load('XoopsFormRendererBootstrap5');
+xoops_load('XoopsFormRendererTailwind');
 
 /**
  * Tests for XoopsFormTabTray
@@ -216,11 +218,13 @@ class XoopsFormTabTrayTest extends TestCase
         $html = $this->tray->render();
 
         $this->assertStringContainsString('name="secret"', $html);
-        // The hidden input is emitted after the tab panes, never inside a pane.
-        $this->assertLessThan(
-            strpos($html, 'name="secret"'),
-            strrpos($html, '</fieldset>')
-        );
+        // The hidden input is emitted after the tab panes, never inside a pane,
+        // so it appears later in the markup than the last closing </fieldset>.
+        $hiddenPos        = strpos($html, 'name="secret"');
+        $lastPaneClosePos = strrpos($html, '</fieldset>');
+        $this->assertNotFalse($hiddenPos);
+        $this->assertNotFalse($lastPaneClosePos);
+        $this->assertGreaterThan($lastPaneClosePos, $hiddenPos);
     }
 
     // ------------------------------------------------------------------
@@ -241,5 +245,41 @@ class XoopsFormTabTrayTest extends TestCase
         $this->tray->addTab('Two');
 
         $this->assertSame('DELEGATED:2', $this->tray->render());
+    }
+
+    // ------------------------------------------------------------------
+    //  Themed renderer output (Bootstrap 5 / Tailwind)
+    // ------------------------------------------------------------------
+
+    public function testBootstrap5RendererEmitsNavTabsAndBs5Classes(): void
+    {
+        $this->tray->addTab('One');
+        $this->tray->addElement(new \XoopsFormText('Name', 'name', 25, 100));
+
+        $html = (new \XoopsFormRendererBootstrap5())->renderFormTabTray($this->tray);
+
+        $this->assertStringContainsString('nav nav-tabs', $html);
+        $this->assertStringContainsString('data-bs-toggle="tab"', $html);
+        $this->assertStringContainsString('tab-pane', $html);
+        $this->assertStringContainsString('role="tabpanel"', $html);
+        // Bootstrap 5 row classes (not the removed form-group / col-xs-*).
+        $this->assertStringContainsString('row mb-3', $html);
+        $this->assertStringContainsString('col-12', $html);
+        $this->assertStringNotContainsString('form-group', $html);
+        $this->assertStringNotContainsString('col-xs-12', $html);
+    }
+
+    public function testTailwindRendererEmitsRadioTablistWithAria(): void
+    {
+        $this->tray->addTab('One');
+        $this->tray->addElement(new \XoopsFormText('Name', 'name', 25, 100));
+
+        $html = (new \XoopsFormRendererTailwind())->renderFormTabTray($this->tray);
+
+        $this->assertStringContainsString('role="tablist"', $html);
+        $this->assertStringContainsString('role="tab"', $html);
+        $this->assertStringContainsString('role="tabpanel"', $html);
+        $this->assertStringContainsString('aria-controls="', $html);
+        $this->assertStringContainsString('aria-labelledby="', $html);
     }
 }

--- a/tests/unit/htdocs/class/xoopsforms/XoopsFormTabTrayTest.php
+++ b/tests/unit/htdocs/class/xoopsforms/XoopsFormTabTrayTest.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace xoopsforms;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+require_once dirname(__DIR__, 4) . '/bootstrap.php';
+
+xoops_load('XoopsFormElement');
+xoops_load('XoopsFormElementTray');
+xoops_load('XoopsFormTabTray');
+xoops_load('XoopsFormTabRendererInterface');
+xoops_load('XoopsFormText');
+xoops_load('XoopsFormHidden');
+xoops_load('XoopsFormRenderer');
+xoops_load('XoopsFormRendererInterface');
+xoops_load('XoopsFormRendererLegacy');
+
+/**
+ * Tests for XoopsFormTabTray
+ */
+#[CoversClass(\XoopsFormTabTray::class)]
+class XoopsFormTabTrayTest extends TestCase
+{
+    /**
+     * @var \XoopsFormTabTray
+     */
+    protected $tray;
+
+    protected function setUp(): void
+    {
+        // Start each test with a renderer that has no tab support, so render()
+        // exercises the framework-neutral fallback unless a test opts in.
+        \XoopsFormRenderer::getInstance()->set(new \XoopsFormRendererLegacy());
+        $this->tray = new \XoopsFormTabTray('Caption', 'myTabs');
+    }
+
+    // ------------------------------------------------------------------
+    //  Constructor / container semantics
+    // ------------------------------------------------------------------
+
+    public function testConstructorSetsCaptionAndName(): void
+    {
+        $this->assertSame('Caption', $this->tray->getCaption());
+        $this->assertSame('myTabs', $this->tray->getName(false));
+    }
+
+    public function testIsContainerReturnsTrue(): void
+    {
+        $this->assertTrue($this->tray->isContainer());
+    }
+
+    public function testIsRequiredReturnsFalseWhenEmpty(): void
+    {
+        $this->assertFalse($this->tray->isRequired());
+    }
+
+    public function testIsRequiredReturnsTrueWhenChildIsRequired(): void
+    {
+        $this->tray->addTab('General');
+        $this->tray->addElement(new \XoopsFormText('Name', 'name', 25, 100), true);
+        $this->assertTrue($this->tray->isRequired());
+    }
+
+    // ------------------------------------------------------------------
+    //  addTab / addElement
+    // ------------------------------------------------------------------
+
+    public function testAddTabReturnsIncrementingIndex(): void
+    {
+        $this->assertSame(0, $this->tray->addTab('First'));
+        $this->assertSame(1, $this->tray->addTab('Second'));
+    }
+
+    public function testAddElementWithoutTabAutoCreatesFirstTab(): void
+    {
+        $this->tray->addElement(new \XoopsFormText('Name', 'name', 25, 100));
+
+        $tabs = $this->tray->getTabs();
+        $this->assertCount(1, $tabs);
+        $this->assertSame('', $tabs[0]['title']);
+        $this->assertCount(1, $tabs[0]['elements']);
+    }
+
+    public function testElementsLandInTheCurrentTab(): void
+    {
+        $this->tray->addTab('One');
+        $this->tray->addElement(new \XoopsFormText('A', 'a', 25, 100));
+        $this->tray->addTab('Two');
+        $this->tray->addElement(new \XoopsFormText('B', 'b', 25, 100));
+        $this->tray->addElement(new \XoopsFormText('C', 'c', 25, 100));
+
+        $tabs = $this->tray->getTabs();
+        $this->assertCount(2, $tabs);
+        $this->assertSame('One', $tabs[0]['title']);
+        $this->assertCount(1, $tabs[0]['elements']);
+        $this->assertSame('Two', $tabs[1]['title']);
+        $this->assertCount(2, $tabs[1]['elements']);
+    }
+
+    // ------------------------------------------------------------------
+    //  getElements (recursive vs non-recursive)
+    // ------------------------------------------------------------------
+
+    public function testGetElementsNonRecursiveReturnsDirectChildren(): void
+    {
+        $inner = new \XoopsFormElementTray('Inner');
+        $inner->addElement(new \XoopsFormText('Inner', 'inner', 25, 100));
+
+        $this->tray->addTab('Tab');
+        $this->tray->addElement(new \XoopsFormText('Outer', 'outer', 25, 100));
+        $this->tray->addElement($inner);
+
+        $elements = $this->tray->getElements(false);
+        $this->assertCount(2, $elements);
+        $this->assertInstanceOf(\XoopsFormElementTray::class, $elements[1]);
+    }
+
+    public function testGetElementsRecursiveFlattensNestedContainers(): void
+    {
+        $inner = new \XoopsFormElementTray('Inner');
+        $inner->addElement(new \XoopsFormText('Inner', 'inner', 25, 100));
+
+        $this->tray->addTab('Tab');
+        $this->tray->addElement(new \XoopsFormText('Outer', 'outer', 25, 100));
+        $this->tray->addElement($inner);
+
+        $elements = $this->tray->getElements(true);
+        $this->assertCount(2, $elements);
+        $this->assertSame('outer', $elements[0]->getName(false));
+        $this->assertSame('inner', $elements[1]->getName(false));
+    }
+
+    // ------------------------------------------------------------------
+    //  getRequired (required bubbling)
+    // ------------------------------------------------------------------
+
+    public function testGetRequiredReturnsEmptyArrayByDefault(): void
+    {
+        $required = $this->tray->getRequired();
+        $this->assertIsArray($required);
+        $this->assertCount(0, $required);
+    }
+
+    public function testGetRequiredCollectsRequiredLeavesAcrossTabs(): void
+    {
+        $this->tray->addTab('One');
+        $req = new \XoopsFormText('Req', 'req', 25, 100);
+        $this->tray->addElement($req, true);
+        $this->tray->addElement(new \XoopsFormText('Opt', 'opt', 25, 100), false);
+
+        $this->tray->addTab('Two');
+        $this->tray->addElement(new \XoopsFormText('Req2', 'req2', 25, 100), true);
+
+        $required = $this->tray->getRequired();
+        $this->assertCount(2, $required);
+        $this->assertSame($req, $required[0]);
+        $this->assertTrue($req->isRequired());
+    }
+
+    public function testGetRequiredBubblesFromNestedContainer(): void
+    {
+        $inner = new \XoopsFormElementTray('Inner');
+        $deep  = new \XoopsFormText('Deep', 'deep', 25, 100);
+        $inner->addElement($deep, true);
+
+        $this->tray->addTab('Tab');
+        $this->tray->addElement($inner);
+
+        $required = $this->tray->getRequired();
+        $this->assertCount(1, $required);
+        $this->assertSame($deep, $required[0]);
+        $this->assertTrue($this->tray->isRequired());
+    }
+
+    public function testGetRequiredReturnsByReference(): void
+    {
+        $this->tray->addTab('Tab');
+        $text = new \XoopsFormText('Name', 'name', 25, 100);
+        $this->tray->addElement($text, true);
+
+        $required = &$this->tray->getRequired();
+        $this->assertSame($text, $required[0]);
+    }
+
+    // ------------------------------------------------------------------
+    //  render() — fallback path
+    // ------------------------------------------------------------------
+
+    public function testFallbackRenderEmitsTabSemantics(): void
+    {
+        $this->tray->addTab('One');
+        $this->tray->addElement(new \XoopsFormText('Name', 'name', 25, 100));
+        $this->tray->addTab('Two');
+        $this->tray->addElement(new \XoopsFormText('Mail', 'mail', 25, 100));
+
+        $html = $this->tray->render();
+
+        $this->assertIsString($html);
+        $this->assertStringContainsString('class="xoops-tabs"', $html);
+        $this->assertStringContainsString('role="tablist"', $html);
+        $this->assertStringContainsString('role="tab"', $html);
+        $this->assertStringContainsString('role="tabpanel"', $html);
+        $this->assertStringContainsString('aria-controls="', $html);
+        $this->assertStringContainsString('aria-selected="true"', $html);
+        $this->assertStringContainsString('aria-labelledby="', $html);
+    }
+
+    public function testFallbackRenderPlacesHiddenFieldsOutsidePanes(): void
+    {
+        $this->tray->addTab('One');
+        $this->tray->addElement(new \XoopsFormText('Name', 'name', 25, 100));
+        $this->tray->addElement(new \XoopsFormHidden('secret', 'value'));
+
+        $html = $this->tray->render();
+
+        $this->assertStringContainsString('name="secret"', $html);
+        // The hidden input is emitted after the tab panes, never inside a pane.
+        $this->assertLessThan(
+            strpos($html, 'name="secret"'),
+            strrpos($html, '</fieldset>')
+        );
+    }
+
+    // ------------------------------------------------------------------
+    //  render() — delegation to a tab-aware renderer
+    // ------------------------------------------------------------------
+
+    public function testRenderDelegatesToTabAwareRenderer(): void
+    {
+        $renderer = new class extends \XoopsFormRendererLegacy implements \XoopsFormTabRendererInterface {
+            public function renderFormTabTray(\XoopsFormTabTray $element): string
+            {
+                return 'DELEGATED:' . count($element->getTabs());
+            }
+        };
+        \XoopsFormRenderer::getInstance()->set($renderer);
+
+        $this->tray->addTab('One');
+        $this->tray->addTab('Two');
+
+        $this->assertSame('DELEGATED:2', $this->tray->render());
+    }
+}

--- a/tests/unit/htdocs/class/xoopsforms/XoopsFormTabTrayTest.php
+++ b/tests/unit/htdocs/class/xoopsforms/XoopsFormTabTrayTest.php
@@ -16,6 +16,8 @@ xoops_load('XoopsFormHidden');
 xoops_load('XoopsFormRenderer');
 xoops_load('XoopsFormRendererInterface');
 xoops_load('XoopsFormRendererLegacy');
+xoops_load('XoopsFormRendererBootstrap3');
+xoops_load('XoopsFormRendererBootstrap4');
 xoops_load('XoopsFormRendererBootstrap5');
 xoops_load('XoopsFormRendererTailwind');
 
@@ -281,5 +283,120 @@ class XoopsFormTabTrayTest extends TestCase
         $this->assertStringContainsString('role="tabpanel"', $html);
         $this->assertStringContainsString('aria-controls="', $html);
         $this->assertStringContainsString('aria-labelledby="', $html);
+    }
+
+    public function testBootstrap3RendererEmitsNavTabs(): void
+    {
+        $this->tray->addTab('One');
+        $this->tray->addElement(new \XoopsFormText('Name', 'name', 25, 100));
+
+        $html = (new \XoopsFormRendererBootstrap3())->renderFormTabTray($this->tray);
+
+        $this->assertStringContainsString('nav nav-tabs', $html);
+        $this->assertStringContainsString('data-toggle="tab"', $html);
+        $this->assertStringContainsString('tab-pane', $html);
+        $this->assertStringContainsString('role="tabpanel"', $html);
+    }
+
+    public function testBootstrap4RendererEmitsNavTabs(): void
+    {
+        $this->tray->addTab('One');
+        $this->tray->addElement(new \XoopsFormText('Name', 'name', 25, 100));
+
+        $html = (new \XoopsFormRendererBootstrap4())->renderFormTabTray($this->tray);
+
+        $this->assertStringContainsString('nav nav-tabs', $html);
+        $this->assertStringContainsString('data-toggle="tab"', $html);
+        $this->assertStringContainsString('tab-pane', $html);
+        $this->assertStringContainsString('role="tabpanel"', $html);
+    }
+
+    // ------------------------------------------------------------------
+    //  Active tab management
+    // ------------------------------------------------------------------
+
+    public function testGetActiveTabDefaultsToZero(): void
+    {
+        $this->assertSame(0, $this->tray->getActiveTab());
+    }
+
+    public function testSetActiveTabStoresIndex(): void
+    {
+        $this->tray->addTab('One');
+        $this->tray->addTab('Two');
+        $this->tray->setActiveTab(1);
+        $this->assertSame(1, $this->tray->getActiveTab());
+    }
+
+    public function testSetActiveTabClampsOutOfRangeIndex(): void
+    {
+        $this->tray->addTab('One');
+        $this->tray->addTab('Two');
+        $this->tray->setActiveTab(99);
+        // Clamped to the last existing tab, never beyond.
+        $this->assertSame(1, $this->tray->getActiveTab());
+    }
+
+    public function testSetActiveTabClampsNegativeIndex(): void
+    {
+        $this->tray->addTab('One');
+        $this->tray->addTab('Two');
+        $this->tray->setActiveTab(-5);
+        $this->assertSame(0, $this->tray->getActiveTab());
+    }
+
+    public function testFallbackDefaultsToFirstTabActive(): void
+    {
+        $this->tray->addTab('One');
+        $this->tray->addElement(new \XoopsFormText('A', 'a', 25, 100));
+        $this->tray->addTab('Two');
+        $this->tray->addElement(new \XoopsFormText('B', 'b', 25, 100));
+
+        $html = $this->tray->render();
+
+        // Exactly one tab is selected, and it is the first one (appears before
+        // the unselected tab in document order).
+        $this->assertSame(1, substr_count($html, 'aria-selected="true"'));
+        $this->assertLessThan(
+            strpos($html, 'aria-selected="false"'),
+            strpos($html, 'aria-selected="true"')
+        );
+    }
+
+    public function testFallbackRespectsActiveTab(): void
+    {
+        $this->tray->addTab('One');
+        $this->tray->addElement(new \XoopsFormText('A', 'a', 25, 100));
+        $this->tray->addTab('Two');
+        $this->tray->addElement(new \XoopsFormText('B', 'b', 25, 100));
+        $this->tray->setActiveTab(1);
+
+        $html = $this->tray->render();
+
+        // Still exactly one selected tab, now the second one (appears after the
+        // unselected first tab in document order).
+        $this->assertSame(1, substr_count($html, 'aria-selected="true"'));
+        $this->assertGreaterThan(
+            strpos($html, 'aria-selected="false"'),
+            strpos($html, 'aria-selected="true"')
+        );
+    }
+
+    public function testBootstrap5RespectsActiveTab(): void
+    {
+        $this->tray->addTab('One');
+        $this->tray->addElement(new \XoopsFormText('A', 'a', 25, 100));
+        $this->tray->addTab('Two');
+        $this->tray->addElement(new \XoopsFormText('B', 'b', 25, 100));
+        $this->tray->setActiveTab(1);
+
+        $html = (new \XoopsFormRendererBootstrap5())->renderFormTabTray($this->tray);
+
+        // The second nav button carries the active state.
+        $this->assertSame(1, substr_count($html, 'aria-selected="true"'));
+        $this->assertGreaterThan(
+            strpos($html, 'aria-selected="false"'),
+            strpos($html, 'aria-selected="true"')
+        );
     }
 }


### PR DESCRIPTION
Add a tabbed container form element, XoopsFormTabTray, plus an optional XoopsFormTabRendererInterface. Like XoopsFormElementTray it is a container: fields stay part of the owning form, so required handling and the form's client-side validation work across every tab.

render() delegates to the active renderer when it implements XoopsFormTabRendererInterface, otherwise it emits a framework-neutral, progressively-enhanced fallback (inactive panes are hidden only under a JS-added hook, so every pane shows when scripting is disabled).

All four bundled themed renderers implement the interface — Bootstrap 5, Bootstrap 4, Bootstrap 3, and Tailwind/DaisyUI: the Bootstrap renderers emit native nav-tabs (data-bs-toggle for BS5, data-toggle for BS3/BS4), Tailwind uses DaisyUI's CSS-only radio-tab pattern. Each renders tab fields in the same row layout as the rest of that renderer's forms. Keeping the tab method in a separate interface means XoopsFormRendererInterface is unchanged, so existing third-party renderers stay source-compatible and simply use the framework-neutral fallback.

The tab tray also exposes a programmatically selectable active tab via getActiveTab()/setActiveTab() (the index is clamped to the existing tab range so an out-of-range value can never leave every pane hidden); the fallback and all renderers honour it instead of hard-coding the first tab. ARIA tab semantics (roles, aria-selected/-controls/-labelledby) are emitted across the fallback and renderers.

Registered additively in xoopsload (both the element and the interface) and xoopsformloader.

## Summary by Sourcery

Introduce a new tabbed form container element with optional themed rendering support while keeping existing form renderers source-compatible.

New Features:
- Add XoopsFormTabTray as a container form element for grouping fields into tabs with shared validation and required handling across panes.
- Provide an optional XoopsFormTabRendererInterface to let form renderers output themed tab markup without changing the base renderer contract.
- Implement tabbed rendering for Bootstrap 5 and Tailwind/DaisyUI form renderers so tab trays integrate with existing theme layouts and behaviors.

Enhancements:
- Register the new tabbed form element in the core xoopsload and xoopsformloader so it is autoloaded like other form components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add tabbed form sections to organize fields into titled tabs with accessible ARIA semantics and a JS-free fallback.
  * Tabbed forms render natively for Bootstrap 5 and Tailwind themes with consistent layout and unique stable IDs.

* **Tests**
  * New unit tests covering construction, tab/element behavior, required-field propagation, rendering fallback, and themed renderer outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
