### PR TITLE
refactor(form): adopt XoopsFormContainerInterface in XoopsForm + foreach-by-ref container iteration

### DIFF
--- a/htdocs/class/xoopsform/form.php
+++ b/htdocs/class/xoopsform/form.php
@@ -312,10 +312,10 @@ class XoopsForm
                     && method_exists($formElement, 'isContainer')
                     && $formElement->isContainer())) {
                 $required_elements = &$formElement->getRequired();
-                $count             = count($required_elements);
-                for ($i = 0; $i < $count; ++$i) {
-                    $this->_required[] = &$required_elements[$i];
+                foreach ($required_elements as &$required_element) {
+                    $this->_required[] = &$required_element;
                 }
+                unset($required_element);
             } elseif ($required) {
                 $formElement->_required = true;
                 $this->_required[]      = &$formElement;
@@ -345,11 +345,10 @@ class XoopsForm
                             && method_exists($child, 'isContainer')
                             && $child->isContainer())) {
                         $elements = &$child->getElements(true);
-                        $count2   = count($elements);
-                        for ($j = 0; $j < $count2; ++$j) {
-                            $ret[] = &$elements[$j];
+                        foreach ($elements as &$element) {
+                            $ret[] = &$element;
                         }
-                        unset($elements);
+                        unset($element, $elements);
                     } else {
                         $ret[] = &$this->_elements[$i];
                     }

--- a/htdocs/class/xoopsform/form.php
+++ b/htdocs/class/xoopsform/form.php
@@ -19,6 +19,8 @@
  */
 defined('XOOPS_ROOT_PATH') || exit('Restricted access');
 
+require_once __DIR__ . '/formcontainerinterface.php';
+
 /**
  * Abstract base class for forms
  *
@@ -302,17 +304,21 @@ class XoopsForm
             $this->_elements[] = $formElement;
         } elseif (is_subclass_of($formElement, 'XoopsFormElement')) {
             $this->_elements[] = &$formElement;
-            if (!$formElement->isContainer()) {
-                if ($required) {
-                    $formElement->_required = true;
-                    $this->_required[]      = &$formElement;
-                }
-            } else {
+            // Prefer the formal container contract; fall back to the legacy
+            // isContainer() duck-typing so third-party containers that predate
+            // XoopsFormContainerInterface keep bubbling their required elements.
+            if ($formElement instanceof XoopsFormContainerInterface
+                || (method_exists($formElement, 'getRequired')
+                    && method_exists($formElement, 'isContainer')
+                    && $formElement->isContainer())) {
                 $required_elements = &$formElement->getRequired();
                 $count             = count($required_elements);
                 for ($i = 0; $i < $count; ++$i) {
                     $this->_required[] = &$required_elements[$i];
                 }
+            } elseif ($required) {
+                $formElement->_required = true;
+                $this->_required[]      = &$formElement;
             }
         }
     }
@@ -333,15 +339,19 @@ class XoopsForm
             $count = count($this->_elements);
             for ($i = 0; $i < $count; ++$i) {
                 if (is_object($this->_elements[$i])) {
-                    if (!$this->_elements[$i]->isContainer()) {
-                        $ret[] = &$this->_elements[$i];
-                    } else {
-                        $elements = &$this->_elements[$i]->getElements(true);
+                    $child = $this->_elements[$i];
+                    if ($child instanceof XoopsFormContainerInterface
+                        || (method_exists($child, 'getElements')
+                            && method_exists($child, 'isContainer')
+                            && $child->isContainer())) {
+                        $elements = &$child->getElements(true);
                         $count2   = count($elements);
                         for ($j = 0; $j < $count2; ++$j) {
                             $ret[] = &$elements[$j];
                         }
                         unset($elements);
+                    } else {
+                        $ret[] = &$this->_elements[$i];
                     }
                 }
             }

--- a/htdocs/class/xoopsform/formelementtray.php
+++ b/htdocs/class/xoopsform/formelementtray.php
@@ -107,10 +107,10 @@ class XoopsFormElementTray extends XoopsFormElement implements XoopsFormContaine
                 && method_exists($formElement, 'isContainer')
                 && $formElement->isContainer())) {
             $required_elements = &$formElement->getRequired();
-            $count             = count($required_elements);
-            for ($i = 0; $i < $count; ++$i) {
-                $this->_required[] = &$required_elements[$i];
+            foreach ($required_elements as &$required_element) {
+                $this->_required[] = &$required_element;
             }
+            unset($required_element);
         } elseif ($required) {
             $formElement->_required = true;
             $this->_required[]      = $formElement;
@@ -147,11 +147,10 @@ class XoopsFormElementTray extends XoopsFormElement implements XoopsFormContaine
                         && method_exists($child, 'isContainer')
                         && $child->isContainer())) {
                     $elements = &$child->getElements(true);
-                    $count2   = count($elements);
-                    for ($j = 0; $j < $count2; ++$j) {
-                        $ret[] = &$elements[$j];
+                    foreach ($elements as &$element) {
+                        $ret[] = &$element;
                     }
-                    unset($elements);
+                    unset($element, $elements);
                 } else {
                     $ret[] = &$this->_elements[$i];
                 }

--- a/htdocs/class/xoopsform/formtabtray.php
+++ b/htdocs/class/xoopsform/formtabtray.php
@@ -178,10 +178,10 @@ class XoopsFormTabTray extends XoopsFormElement implements XoopsFormContainerInt
                 && method_exists($formElement, 'isContainer')
                 && $formElement->isContainer())) {
             $required_elements = &$formElement->getRequired();
-            $count             = count($required_elements);
-            for ($i = 0; $i < $count; ++$i) {
-                $this->_required[] = &$required_elements[$i];
+            foreach ($required_elements as &$required_element) {
+                $this->_required[] = &$required_element;
             }
+            unset($required_element);
         } elseif ($required) {
             $formElement->_required = true;
             $this->_required[]      = $formElement;
@@ -256,11 +256,10 @@ class XoopsFormTabTray extends XoopsFormElement implements XoopsFormContainerInt
                     && method_exists($child, 'isContainer')
                     && $child->isContainer())) {
                 $elements = &$child->getElements(true);
-                $count2   = count($elements);
-                for ($j = 0; $j < $count2; ++$j) {
-                    $ret[] = &$elements[$j];
+                foreach ($elements as &$element) {
+                    $ret[] = &$element;
                 }
-                unset($elements);
+                unset($element, $elements);
             } else {
                 $ret[] = &$this->_elements[$i];
             }

--- a/tests/unit/htdocs/class/xoopsforms/XoopsFormTest.php
+++ b/tests/unit/htdocs/class/xoopsforms/XoopsFormTest.php
@@ -134,7 +134,47 @@ class XoopsFormTest extends TestCase
         $this->assertSame('legacy_req', $required[0]->getName(false));
     }
 
-    public function testGetElementsRecursiveFlattensContainersAndKeepsStrings(): void
+    public function testAddElementBubblesRequiredFromNonSequentiallyKeyedContainer(): void
+    {
+        // Robustness: a container whose getRequired() returns a non-sequentially
+        // keyed array must still bubble every element (the old index-based loop
+        // would have silently skipped them).
+        $a      = new \XoopsFormText('A', 'req_a', 25, 100);
+        $b      = new \XoopsFormText('B', 'req_b', 25, 100);
+        $legacy = new class($a, $b) extends \XoopsFormElement {
+            private $list;
+            public function __construct($a, $b)
+            {
+                $this->list = [3 => $a, 7 => $b];
+            }
+            public function isContainer()
+            {
+                return true;
+            }
+            public function &getRequired()
+            {
+                return $this->list;
+            }
+            public function &getElements($recurse = false)
+            {
+                return $this->list;
+            }
+            public function render()
+            {
+                return '';
+            }
+        };
+
+        $this->form->addElement($legacy);
+
+        $required = $this->form->getRequired();
+        $this->assertCount(2, $required);
+        $names = [$required[0]->getName(false), $required[1]->getName(false)];
+        $this->assertContains('req_a', $names);
+        $this->assertContains('req_b', $names);
+    }
+
+    public function testGetElementsRecursiveFlattensContainersAndSkipsStringElements(): void
     {
         $tray = new \XoopsFormElementTray('Group');
         $tray->addElement(new \XoopsFormText('Inner', 'inner', 25, 100));

--- a/tests/unit/htdocs/class/xoopsforms/XoopsFormTest.php
+++ b/tests/unit/htdocs/class/xoopsforms/XoopsFormTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 require_once dirname(__DIR__, 4) . '/bootstrap.php';
 
 xoops_load('XoopsFormElement');
+xoops_load('XoopsFormContainerInterface');
 xoops_load('XoopsFormElementTray');
 xoops_load('XoopsForm');
 xoops_load('XoopsSimpleForm');
@@ -77,6 +78,77 @@ class XoopsFormTest extends TestCase
         $form = new \XoopsSimpleForm('Title', 'form', 'action.php', 'post', false);
         $elements = $form->getElements();
         $this->assertCount(0, $elements);
+    }
+
+    // ------------------------------------------------------------------
+    //  Container contract: interface path + legacy duck-typed fallback
+    // ------------------------------------------------------------------
+
+    public function testAddElementBubblesRequiredFromInterfaceContainer(): void
+    {
+        $tray = new \XoopsFormElementTray('Group');
+        $tray->addElement(new \XoopsFormText('Req', 'iface_req', 25, 100), true);
+
+        $this->form->addElement($tray);
+
+        $required = $this->form->getRequired();
+        $this->assertCount(1, $required);
+        $this->assertSame('iface_req', $required[0]->getName(false));
+    }
+
+    public function testAddElementBubblesRequiredFromLegacyDuckTypedContainer(): void
+    {
+        // BC: a third-party container that returns true from isContainer() and
+        // implements getRequired()/getElements() without implementing the new
+        // interface must still have its required elements bubbled.
+        $req    = new \XoopsFormText('Legacy', 'legacy_req', 25, 100);
+        $legacy = new class($req) extends \XoopsFormElement {
+            private $list;
+            public function __construct($req)
+            {
+                $this->list = [$req];
+            }
+            public function isContainer()
+            {
+                return true;
+            }
+            public function &getRequired()
+            {
+                return $this->list;
+            }
+            public function &getElements($recurse = false)
+            {
+                return $this->list;
+            }
+            public function render()
+            {
+                return '';
+            }
+        };
+        $this->assertNotInstanceOf(\XoopsFormContainerInterface::class, $legacy);
+
+        $this->form->addElement($legacy);
+
+        $required = $this->form->getRequired();
+        $this->assertCount(1, $required);
+        $this->assertSame('legacy_req', $required[0]->getName(false));
+    }
+
+    public function testGetElementsRecursiveFlattensContainersAndKeepsStrings(): void
+    {
+        $tray = new \XoopsFormElementTray('Group');
+        $tray->addElement(new \XoopsFormText('Inner', 'inner', 25, 100));
+
+        $this->form->addElement('<hr>'); // string element (e.g. addBreak)
+        $this->form->addElement(new \XoopsFormText('Top', 'top', 25, 100));
+        $this->form->addElement($tray);
+
+        $flat = $this->form->getElements(true);
+        // The string is skipped by getElements(recurse) (guarded by is_object);
+        // the tray is flattened to its leaf.
+        $this->assertCount(2, $flat);
+        $this->assertSame('top', $flat[0]->getName(false));
+        $this->assertSame('inner', $flat[1]->getName(false));
     }
 
     // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to #90. Two related cleanups in the form container layer:

1. **Adopt `XoopsFormContainerInterface` in `XoopsForm`** — the last duck-typing site. `XoopsForm::addElement()` and the recursive `XoopsForm::getElements()` now detect containers via `instanceof XoopsFormContainerInterface` (with the same `method_exists()`/`isContainer()` BC fallback as the trays), instead of the bare `isContainer()` check.
2. **Iterate container elements with `foreach` by reference** in `XoopsForm`, `XoopsFormElementTray`, and `XoopsFormTabTray`. The previous index-based `for` loops assumed sequentially-keyed arrays; a third-party container returning a non-sequential/associative array from `getRequired()`/`getElements()` would have triggered undefined-index warnings and silently dropped elements. `foreach`-by-ref handles any key shape (verified: it carries no aliasing pitfall — captured references stay bound to their original slots).

Existing behaviour is otherwise preserved: the `is_string()` branch in `XoopsForm::addElement()` (used by `addBreak()`) and the `is_object()` guard in `getElements()` are untouched, so string elements still pass through.

## Backward compatibility

Same strategy as #90 — core containers detected via the interface; legacy third-party containers keep working through the fallback. No native return types added to `getRequired()`/`getElements()`.

## Testing

- New `XoopsFormTest` cases: required bubbling from an interface container and a legacy duck-typed container; recursive `getElements()` flattening that skips string elements; and a **non-sequentially-keyed** container that still bubbles all required elements (would have failed under the old `for` loop).
- Full `xoopsforms` suite green on PHP 8.5 (1197 tests / 2106 assertions); all changed files lint clean on PHP 8.2.
