### PR TITLE
refactor(form): introduce XoopsFormContainerInterface for container contract

### DIFF
--- a/htdocs/class/xoopsform/formcontainerinterface.php
+++ b/htdocs/class/xoopsform/formcontainerinterface.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * XOOPS form container interface
+ *
+ * You may not change or alter any portion of this comment or credits
+ * of supporting developers from this source code or any supporting source code
+ * which is considered copyrighted (c) material of the original comment or credit authors.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2.0 or later (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @link      https://xoops.org
+ */
+
+defined('XOOPS_ROOT_PATH') || exit('Restricted access');
+
+/**
+ * Formal contract for form elements that group other form elements.
+ *
+ * Implemented by {@link XoopsFormElementTray} and {@link XoopsFormTabTray}. A
+ * container keeps its children part of the owning form, so the form's required
+ * handling and generated client-side validation reach every nested element.
+ *
+ * The legacy discriminator for "is this a container?" was the {@link
+ * XoopsFormElement::isContainer()} method. This interface formalises that role
+ * so callers can detect containers with `instanceof` while the return types of
+ * getRequired()/getElements() stay PHPDoc-only — they are long-standing public
+ * signatures used across the module ecosystem and MUST NOT gain native return
+ * types, which would be a backward-compatibility break.
+ *
+ * @category  XoopsForm
+ * @package   XoopsFormContainerInterface
+ * @author    XOOPS Development Team
+ * @copyright (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2.0 or later (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @link      https://xoops.org
+ */
+interface XoopsFormContainerInterface
+{
+    /**
+     * Is this element a container of other elements?
+     *
+     * @return bool
+     */
+    public function isContainer();
+
+    /**
+     * Get the required child elements (by reference, so the owning form can
+     * merge them into its own required list).
+     *
+     * @return XoopsFormElement[] array of {@link XoopsFormElement}s
+     */
+    public function &getRequired();
+
+    /**
+     * Get the child elements. With $recurse, nested containers are flattened so
+     * the owning form sees every leaf element.
+     *
+     * @param bool $recurse flatten nested containers?
+     *
+     * @return XoopsFormElement[] array of {@link XoopsFormElement}s
+     */
+    public function &getElements($recurse = false);
+}

--- a/htdocs/class/xoopsform/formelementtray.php
+++ b/htdocs/class/xoopsform/formelementtray.php
@@ -103,8 +103,10 @@ class XoopsFormElementTray extends XoopsFormElement implements XoopsFormContaine
         // isContainer() duck-typing so third-party containers that predate
         // XoopsFormContainerInterface keep bubbling their required elements.
         if ($formElement instanceof XoopsFormContainerInterface
-            || (method_exists($formElement, 'getRequired') && $formElement->isContainer())) {
-            $required_elements = $formElement->getRequired();
+            || (method_exists($formElement, 'getRequired')
+                && method_exists($formElement, 'isContainer')
+                && $formElement->isContainer())) {
+            $required_elements = &$formElement->getRequired();
             $count             = count($required_elements);
             for ($i = 0; $i < $count; ++$i) {
                 $this->_required[] = &$required_elements[$i];
@@ -141,7 +143,9 @@ class XoopsFormElementTray extends XoopsFormElement implements XoopsFormContaine
             for ($i = 0; $i < $count; ++$i) {
                 $child = $this->_elements[$i];
                 if ($child instanceof XoopsFormContainerInterface
-                    || (method_exists($child, 'getElements') && $child->isContainer())) {
+                    || (method_exists($child, 'getElements')
+                        && method_exists($child, 'isContainer')
+                        && $child->isContainer())) {
                     $elements = &$child->getElements(true);
                     $count2   = count($elements);
                     for ($j = 0; $j < $count2; ++$j) {

--- a/htdocs/class/xoopsform/formelementtray.php
+++ b/htdocs/class/xoopsform/formelementtray.php
@@ -19,10 +19,12 @@
 
 defined('XOOPS_ROOT_PATH') || exit('Restricted access');
 
+require_once __DIR__ . '/formcontainerinterface.php';
+
 /**
  * A group of form elements
  */
-class XoopsFormElementTray extends XoopsFormElement
+class XoopsFormElementTray extends XoopsFormElement implements XoopsFormContainerInterface
 {
     public const ORIENTATION_HORIZONTAL = 'horizontal';
     public const ORIENTATION_VERTICAL   = 'vertical';
@@ -97,17 +99,19 @@ class XoopsFormElementTray extends XoopsFormElement
     public function addElement(XoopsFormElement $formElement, $required = false)
     {
         $this->_elements[] = $formElement;
-        if (!$formElement->isContainer()) {
-            if ($required) {
-                $formElement->_required = true;
-                $this->_required[]      = $formElement;
-            }
-        } else {
+        // Prefer the formal container contract; fall back to the legacy
+        // isContainer() duck-typing so third-party containers that predate
+        // XoopsFormContainerInterface keep bubbling their required elements.
+        if ($formElement instanceof XoopsFormContainerInterface
+            || (method_exists($formElement, 'getRequired') && $formElement->isContainer())) {
             $required_elements = $formElement->getRequired();
             $count             = count($required_elements);
             for ($i = 0; $i < $count; ++$i) {
                 $this->_required[] = &$required_elements[$i];
             }
+        } elseif ($required) {
+            $formElement->_required = true;
+            $this->_required[]      = $formElement;
         }
     }
 
@@ -135,15 +139,17 @@ class XoopsFormElementTray extends XoopsFormElement
             $ret   = [];
             $count = count($this->_elements);
             for ($i = 0; $i < $count; ++$i) {
-                if (!$this->_elements[$i]->isContainer()) {
-                    $ret[] = &$this->_elements[$i];
-                } else {
-                    $elements = &$this->_elements[$i]->getElements(true);
+                $child = $this->_elements[$i];
+                if ($child instanceof XoopsFormContainerInterface
+                    || (method_exists($child, 'getElements') && $child->isContainer())) {
+                    $elements = &$child->getElements(true);
                     $count2   = count($elements);
                     for ($j = 0; $j < $count2; ++$j) {
                         $ret[] = &$elements[$j];
                     }
                     unset($elements);
+                } else {
+                    $ret[] = &$this->_elements[$i];
                 }
             }
 

--- a/htdocs/class/xoopsform/formtabtray.php
+++ b/htdocs/class/xoopsform/formtabtray.php
@@ -174,8 +174,10 @@ class XoopsFormTabTray extends XoopsFormElement implements XoopsFormContainerInt
         // isContainer() duck-typing so third-party containers that predate
         // XoopsFormContainerInterface keep bubbling their required elements.
         if ($formElement instanceof XoopsFormContainerInterface
-            || (method_exists($formElement, 'getRequired') && $formElement->isContainer())) {
-            $required_elements = $formElement->getRequired();
+            || (method_exists($formElement, 'getRequired')
+                && method_exists($formElement, 'isContainer')
+                && $formElement->isContainer())) {
+            $required_elements = &$formElement->getRequired();
             $count             = count($required_elements);
             for ($i = 0; $i < $count; ++$i) {
                 $this->_required[] = &$required_elements[$i];
@@ -250,7 +252,9 @@ class XoopsFormTabTray extends XoopsFormElement implements XoopsFormContainerInt
         for ($i = 0; $i < $count; ++$i) {
             $child = $this->_elements[$i];
             if ($child instanceof XoopsFormContainerInterface
-                || (method_exists($child, 'getElements') && $child->isContainer())) {
+                || (method_exists($child, 'getElements')
+                    && method_exists($child, 'isContainer')
+                    && $child->isContainer())) {
                 $elements = &$child->getElements(true);
                 $count2   = count($elements);
                 for ($j = 0; $j < $count2; ++$j) {

--- a/htdocs/class/xoopsform/formtabtray.php
+++ b/htdocs/class/xoopsform/formtabtray.php
@@ -17,6 +17,7 @@
 defined('XOOPS_ROOT_PATH') || exit('Restricted access');
 
 require_once __DIR__ . '/renderer/XoopsFormTabRendererInterface.php';
+require_once __DIR__ . '/formcontainerinterface.php';
 
 /**
  * A tabbed group of form elements.
@@ -50,7 +51,7 @@ require_once __DIR__ . '/renderer/XoopsFormTabRendererInterface.php';
  * @license   GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
  * @link      https://xoops.org
  */
-class XoopsFormTabTray extends XoopsFormElement
+class XoopsFormTabTray extends XoopsFormElement implements XoopsFormContainerInterface
 {
     /**
      * Tab panes: each entry is ['title' => string, 'elements' => XoopsFormElement[]].
@@ -169,17 +170,19 @@ class XoopsFormTabTray extends XoopsFormElement
         $this->_tabs[$this->_currentTab]['elements'][] = $formElement;
         $this->_elements[]                             = $formElement;
 
-        if (!$formElement->isContainer()) {
-            if ($required) {
-                $formElement->_required = true;
-                $this->_required[]      = $formElement;
-            }
-        } else {
+        // Prefer the formal container contract; fall back to the legacy
+        // isContainer() duck-typing so third-party containers that predate
+        // XoopsFormContainerInterface keep bubbling their required elements.
+        if ($formElement instanceof XoopsFormContainerInterface
+            || (method_exists($formElement, 'getRequired') && $formElement->isContainer())) {
             $required_elements = $formElement->getRequired();
             $count             = count($required_elements);
             for ($i = 0; $i < $count; ++$i) {
                 $this->_required[] = &$required_elements[$i];
             }
+        } elseif ($required) {
+            $formElement->_required = true;
+            $this->_required[]      = $formElement;
         }
     }
 
@@ -245,15 +248,17 @@ class XoopsFormTabTray extends XoopsFormElement
         $ret   = [];
         $count = count($this->_elements);
         for ($i = 0; $i < $count; ++$i) {
-            if (!$this->_elements[$i]->isContainer()) {
-                $ret[] = &$this->_elements[$i];
-            } else {
-                $elements = &$this->_elements[$i]->getElements(true);
+            $child = $this->_elements[$i];
+            if ($child instanceof XoopsFormContainerInterface
+                || (method_exists($child, 'getElements') && $child->isContainer())) {
+                $elements = &$child->getElements(true);
                 $count2   = count($elements);
                 for ($j = 0; $j < $count2; ++$j) {
                     $ret[] = &$elements[$j];
                 }
                 unset($elements);
+            } else {
+                $ret[] = &$this->_elements[$i];
             }
         }
 

--- a/htdocs/class/xoopsload.php
+++ b/htdocs/class/xoopsload.php
@@ -194,6 +194,7 @@ class XoopsLoad
             'xoopseditorhandler'         => XOOPS_ROOT_PATH . '/class/xoopseditor/xoopseditor.php',
             'xoopsformloader'            => XOOPS_ROOT_PATH . '/class/xoopsformloader.php',
             'xoopsformelement'           => XOOPS_ROOT_PATH . '/class/xoopsform/formelement.php',
+            'xoopsformcontainerinterface' => XOOPS_ROOT_PATH . '/class/xoopsform/formcontainerinterface.php',
             'xoopsform'                  => XOOPS_ROOT_PATH . '/class/xoopsform/form.php',
             'xoopsformlabel'             => XOOPS_ROOT_PATH . '/class/xoopsform/formlabel.php',
             'xoopsformselect'            => XOOPS_ROOT_PATH . '/class/xoopsform/formselect.php',

--- a/tests/unit/htdocs/class/xoopsforms/XoopsFormElementTrayTest.php
+++ b/tests/unit/htdocs/class/xoopsforms/XoopsFormElementTrayTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 require_once dirname(__DIR__, 4) . '/bootstrap.php';
 
 xoops_load('XoopsFormElement');
+xoops_load('XoopsFormContainerInterface');
 xoops_load('XoopsFormElementTray');
 xoops_load('XoopsFormText');
 xoops_load('XoopsFormHidden');
@@ -73,6 +74,127 @@ class XoopsFormElementTrayTest extends TestCase
     public function testIsContainerReturnsTrue(): void
     {
         $this->assertTrue($this->tray->isContainer());
+    }
+
+    public function testImplementsContainerInterface(): void
+    {
+        $this->assertInstanceOf(\XoopsFormContainerInterface::class, $this->tray);
+    }
+
+    // ------------------------------------------------------------------
+    //  Container contract: interface path + legacy duck-typed fallback
+    // ------------------------------------------------------------------
+
+    public function testInterfaceContainerBubblesRequiredEvenWhenIsContainerFalse(): void
+    {
+        // A container detected via the interface must be treated as a container
+        // regardless of what isContainer() reports.
+        $req       = new \XoopsFormText('Req', 'iface_req', 25, 100);
+        $container = new class($req) extends \XoopsFormElement implements \XoopsFormContainerInterface {
+            private $list;
+            public function __construct($req)
+            {
+                $this->list = [$req];
+            }
+            public function isContainer()
+            {
+                return false;
+            }
+            public function &getRequired()
+            {
+                return $this->list;
+            }
+            public function &getElements($recurse = false)
+            {
+                return $this->list;
+            }
+            public function render()
+            {
+                return '';
+            }
+        };
+
+        $this->tray->addElement($container);
+
+        $required = $this->tray->getRequired();
+        $this->assertCount(1, $required);
+        $this->assertSame('iface_req', $required[0]->getName(false));
+    }
+
+    public function testLegacyDuckTypedContainerStillBubblesRequired(): void
+    {
+        // BC: a third-party container that predates the interface (isContainer()
+        // returns true, implements getRequired()/getElements(), but does NOT
+        // implement XoopsFormContainerInterface) must still bubble its required.
+        $req    = new \XoopsFormText('Legacy', 'legacy_req', 25, 100);
+        $legacy = new class($req) extends \XoopsFormElement {
+            private $list;
+            public function __construct($req)
+            {
+                $this->list = [$req];
+            }
+            public function isContainer()
+            {
+                return true;
+            }
+            public function &getRequired()
+            {
+                return $this->list;
+            }
+            public function &getElements($recurse = false)
+            {
+                return $this->list;
+            }
+            public function render()
+            {
+                return '';
+            }
+        };
+        $this->assertNotInstanceOf(\XoopsFormContainerInterface::class, $legacy);
+
+        $this->tray->addElement($legacy);
+
+        $required = $this->tray->getRequired();
+        $this->assertCount(1, $required);
+        $this->assertSame('legacy_req', $required[0]->getName(false));
+    }
+
+    public function testGetElementsRecursiveFlattensLegacyDuckTypedContainer(): void
+    {
+        // BC: recursive flattening must also honour legacy duck-typed containers.
+        $leaf   = new \XoopsFormText('Leaf', 'legacy_leaf', 25, 100);
+        $legacy = new class($leaf) extends \XoopsFormElement {
+            private $list;
+            public function __construct($leaf)
+            {
+                $this->list = [$leaf];
+            }
+            public function isContainer()
+            {
+                return true;
+            }
+            public function &getRequired()
+            {
+                static $none = [];
+                return $none;
+            }
+            public function &getElements($recurse = false)
+            {
+                return $this->list;
+            }
+            public function render()
+            {
+                return '';
+            }
+        };
+
+        $this->tray->addElement(new \XoopsFormText('Top', 'top', 25, 100));
+        $this->tray->addElement($legacy);
+
+        $flat = $this->tray->getElements(true);
+        $this->assertCount(2, $flat);
+        $this->assertSame('top', $flat[0]->getName(false));
+        $this->assertSame('legacy_leaf', $flat[1]->getName(false));
     }
 
     // ------------------------------------------------------------------

--- a/tests/unit/htdocs/class/xoopsforms/XoopsFormTabTrayTest.php
+++ b/tests/unit/htdocs/class/xoopsforms/XoopsFormTabTrayTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 require_once dirname(__DIR__, 4) . '/bootstrap.php';
 
 xoops_load('XoopsFormElement');
+xoops_load('XoopsFormContainerInterface');
 xoops_load('XoopsFormElementTray');
 xoops_load('XoopsFormTabTray');
 xoops_load('XoopsFormTabRendererInterface');
@@ -53,6 +54,50 @@ class XoopsFormTabTrayTest extends TestCase
     public function testIsContainerReturnsTrue(): void
     {
         $this->assertTrue($this->tray->isContainer());
+    }
+
+    public function testImplementsContainerInterface(): void
+    {
+        $this->assertInstanceOf(\XoopsFormContainerInterface::class, $this->tray);
+    }
+
+    public function testLegacyDuckTypedContainerStillBubblesRequired(): void
+    {
+        // BC: a third-party container that returns true from isContainer() and
+        // implements getRequired()/getElements() without implementing the new
+        // interface must still have its required elements bubbled.
+        $req    = new \XoopsFormText('Legacy', 'legacy_req', 25, 100);
+        $legacy = new class($req) extends \XoopsFormElement {
+            private $list;
+            public function __construct($req)
+            {
+                $this->list = [$req];
+            }
+            public function isContainer()
+            {
+                return true;
+            }
+            public function &getRequired()
+            {
+                return $this->list;
+            }
+            public function &getElements($recurse = false)
+            {
+                return $this->list;
+            }
+            public function render()
+            {
+                return '';
+            }
+        };
+        $this->assertNotInstanceOf(\XoopsFormContainerInterface::class, $legacy);
+
+        $this->tray->addTab('Tab');
+        $this->tray->addElement($legacy);
+
+        $required = $this->tray->getRequired();
+        $this->assertCount(1, $required);
+        $this->assertSame('legacy_req', $required[0]->getName(false));
     }
 
     public function testIsRequiredReturnsFalseWhenEmpty(): void

--- a/tests/unit/htdocs/class/xoopsforms/XoopsFormTabTrayTest.php
+++ b/tests/unit/htdocs/class/xoopsforms/XoopsFormTabTrayTest.php
@@ -100,6 +100,45 @@ class XoopsFormTabTrayTest extends TestCase
         $this->assertSame('legacy_req', $required[0]->getName(false));
     }
 
+    public function testGetElementsRecursiveFlattensLegacyDuckTypedContainer(): void
+    {
+        // BC: recursive flattening must also honour legacy duck-typed containers.
+        $leaf   = new \XoopsFormText('Leaf', 'legacy_leaf', 25, 100);
+        $legacy = new class($leaf) extends \XoopsFormElement {
+            private $list;
+            public function __construct($leaf)
+            {
+                $this->list = [$leaf];
+            }
+            public function isContainer()
+            {
+                return true;
+            }
+            public function &getRequired()
+            {
+                static $none = [];
+                return $none;
+            }
+            public function &getElements($recurse = false)
+            {
+                return $this->list;
+            }
+            public function render()
+            {
+                return '';
+            }
+        };
+
+        $this->tray->addTab('Tab');
+        $this->tray->addElement(new \XoopsFormText('Top', 'top', 25, 100));
+        $this->tray->addElement($legacy);
+
+        $flat = $this->tray->getElements(true);
+        $this->assertCount(2, $flat);
+        $this->assertSame('top', $flat[0]->getName(false));
+        $this->assertSame('legacy_leaf', $flat[1]->getName(false));
+    }
+
     public function testIsRequiredReturnsFalseWhenEmpty(): void
     {
         $this->assertFalse($this->tray->isRequired());


### PR DESCRIPTION
## Summary

Introduces a formal `XoopsFormContainerInterface` to replace the `isContainer()` duck-typing used by the form container elements, closing #88.

Supersedes the draft #89: in addition to the interface + `addElement()` changes, this also converts the **recursive `getElements(true)`** path, registers the interface in **`xoopsload`**, and preserves **backward compatibility** for third-party containers.

## Changes

- **New `XoopsFormContainerInterface`** declaring `isContainer()`, `&getRequired()`, `&getElements($recurse = false)`. Return types are **PHPDoc-only** (no native `: array`) — these are long-standing public signatures used across the module ecosystem, and native return types would be a BC break. Registered in `xoopsload` so `xoops_load('XoopsFormContainerInterface')` resolves it.
- **`XoopsFormElementTray`** and **`XoopsFormTabTray`** implement the interface. Their subclasses (`XoopsFormDateTime`, `XoopsFormSelectEditor`, `XoopsFormSelectUser`) inherit it for free.
- **Both** `addElement()` **and** the recursive `getElements()` on each tray now prefer `instanceof XoopsFormContainerInterface`, with a `method_exists() && isContainer()` fallback. This resolves the static-analysis `method.notFound` notes on the core path while keeping the legacy duck-typing alive, so third-party containers that predate the interface still bubble required elements and flatten correctly.

## Backward compatibility

The guard is `instanceof XoopsFormContainerInterface || (method_exists($el, 'getRequired'|'getElements') && $el->isContainer())`. A third-party container that returns `true` from `isContainer()` without (yet) implementing the interface keeps working exactly as before — verified by tests. No native return types are added to `getRequired()`/`getElements()`.

## Testing

- New tests: interface implementation; an interface container with `isContainer() === false` (proves `instanceof` is the discriminator); legacy duck-typed container still bubbling required; recursive flattening of a legacy duck-typed container.
- Full form suite green on PHP 8.5 (76 tests / 143 assertions); all changed files lint clean on PHP 8.2 (the supported floor).

Closes #88.
