### PR TITLE
Security/hardening pass

### DIFF
--- a/htdocs/ajaxfineupload.php
+++ b/htdocs/ajaxfineupload.php
@@ -60,8 +60,20 @@ use Xmf\Jwt\TokenReader;
 // This runs BEFORE mainfile.php loads the XMF autoloader, so use the raw
 // superglobals here rather than Xmf\Request (which is not defined yet).
 // FineUploader may send the token in the request body or the query string.
+//
+// A Fine Uploader request carries the JWT (validated below, once mainfile has
+// loaded). Protector's pre-checks run during mainfile, before that validation,
+// and false-positive on a legitimate multi-file upload:
+//   - the rapid concurrent POST burst trips the DoS/post-flood filter, and
+//   - check_uploaded_files() rejects ordinary image filenames with more than one
+//     dot ("pngkey.com-….png") and any image getimagesize() cannot parse.
+// This endpoint enforces its own extension + MIME allowlist and stores files
+// under generated single-extension names, so skip those two Protector filters
+// here. The upload is still only processed after the JWT is validated, so a
+// request with a bogus token skips the filters but stores nothing.
 if (isset($_POST['Authorization']) || isset($_GET['Authorization'])) {
     define('PROTECTOR_SKIP_DOS_CHECK', 1);
+    define('PROTECTOR_SKIP_FILESCHECKER', 1);
 }
 include __DIR__ . '/mainfile.php';
 $xoopsLogger->activated = false;

--- a/htdocs/ajaxfineupload.php
+++ b/htdocs/ajaxfineupload.php
@@ -116,16 +116,20 @@ $method = get_request_method();
 if ($method === 'POST') {
     header('Content-Type: text/plain');
 
-    // Assumes you have a chunking.success.endpoint set to point here with a query parameter of "done".
-    // For example: /myserver/handlers/endpoint.php?done
-    if (\Xmf\Request::hasVar('done', 'GET')) {
-        $result = $uploader->combineChunks(XOOPS_ROOT_PATH . '/uploads');
-    } else { // Handle upload requests
-        // Call handleUpload() with the name of the folder, relative to PHP's getcwd()
-        $result = $uploader->handleUpload(XOOPS_ROOT_PATH . '/uploads');
+    try {
+        // Assumes you have a chunking.success.endpoint set to point here with a query parameter of "done".
+        // For example: /myserver/handlers/endpoint.php?done
+        if (\Xmf\Request::hasVar('done', 'GET')) {
+            $result = $uploader->combineChunks(XOOPS_ROOT_PATH . '/uploads');
+        } else { // Handle upload requests
+            // Call handleUpload() with the name of the folder, relative to PHP's getcwd()
+            $result = $uploader->handleUpload(XOOPS_ROOT_PATH . '/uploads');
 
-        // To return a name used for uploaded file you can use the following line.
-        $result['uploadName'] = $uploader->getUploadName();
+            // To return a name used for uploaded file you can use the following line.
+            $result['uploadName'] = $uploader->getUploadName();
+        }
+    } catch (\RuntimeException $e) {
+        $result = ['success' => false, 'error' => 'Upload rejected.', 'preventRetry' => true];
     }
 
     //====================
@@ -134,7 +138,11 @@ if ($method === 'POST') {
 
     echo json_encode($result);
 } elseif ($method == 'DELETE') { // for delete file requests
-    $result = $uploader->handleDelete('files');
+    try {
+        $result = $uploader->handleDelete('files');
+    } catch (\RuntimeException $e) {
+        $result = ['success' => false, 'error' => 'Delete rejected.'];
+    }
     echo json_encode($result);
 } else {
     header('HTTP/1.0 405 Method Not Allowed');

--- a/htdocs/ajaxfineupload.php
+++ b/htdocs/ajaxfineupload.php
@@ -57,7 +57,10 @@ use Xmf\Jwt\TokenReader;
  * SOFTWARE.
  */
 
-if (\Xmf\Request::hasVar('Authorization', 'POST')) {
+// This runs BEFORE mainfile.php loads the XMF autoloader, so use the raw
+// superglobals here rather than Xmf\Request (which is not defined yet).
+// FineUploader may send the token in the request body or the query string.
+if (isset($_POST['Authorization']) || isset($_GET['Authorization'])) {
     define('PROTECTOR_SKIP_DOS_CHECK', 1);
 }
 include __DIR__ . '/mainfile.php';

--- a/htdocs/ajaxfineupload.php
+++ b/htdocs/ajaxfineupload.php
@@ -144,7 +144,8 @@ if ($method === 'POST') {
             $result['uploadName'] = $uploader->getUploadName();
         }
     } catch (\Throwable $e) {
-        trigger_error('FineUploader rejected upload: ' . $e->getMessage(), E_USER_WARNING);
+        // Return JSON only — never emit the exception (it can carry absolute
+        // paths, and on a display_errors host it would corrupt the response).
         $result = ['success' => false, 'error' => 'Upload rejected.', 'preventRetry' => true];
     }
 
@@ -157,7 +158,6 @@ if ($method === 'POST') {
     try {
         $result = $uploader->handleDelete('files');
     } catch (\Throwable $e) {
-        trigger_error('FineUploader rejected delete: ' . $e->getMessage(), E_USER_WARNING);
         $result = ['success' => false, 'error' => 'Delete rejected.'];
     }
     echo json_encode($result);

--- a/htdocs/ajaxfineupload.php
+++ b/htdocs/ajaxfineupload.php
@@ -71,7 +71,16 @@ use Xmf\Jwt\TokenReader;
 // under generated single-extension names, so skip those two Protector filters
 // here. The upload is still only processed after the JWT is validated, so a
 // request with a bogus token skips the filters but stores nothing.
-if (isset($_POST['Authorization']) || isset($_GET['Authorization'])) {
+//
+// The JWT cannot be verified this early, but to keep a bare "?Authorization=x"
+// from disabling Protector and hammering this script, require a mutating method
+// and a JWT-shaped value (three base64url segments) before skipping.
+$fuAuthz  = $_POST['Authorization'] ?? $_GET['Authorization'] ?? '';
+$fuMethod = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+if (in_array($fuMethod, ['POST', 'DELETE'], true)
+    && is_string($fuAuthz)
+    && 1 === preg_match('~^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$~', $fuAuthz)
+) {
     define('PROTECTOR_SKIP_DOS_CHECK', 1);
     define('PROTECTOR_SKIP_FILESCHECKER', 1);
 }

--- a/htdocs/ajaxfineupload.php
+++ b/htdocs/ajaxfineupload.php
@@ -128,7 +128,8 @@ if ($method === 'POST') {
             // To return a name used for uploaded file you can use the following line.
             $result['uploadName'] = $uploader->getUploadName();
         }
-    } catch (\RuntimeException $e) {
+    } catch (\Throwable $e) {
+        trigger_error('FineUploader rejected upload: ' . $e->getMessage(), E_USER_WARNING);
         $result = ['success' => false, 'error' => 'Upload rejected.', 'preventRetry' => true];
     }
 
@@ -140,7 +141,8 @@ if ($method === 'POST') {
 } elseif ($method == 'DELETE') { // for delete file requests
     try {
         $result = $uploader->handleDelete('files');
-    } catch (\RuntimeException $e) {
+    } catch (\Throwable $e) {
+        trigger_error('FineUploader rejected delete: ' . $e->getMessage(), E_USER_WARNING);
         $result = ['success' => false, 'error' => 'Delete rejected.'];
     }
     echo json_encode($result);

--- a/htdocs/browse.php
+++ b/htdocs/browse.php
@@ -53,8 +53,12 @@ if ($path_type === 'var') {
 $file = realpath($xoops->path($path));
 $dir  = realpath($xoops->paths[$path_type][0]);
 
-//We are not allowing directory traversal either
-if (false === strpos($file, (string) $dir)) {
+//We are not allowing directory traversal either: the resolved file must sit
+//inside the resolved root. Require a path-boundary match, not a substring
+//match (which a sibling directory sharing the root's name prefix would pass).
+$dirPrefix = rtrim((string) $dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+if (false === $file || false === $dir
+    || !str_starts_with($file . DIRECTORY_SEPARATOR, $dirPrefix)) {
     http_response_code(404);
     exit();
 }

--- a/htdocs/class/auth/auth_ldap.php
+++ b/htdocs/class/auth/auth_ldap.php
@@ -292,7 +292,8 @@ class XoopsAuthLdap extends XoopsAuth
                 $this->setErrors(0, sprintf(_AUTH_LDAP_USER_NOT_FOUND, $uname, $filter, $this->ldap_base_dn));
             }
         } else {
-            $userDN = $this->ldap_loginldap_attr . '=' . $uname . ',' . $this->ldap_base_dn;
+            $userDN = $this->ldap_loginldap_attr . '='
+                . ldap_escape((string) $uname, '', LDAP_ESCAPE_DN) . ',' . $this->ldap_base_dn;
         }
 
         return $userDN;
@@ -306,11 +307,14 @@ class XoopsAuthLdap extends XoopsAuth
      */
     public function getFilter($uname)
     {
+        // Escape the login value for an LDAP search filter so metacharacters such
+        // as * ( ) \ cannot alter the query.
+        $safe   = ldap_escape((string) $uname, '', LDAP_ESCAPE_FILTER);
         $filter = '';
         if ($this->ldap_filter_person != '') {
-            $filter = str_replace('@@loginname@@', $uname, $this->ldap_filter_person);
+            $filter = str_replace('@@loginname@@', $safe, $this->ldap_filter_person);
         } else {
-            $filter = $this->ldap_loginldap_attr . '=' . $uname;
+            $filter = $this->ldap_loginldap_attr . '=' . $safe;
         }
 
         return $filter;

--- a/htdocs/class/module.textsanitizer.php
+++ b/htdocs/class/module.textsanitizer.php
@@ -560,7 +560,9 @@ class MyTextSanitizer
      */
     protected function makeClickableCallbackEmailAddress($match)
     {
-        $email = $match[2];  // Extract the email address
+        // Decode only this matched token (never the whole buffer) so a pre-encoded
+        // address round-trips to a single, safely re-encoded output.
+        $email = html_entity_decode($match[2], ENT_QUOTES, 'UTF-8');
         return $match[1] . '<a href="mailto:' . htmlspecialchars($email, ENT_QUOTES, 'UTF-8') . '">' . htmlspecialchars($email, ENT_QUOTES, 'UTF-8') . '</a>';
     }
 
@@ -643,8 +645,11 @@ class MyTextSanitizer
     }
 
     public function makeClickable($text) {
-        // Decode HTML entities
-        $text = html_entity_decode($text, ENT_QUOTES, 'UTF-8');
+        // Do NOT entity-decode the whole buffer here. displayTarea() may have
+        // already encoded this text for safe display, and decoding everything back
+        // would undo that encoding. Each match below decodes only its own URL or
+        // email token and then re-encodes it, so links render correctly while the
+        // surrounding text keeps the encoding displayTarea() applied.
 
         // Convert line breaks and multiple spaces to a single space
         $text = preg_replace('/[\n\s]+/', ' ', $text);
@@ -658,7 +663,9 @@ class MyTextSanitizer
         $text = preg_replace_callback(
             $pattern,
             function ($matches) {
-                $url = $matches[2];
+                // Decode only the matched URL token so a pre-encoded URL round-trips
+                // to a single, safely re-encoded href (&amp; stays &amp;, not &amp;amp;).
+                $url = html_entity_decode($matches[2], ENT_QUOTES, 'UTF-8');
                 $prefix = $matches[0][0] ?? ''; // Get the prefix character (space, bracket, etc.)
                 $openingBracket = $matches[1] ?? ''; // Check for the opening angle bracket
 

--- a/htdocs/include/comment_delete.php
+++ b/htdocs/include/comment_delete.php
@@ -96,12 +96,9 @@ if (!is_object($xoopsUser)) {
 }
 
 if (false !== $accesserror) {
-    $ref = xoops_getenv('HTTP_REFERER');
-    if ($ref != '') {
-        redirect_header($ref, 2, _NOPERM);
-    } else {
-        redirect_header($redirect_page . '?' . $comment_config['itemName'] . '=' . (int) $com_itemid, 2, _NOPERM);
-    }
+    // Redirect to the known item page rather than to the request-supplied
+    // Referer header.
+    redirect_header($redirect_page . '?' . $comment_config['itemName'] . '=' . (int) $com_itemid, 2, _NOPERM);
     exit();
 }
 

--- a/htdocs/include/comment_delete.php
+++ b/htdocs/include/comment_delete.php
@@ -102,7 +102,7 @@ if (!is_object($xoopsUser)) {
 if (false !== $accesserror) {
     // Redirect to the known item page rather than to the request-supplied
     // Referer header.
-    redirect_header($redirect_page . '?' . $comment_config['itemName'] . '=' . (int) $com_itemid, 2, _NOPERM);
+    redirect_header($redirect_page . '=' . (int) $com_itemid, 2, _NOPERM);
     exit();
 }
 
@@ -110,7 +110,7 @@ xoops_loadLanguage('comment');
 switch ($op) {
     case 'delete_one':
         if (!$GLOBALS['xoopsSecurity']->check()) {
-            redirect_header($redirect_page . '?' . $comment_config['itemName'] . '=' . (int) $com_itemid, 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+            redirect_header($redirect_page . '=' . (int) $com_itemid, 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
         }
         /** @var  XoopsCommentHandler $comment_handler */
         $comment_handler = xoops_getHandler('comment');
@@ -202,7 +202,7 @@ switch ($op) {
 
     case 'delete_all':
         if (!$GLOBALS['xoopsSecurity']->check()) {
-            redirect_header($redirect_page . '?' . $comment_config['itemName'] . '=' . (int) $com_itemid, 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+            redirect_header($redirect_page . '=' . (int) $com_itemid, 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
         }
         /** @var  XoopsCommentHandler $comment_handler */
         $comment_handler = xoops_getHandler('comment');

--- a/htdocs/include/comment_delete.php
+++ b/htdocs/include/comment_delete.php
@@ -29,6 +29,7 @@ $filters = [
     'op' => FILTER_SANITIZE_FULL_SPECIAL_CHARS,
     'com_order' => FILTER_VALIDATE_INT,
     'com_id' => FILTER_VALIDATE_INT,
+    'com_itemid' => FILTER_VALIDATE_INT,
 ];
 
 if (!empty($_POST)) {
@@ -39,6 +40,9 @@ if (!empty($_POST)) {
 $com_mode  = $result['com_mode'] ?: 'flat';
 $com_order = $result['com_order'] ?: XOOPS_COMMENT_OLD1ST;
 $com_id    = $result['com_id'] ?: 0;
+// Available for the early redirect targets below; reassigned from the comment
+// object once it is loaded in the delete branches.
+$com_itemid = $result['com_itemid'] ?: 0;
 if ($result['op']) {
     $op = $result['op'];
 }

--- a/htdocs/include/comment_delete.php
+++ b/htdocs/include/comment_delete.php
@@ -105,6 +105,9 @@ if (false !== $accesserror) {
 xoops_loadLanguage('comment');
 switch ($op) {
     case 'delete_one':
+        if (!$GLOBALS['xoopsSecurity']->check()) {
+            redirect_header($redirect_page . '?' . $comment_config['itemName'] . '=' . (int) $com_itemid, 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+        }
         /** @var  XoopsCommentHandler $comment_handler */
         $comment_handler = xoops_getHandler('comment');
         $comment         = $comment_handler->get($com_id);
@@ -194,6 +197,9 @@ switch ($op) {
         break;
 
     case 'delete_all':
+        if (!$GLOBALS['xoopsSecurity']->check()) {
+            redirect_header($redirect_page . '?' . $comment_config['itemName'] . '=' . (int) $com_itemid, 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+        }
         /** @var  XoopsCommentHandler $comment_handler */
         $comment_handler = xoops_getHandler('comment');
         $comment         = $comment_handler->get($com_id);

--- a/htdocs/include/cp_functions.php
+++ b/htdocs/include/cp_functions.php
@@ -42,6 +42,12 @@ function xoops_cp_header()
  */
 function xoops_cp_footer()
 {
+    // Emit a request token on every control-panel page so admin AJAX actions
+    // (status toggles, drag/drop ordering, ...) can submit and validate it.
+    if (isset($GLOBALS['xoopsSecurity']) && is_object($GLOBALS['xoopsSecurity'])) {
+        echo '<div id="xo-admin-token" style="display:none">'
+            . $GLOBALS['xoopsSecurity']->getTokenHTML() . '</div>';
+    }
     xoops_load('cpanel', 'system');
     $cpanel = XoopsSystemCpanel::getInstance();
     $cpanel->gui->footer();

--- a/htdocs/include/file_safety.php
+++ b/htdocs/include/file_safety.php
@@ -256,14 +256,19 @@ if (!function_exists('xoops_isLocalUrl')) {
             return false;
         }
 
-        $sameHost   = strcasecmp($parts['host'], $base['host']) === 0;
-        $sameScheme = strcasecmp($parts['scheme'] ?? 'http', $base['scheme'] ?? 'http') === 0;
+        $sameHost = strcasecmp($parts['host'], $base['host']) === 0;
+
+        // A scheme-relative target (//host/...) inherits the base scheme, so
+        // compare against the base rather than defaulting to http.
+        $baseScheme   = strtolower($base['scheme'] ?? 'http');
+        $targetScheme = strtolower($parts['scheme'] ?? $baseScheme);
+        $sameScheme   = $targetScheme === $baseScheme;
 
         // Normalise default ports so http://host and http://host:80 (and the
         // https/443 pair) compare as the same origin.
         $defaultPorts = ['http' => 80, 'https' => 443, 'ftp' => 21];
-        $targetPort = $parts['port'] ?? ($defaultPorts[strtolower($parts['scheme'] ?? '')] ?? null);
-        $basePort   = $base['port'] ?? ($defaultPorts[strtolower($base['scheme'] ?? '')] ?? null);
+        $targetPort = $parts['port'] ?? ($defaultPorts[$targetScheme] ?? null);
+        $basePort   = $base['port'] ?? ($defaultPorts[$baseScheme] ?? null);
         $samePort   = $targetPort === $basePort;
 
         return $sameHost && $sameScheme && $samePort;

--- a/htdocs/include/file_safety.php
+++ b/htdocs/include/file_safety.php
@@ -213,3 +213,51 @@ if (!function_exists('xoops_remove_file_quietly')) {
         }
     }
 }
+
+if (!function_exists('xoops_isLocalUrl')) {
+    /**
+     * Decide whether an absolute or scheme-relative URL points at this site.
+     *
+     * Decodes HTML entities first, rejects control characters, then compares
+     * scheme, host and port against XOOPS_URL exactly. A look-alike host such as
+     * `localhost.example.org`, a userinfo trick such as `localhost@evil.test`, or
+     * a scheme-relative `//evil.test` therefore does not match. A single
+     * leading-slash, root-relative path (e.g. `/index.php`) is treated as local;
+     * `//` is not. Bare relative paths (e.g. `user.php`) are the caller's
+     * responsibility and are intentionally not the target of this helper.
+     *
+     * @param string $url candidate URL
+     * @return bool true when the target is same-origin or a root-relative path
+     */
+    function xoops_isLocalUrl($url)
+    {
+        $decoded = html_entity_decode((string) $url, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        if (preg_match('/[\x00-\x1F\x7F]/', $decoded)) {
+            return false; // control characters / CR-LF
+        }
+
+        $parts = parse_url($decoded);
+        if ($parts === false) {
+            return false;
+        }
+
+        if (!isset($parts['host'])) {
+            // Path-only target: allow single-slash root-relative, reject `//host`.
+            return isset($parts['path'])
+                && strncmp($parts['path'], '/', 1) === 0
+                && strncmp($decoded, '//', 2) !== 0;
+        }
+
+        $base = parse_url((string) XOOPS_URL);
+        if (!is_array($base) || !isset($base['host'])) {
+            return false;
+        }
+
+        $sameHost   = strcasecmp($parts['host'], $base['host']) === 0;
+        $sameScheme = strcasecmp($parts['scheme'] ?? 'http', $base['scheme'] ?? 'http') === 0;
+        $samePort   = ($parts['port'] ?? null) === ($base['port'] ?? null);
+
+        return $sameHost && $sameScheme && $samePort;
+    }
+}

--- a/htdocs/include/file_safety.php
+++ b/htdocs/include/file_safety.php
@@ -2,12 +2,14 @@
 /**
  * Side-effect-free file-safety helpers.
  *
- * Hosts the three small filesystem helpers used by atomic-write and
- * cleanup paths:
+ * Hosts small, dependency-light safety helpers used by atomic-write, cleanup
+ * and redirect paths:
  *
  *  - xoops_file_label()        — root-relative label for warnings
+ *  - xoops_safe_basename()     — null-byte-safe basename() with placeholder
  *  - xoops_chmod_quietly()     — scoped-suppressed chmod() with single warning
  *  - xoops_remove_file_quietly() — scoped-suppressed unlink() with single warning
+ *  - xoops_isLocalUrl()        — strict same-origin check (scheme/host/port) for redirects
  *
  * They originally lived in include/cp_functions.php, but that file
  * unconditionally `define()`s XOOPS_CPFUNC_LOADED, which include/

--- a/htdocs/include/file_safety.php
+++ b/htdocs/include/file_safety.php
@@ -258,7 +258,13 @@ if (!function_exists('xoops_isLocalUrl')) {
 
         $sameHost   = strcasecmp($parts['host'], $base['host']) === 0;
         $sameScheme = strcasecmp($parts['scheme'] ?? 'http', $base['scheme'] ?? 'http') === 0;
-        $samePort   = ($parts['port'] ?? null) === ($base['port'] ?? null);
+
+        // Normalise default ports so http://host and http://host:80 (and the
+        // https/443 pair) compare as the same origin.
+        $defaultPorts = ['http' => 80, 'https' => 443, 'ftp' => 21];
+        $targetPort = $parts['port'] ?? ($defaultPorts[strtolower($parts['scheme'] ?? '')] ?? null);
+        $basePort   = $base['port'] ?? ($defaultPorts[strtolower($base['scheme'] ?? '')] ?? null);
+        $samePort   = $targetPort === $basePort;
 
         return $sameHost && $sameScheme && $samePort;
     }

--- a/htdocs/include/file_safety.php
+++ b/htdocs/include/file_safety.php
@@ -245,8 +245,12 @@ if (!function_exists('xoops_isLocalUrl')) {
         }
 
         if (!isset($parts['host'])) {
-            // Path-only target: allow single-slash root-relative, reject `//host`.
-            return isset($parts['path'])
+            // A scheme with no host (e.g. "http:/evil.test/") is malformed and a
+            // browser may normalise it to an external absolute URL — reject it. A
+            // genuine root-relative path carries no scheme: allow a single-slash
+            // path, reject `//host`.
+            return !isset($parts['scheme'])
+                && isset($parts['path'])
                 && strncmp($parts['path'], '/', 1) === 0
                 && strncmp($decoded, '//', 2) !== 0;
         }

--- a/htdocs/include/file_safety.php
+++ b/htdocs/include/file_safety.php
@@ -252,7 +252,7 @@ if (!function_exists('xoops_isLocalUrl')) {
         }
 
         $base = parse_url((string) XOOPS_URL);
-        if (!is_array($base) || !isset($base['host'])) {
+        if (!isset($base['host'])) {
             return false;
         }
 

--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -791,9 +791,12 @@ function redirect_header($url, $time = 3, $message = '', $addredirect = true, $a
             $url = XOOPS_URL;
         }
     }
-    if (!$allowExternalLink && $pos = strpos($url, '://')) {
-        $xoopsLocation = substr(XOOPS_URL, strpos(XOOPS_URL, '://') + 3);
-        if (strcasecmp(substr($url, $pos + 3, strlen($xoopsLocation)), $xoopsLocation)) {
+    if (!$allowExternalLink && (false !== strpos($url, '://') || 0 === strncmp((string) $url, '//', 2))) {
+        // Absolute or scheme-relative target: confirm it is same-origin with
+        // XOOPS_URL (full scheme/host/port match, not a prefix). Bare relative
+        // paths are left untouched, matching the previous behaviour.
+        require_once __DIR__ . '/file_safety.php';
+        if (!xoops_isLocalUrl($url)) {
             $url = XOOPS_URL;
         }
     }

--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -791,12 +791,15 @@ function redirect_header($url, $time = 3, $message = '', $addredirect = true, $a
             $url = XOOPS_URL;
         }
     }
-    if (!$allowExternalLink && (false !== strpos($url, '://') || 0 === strncmp((string) $url, '//', 2))) {
-        // Absolute or scheme-relative target: confirm it is same-origin with
-        // XOOPS_URL (full scheme/host/port match, not a prefix). Bare relative
-        // paths are left untouched, matching the previous behaviour.
+    if (!$allowExternalLink) {
         require_once __DIR__ . '/file_safety.php';
-        if (!xoops_isLocalUrl($url)) {
+        $decoded = html_entity_decode((string) $url, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        // Validate any scheme-bearing (http:, data:, mailto:, ...) or
+        // scheme-relative target against XOOPS_URL (full scheme/host/port match,
+        // not a prefix). Bare relative paths carry no scheme and are left
+        // untouched, matching the previous behaviour.
+        if ((null !== parse_url($decoded, PHP_URL_SCHEME) || 0 === strncmp(ltrim($decoded), '//', 2))
+            && !xoops_isLocalUrl($url)) {
             $url = XOOPS_URL;
         }
     }

--- a/htdocs/modules/profile/admin/step.php
+++ b/htdocs/modules/profile/admin/step.php
@@ -36,6 +36,8 @@ switch ($op) {
         $criteria->setSort('step_order');
         $criteria->setOrder('ASC');
         $GLOBALS['xoopsTpl']->assign('steps', $handler->getObjects($criteria, true, false));
+        // raw token value for the tokenised toggle action link
+        $GLOBALS['xoopsTpl']->assign('steps_csrf', $GLOBALS['xoopsSecurity']->createToken());
         $template_main = 'profile_admin_steplist.tpl';
         break;
 
@@ -108,6 +110,10 @@ switch ($op) {
         break;
 
     case 'toggle':
+        if (!$GLOBALS['xoopsSecurity']->check(false)) {
+            redirect_header('step.php', 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+            break;
+        }
         if (Request::hasVar('step_id', 'GET')) {
             $step_id = Request::getInt('step_id', 0, 'GET');
             profile_stepsave_toggle($step_id);

--- a/htdocs/modules/profile/templates/profile_admin_steplist.tpl
+++ b/htdocs/modules/profile/templates/profile_admin_steplist.tpl
@@ -8,7 +8,7 @@
             <td><{$step.step_name}></td>
             <td align="center"><{$step.step_order}></td>
             <td align="center">
-                <a href="step.php?op=toggle&amp;step_save=<{$step.step_save}>&amp;step_id=<{$step.step_id}>"><img
+                <a href="step.php?op=toggle&amp;step_save=<{$step.step_save}>&amp;step_id=<{$step.step_id}>&amp;XOOPS_TOKEN_REQUEST=<{$steps_csrf}>"><img
                             src="<{xoModuleIcons16}><{$step.step_save}>.png" title="<{$smarty.const._PROFILE_AM_SAVESTEP_TOGGLE}>"
                             alt="<{$smarty.const._PROFILE_AM_SAVESTEP_TOGGLE}>"/></a>
             </td>

--- a/htdocs/modules/system/admin/avatars/main.php
+++ b/htdocs/modules/system/admin/avatars/main.php
@@ -28,6 +28,13 @@ if (!xoops_getModuleOption('active_avatars', 'system')) {
 // Get Action type
 $op = Request::getString('op', 'list');
 
+// The status toggle arrives via AJAX (system_setStatus); validate the request
+// token before any output so a forged request cannot flip the display flag.
+if ('display' === $op && !$GLOBALS['xoopsSecurity']->check(false)) {
+    http_response_code(403);
+    exit();
+}
+
 // Define main template
 $GLOBALS['xoopsOption']['template_main'] = 'system_avatars.tpl';
 // Call Header

--- a/htdocs/modules/system/admin/blocksadmin/main.php
+++ b/htdocs/modules/system/admin/blocksadmin/main.php
@@ -48,6 +48,14 @@ if ($type === 'preview') {
 
 $bid = Request::getInt('bid', 0);
 
+// The block visibility/drag/order operations arrive via AJAX; validate the
+// request token before any output and stop quietly on mismatch (these endpoints
+// ignore the response body).
+if (in_array($op, ['display', 'drag', 'order'], true) && !$GLOBALS['xoopsSecurity']->check(false)) {
+    http_response_code(403);
+    exit();
+}
+
 // Define main template
 $GLOBALS['xoopsOption']['template_main'] = 'system_blocks.tpl';
 // Call Header

--- a/htdocs/modules/system/admin/groups/main.php
+++ b/htdocs/modules/system/admin/groups/main.php
@@ -349,6 +349,9 @@ switch ($op) {
 
         //Add users group
     case 'action_group':
+        if (!$GLOBALS['xoopsSecurity']->check()) {
+            redirect_header('admin.php?fct=users', 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+        }
         $error = true;
         $edit_group    = Request::getCmd('edit_group', '', 'POST');
         $selgroups     = Request::getInt('selgroups', 0, 'POST');

--- a/htdocs/modules/system/admin/groups/main.php
+++ b/htdocs/modules/system/admin/groups/main.php
@@ -350,7 +350,7 @@ switch ($op) {
         //Add users group
     case 'action_group':
         if (!$GLOBALS['xoopsSecurity']->check()) {
-            redirect_header('admin.php?fct=users', 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+            redirect_header('admin.php?fct=groups', 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
         }
         $error = true;
         $edit_group    = Request::getCmd('edit_group', '', 'POST');

--- a/htdocs/modules/system/admin/images/main.php
+++ b/htdocs/modules/system/admin/images/main.php
@@ -64,6 +64,14 @@ if (!$xoopsUser->isAdmin($xoopsModule->mid()) && ($op === 'delfile' || $op === '
     redirect_header('admin.php?fct=images', 1);
 }
 
+// The category/image display toggles arrive via AJAX (system_setStatus);
+// validate the request token before any output so a forged request cannot flip
+// the display flag.
+if (in_array($op, ['display_cat', 'display_img'], true) && !$GLOBALS['xoopsSecurity']->check(false)) {
+    http_response_code(403);
+    exit();
+}
+
 // Define main template
 $GLOBALS['xoopsOption']['template_main'] = 'system_images.tpl';
 // Call Header

--- a/htdocs/modules/system/admin/mailusers/main.php
+++ b/htdocs/modules/system/admin/mailusers/main.php
@@ -155,6 +155,9 @@ switch ($op) {
 
     // Send
     case 'send':
+        if (!$GLOBALS['xoopsSecurity']->check()) {
+            redirect_header('admin.php?fct=mailusers', 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+        }
         // Define Breadcrumb and tips
         $xoBreadCrumb->addLink(_AM_SYSTEM_MAILUSERS_LIST);
         $xoBreadCrumb->render();

--- a/htdocs/modules/system/admin/smilies/main.php
+++ b/htdocs/modules/system/admin/smilies/main.php
@@ -33,6 +33,13 @@ $mimetypes   = ['image/gif', 'image/jpeg', 'image/pjpeg', 'image/x-png', 'image/
 $upload_size = 500000;
 // Get Action type
 $op = Request::hasVar('op', 'POST') ? Request::getString('op', 'list', 'POST') : Request::getString('op', 'list', 'GET');
+
+// The status toggle arrives via AJAX (system_setStatus); validate the request
+// token before any output so a forged request cannot flip the display flag.
+if ('smilies_update_display' === $op && !$GLOBALS['xoopsSecurity']->check(false)) {
+    http_response_code(403);
+    exit();
+}
 // Get smilies handler
 /** @var  SystemsmiliesHandler $smilies_Handler */
 $smilies_Handler = xoops_getModuleHandler('smilies', 'system');

--- a/htdocs/modules/system/admin/userrank/main.php
+++ b/htdocs/modules/system/admin/userrank/main.php
@@ -38,6 +38,13 @@ $mimetypes   = ['image/gif', 'image/jpeg', 'image/pjpeg', 'image/x-png', 'image/
 $upload_size = 500000;
 // Get Action type
 $op = Request::hasVar('op', 'POST') ? Request::getString('op', 'list', 'POST') : Request::getString('op', 'list', 'GET');
+
+// The status toggle arrives via AJAX (system_setStatus); validate the request
+// token before any output so a forged request cannot flip the special flag.
+if ('userrank_update_special' === $op && !$GLOBALS['xoopsSecurity']->check(false)) {
+    http_response_code(403);
+    exit();
+}
 // Get userrank handler
 /** @var SystemUserrankHandler $userrank_Handler */
 $userrank_Handler = xoops_getModuleHandler('userrank', 'system');

--- a/htdocs/modules/system/admin/users/jquery.php
+++ b/htdocs/modules/system/admin/users/jquery.php
@@ -36,6 +36,10 @@ switch ($op) {
 
     // Display post
     case 'display_post':
+        if (!$GLOBALS['xoopsSecurity']->check(false)) {
+            http_response_code(403);
+            exit();
+        }
         global $xoopsDB;
 
         $GLOBALS['xoopsLogger']->activated = false;

--- a/htdocs/modules/system/admin/users/jquery.php
+++ b/htdocs/modules/system/admin/users/jquery.php
@@ -61,7 +61,7 @@ switch ($op) {
                 $tables[] = ['table_name' => 'bb_posts', 'uid_column' => 'uid'];
             }
         }
-        $uid         = Request::getInt('uid', 0);
+        $uid         = Request::getInt('uid', 0, 'POST');
         $total_posts = 0;
         foreach ($tables as $table) {
             $criteria = new CriteriaCompo();

--- a/htdocs/modules/system/admin/users/main.php
+++ b/htdocs/modules/system/admin/users/main.php
@@ -361,6 +361,10 @@ case 'users_save':
 
         // Active member
     case 'users_active':
+        if (!$GLOBALS['xoopsSecurity']->check(false)) {
+            redirect_header('admin.php?fct=users', 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+            break;
+        }
         if (Request::hasVar('uid')) {
             $obj = $member_handler->getUser($uid);
         }
@@ -377,6 +381,10 @@ case 'users_save':
 
         // Synchronize
     case 'users_synchronize':
+        if (!$GLOBALS['xoopsSecurity']->check(false)) {
+            redirect_header('admin.php?fct=users', 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+            break;
+        }
         if (Request::hasVar('status') && Request::getString('status') == 1) {
             synchronize($uid, 'user');
         } elseif (Request::hasVar('status') && Request::getString('status') == 2) {
@@ -928,6 +936,8 @@ case 'users_save':
             $tokenElement = new XoopsFormHiddenToken();
             $token = $tokenElement->render();
             $xoopsTpl->assign('form_token', $token);
+            // raw token value for the tokenised activate / synchronize action links
+            $xoopsTpl->assign('users_csrf', $GLOBALS['xoopsSecurity']->createToken());
 
             // echo $requete_search;
 

--- a/htdocs/modules/system/admin/users/main.php
+++ b/htdocs/modules/system/admin/users/main.php
@@ -365,7 +365,8 @@ case 'users_save':
             redirect_header('admin.php?fct=users', 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
             break;
         }
-        if (Request::hasVar('uid')) {
+        if (Request::hasVar('uid', 'GET')) {
+            $uid = Request::getInt('uid', 0, 'GET');
             $obj = $member_handler->getUser($uid);
         }
         if (!isset($obj) || !is_object($obj)) {
@@ -385,9 +386,11 @@ case 'users_save':
             redirect_header('admin.php?fct=users', 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
             break;
         }
-        if (Request::hasVar('status') && Request::getString('status') == 1) {
+        $status = Request::getInt('status', 0, 'GET');
+        if (1 === $status) {
+            $uid = Request::getInt('uid', 0, 'GET');
             synchronize($uid, 'user');
-        } elseif (Request::hasVar('status') && Request::getString('status') == 2) {
+        } elseif (2 === $status) {
             synchronize('', 'all users');
         }
         redirect_header('admin.php?fct=users', 1, _AM_SYSTEM_DBUPDATED);

--- a/htdocs/modules/system/class/fineuploadhandler.php
+++ b/htdocs/modules/system/class/fineuploadhandler.php
@@ -62,6 +62,71 @@ abstract class SystemFineUploadHandler
     }
 
     /**
+     * Confirm a client-supplied chunk identifier is a single safe path segment.
+     *
+     * @param string $uuid
+     * @return string the validated identifier
+     * @throws \RuntimeException when the value is not a plain identifier
+     */
+    protected function safeUuid($uuid)
+    {
+        $uuid = (string) $uuid;
+        if (1 !== preg_match('/^[A-Za-z0-9_-]{1,64}$/', $uuid)) {
+            throw new \RuntimeException('Invalid upload identifier.');
+        }
+        return $uuid;
+    }
+
+    /**
+     * Reduce a client-supplied filename to a single safe leaf name and, when an
+     * extension allowlist is configured, confirm the extension is permitted. This
+     * is applied on the chunk-combine path as well as on normal upload, so a
+     * combine request cannot introduce a path segment or a disallowed type.
+     *
+     * @param string $name
+     * @return string the validated leaf name
+     * @throws \RuntimeException when the value is empty, hidden, or disallowed
+     */
+    protected function safeLeafName($name)
+    {
+        $name = basename(str_replace('\\', '/', (string) $name));
+        if ('' === $name || '.' === $name[0]) {
+            throw new \RuntimeException('Invalid file name.');
+        }
+        if (!empty($this->allowedExtensions)) {
+            $ext = strtolower((string) pathinfo($name, PATHINFO_EXTENSION));
+            if (!in_array($ext, array_map('strtolower', $this->allowedExtensions), true)) {
+                throw new \RuntimeException('File has an invalid extension.');
+            }
+        }
+        return $name;
+    }
+
+    /**
+     * Defence-in-depth check that a built path stays under $root. The UUID and
+     * leaf name are already validated, so this performs a filesystem-independent
+     * lexical check (no realpath) that rejects residual parent traversal and
+     * confirms the root prefix - it never rejects a directory that does not exist
+     * yet, which would otherwise break the first chunk of an upload.
+     *
+     * @param string $path
+     * @param string $root
+     * @return string the validated path
+     * @throws \RuntimeException when the path would fall outside $root
+     */
+    protected function assertWithin($path, $root)
+    {
+        $normalizedPath = str_replace('\\', '/', (string) $path);
+        $normalizedRoot = rtrim(str_replace('\\', '/', (string) $root), '/') . '/';
+        if (false !== strpos($normalizedPath, '../')
+            || str_ends_with($normalizedPath, '/..')
+            || 0 !== strncmp($normalizedPath, $normalizedRoot, strlen($normalizedRoot))) {
+            throw new \RuntimeException('Path escapes upload root.');
+        }
+        return $path;
+    }
+
+    /**
      * Get the original filename
      */
     public function getName()
@@ -95,14 +160,21 @@ abstract class SystemFineUploadHandler
      */
     public function combineChunks($uploadDirectory, $name = null)
     {
-        $uuid = Request::getString('qquuid', '', 'POST');
-        if ('' === $name) {
+        $uuid = $this->safeUuid(Request::getString('qquuid', '', 'POST'));
+        if (null === $name || '' === $name) {
             $name = $this->getName();
         }
-        $targetFolder = $this->chunksFolder . DIRECTORY_SEPARATOR . $uuid;
-        $totalParts = Request::getInt('qqtotalparts', 1, 'REQUEST');
+        $name = $this->safeLeafName($name);
+        $targetFolder = $this->assertWithin(
+            $this->chunksFolder . DIRECTORY_SEPARATOR . $uuid,
+            $this->chunksFolder
+        );
+        $totalParts = Request::getInt('qqtotalparts', 1, 'POST');
 
-        $targetPath = implode(DIRECTORY_SEPARATOR, [$uploadDirectory, $uuid, $name]);
+        $targetPath = $this->assertWithin(
+            implode(DIRECTORY_SEPARATOR, [$uploadDirectory, $uuid, $name]),
+            $uploadDirectory
+        );
         $this->uploadName = $name;
 
         if (!file_exists($targetPath)) {
@@ -236,18 +308,24 @@ abstract class SystemFineUploadHandler
             $totalParts = (int) Request::getString('qqtotalparts');
         }
 
-        $uuid = Request::getString('qquuid');
+        $uuid = $this->safeUuid(Request::getString('qquuid', '', 'POST'));
         if ($totalParts > 1) {
             # chunked upload
 
             $chunksFolder = $this->chunksFolder;
-            $partIndex = (int) Request::getString('qqpartindex');
+            $partIndex = Request::getInt('qqpartindex', -1, 'POST');
+            if ($partIndex < 0 || $partIndex >= $totalParts) {
+                throw new \RuntimeException('Invalid chunk metadata.');
+            }
 
             if (!is_writable($chunksFolder) && !is_executable($uploadDirectory)) {
                 return ['error' => "Server error. Chunks directory isn't writable or executable."];
             }
 
-            $targetFolder = $this->chunksFolder . DIRECTORY_SEPARATOR . $uuid;
+            $targetFolder = $this->assertWithin(
+                $this->chunksFolder . DIRECTORY_SEPARATOR . $uuid,
+                $this->chunksFolder
+            );
 
             if (!file_exists($targetFolder)) {
                 if (!mkdir($targetFolder, 0775, true) && !is_dir($targetFolder)) {
@@ -264,7 +342,11 @@ abstract class SystemFineUploadHandler
         } else {
             # non-chunked upload
 
-            $target = implode(DIRECTORY_SEPARATOR, [$uploadDirectory, $uuid, $name]);
+            $name = $this->safeLeafName($name);
+            $target = $this->assertWithin(
+                implode(DIRECTORY_SEPARATOR, [$uploadDirectory, $uuid, $name]),
+                $uploadDirectory
+            );
 
             if ($target) {
                 $this->uploadName = basename($target);
@@ -318,17 +400,20 @@ abstract class SystemFineUploadHandler
             if ('' !== $url) {
                 $url    = parse_url($url, PHP_URL_PATH);
                 $tokens = explode('/', $url);
-                $uuid = $tokens[count($tokens) - 1];
+                $uuid = $this->safeUuid($tokens[count($tokens) - 1]);
             }
         } elseif ('POST' === $method) {
-            $uuid = Request::getString('qquuid', '', 'REQUEST');
+            $uuid = $this->safeUuid(Request::getString('qquuid', '', 'POST'));
         } else {
             return ['success' => false,
                 'error'   => 'Invalid request method! ' . $method,
             ];
         }
 
-        $target = implode(DIRECTORY_SEPARATOR, [$uploadDirectory, $uuid]);
+        $target = $this->assertWithin(
+            implode(DIRECTORY_SEPARATOR, [$uploadDirectory, $uuid]),
+            $uploadDirectory
+        );
 
         if (is_dir($target)) {
             $this->removeDir($target);
@@ -428,10 +513,13 @@ abstract class SystemFineUploadHandler
                 continue;
             }
 
-            if (is_dir($item)) {
-                $this->removeDir($item);
+            // Build the full child path so recursion and deletion act on the
+            // intended entry rather than a bare name resolved against the CWD.
+            $child = $dir . DIRECTORY_SEPARATOR . $item;
+            if (is_dir($child)) {
+                $this->removeDir($child);
             } else {
-                unlink(implode(DIRECTORY_SEPARATOR, [$dir, $item]));
+                unlink($child);
             }
         }
         rmdir($dir);

--- a/htdocs/modules/system/class/fineuploadhandler.php
+++ b/htdocs/modules/system/class/fineuploadhandler.php
@@ -310,18 +310,24 @@ abstract class SystemFineUploadHandler
 
         $mimeType = '';
         if (!empty($this->allowedMimeTypes)) {
-
-            $temp = $this->inputName;
-            $mimeType = mime_content_type(Request::getArray($temp, [], 'FILES')['tmp_name']);
-            if (!in_array($mimeType, $this->allowedMimeTypes)) {
+            $fileArr = Request::getArray($this->inputName, [], 'FILES');
+            $tmpName = $fileArr['tmp_name'] ?? '';
+            if ('' === $tmpName || !is_string($tmpName) || !is_readable($tmpName)) {
+                return ['error' => 'File is empty.', 'preventRetry' => true];
+            }
+            $mimeType = mime_content_type($tmpName);
+            if (false === $mimeType || !in_array($mimeType, $this->allowedMimeTypes, true)) {
                 return ['error' => 'File is of an invalid type.', 'preventRetry' => true];
             }
         }
 
         // Save a chunk
         $totalParts = 1;
-        if (Request::hasVar('qqtotalparts')) {
+        if (Request::hasVar('qqtotalparts', 'REQUEST')) {
             $totalParts = Request::getInt('qqtotalparts', 1, 'REQUEST');
+        }
+        if ($totalParts < 1) {
+            throw new \RuntimeException('Invalid chunk metadata.');
         }
 
         // FineUploader sends its qq* identifiers where the REQUEST hash finds them

--- a/htdocs/modules/system/class/fineuploadhandler.php
+++ b/htdocs/modules/system/class/fineuploadhandler.php
@@ -599,10 +599,13 @@ abstract class SystemFineUploadHandler
      */
     protected function isInaccessible($directory)
     {
-        $isWin = $this->isWindows();
-        $folderInaccessible =
-            ($isWin) ? !is_writable($directory) : (!is_writable($directory) && !is_executable($directory));
-        return $folderInaccessible;
+        // A directory must be writable to create files in, and (on non-Windows)
+        // executable to traverse; lacking either makes it unusable. is_executable()
+        // is unreliable for directories on Windows, so it is only checked elsewhere.
+        if (!is_writable($directory)) {
+            return true;
+        }
+        return !$this->isWindows() && !is_executable($directory);
     }
 
     /**

--- a/htdocs/modules/system/class/fineuploadhandler.php
+++ b/htdocs/modules/system/class/fineuploadhandler.php
@@ -87,11 +87,8 @@ abstract class SystemFineUploadHandler
      * @return string the validated leaf name
      * @throws \RuntimeException when the value is empty, hidden, or disallowed
      */
-    protected function safeLeafName($name): string
+    protected function safeLeafName(string $name): string
     {
-        if (!is_string($name)) {
-            throw new \RuntimeException('Invalid file name.');
-        }
         $name = basename(str_replace('\\', '/', $name));
         if ('' === $name || '.' === $name[0]
             || strlen($name) > 255
@@ -268,7 +265,7 @@ abstract class SystemFineUploadHandler
 
         // Get size and name
         $file = Request::getArray($this->inputName, [], 'FILES');
-        $size = $file['size'];
+        $size = $file['size'] ?? 0;
         // Pin the declared total size to POST so a GET/cookie value cannot
         // understate the size and slip past the size-limit check below.
         if (Request::hasVar('qqtotalfilesize', 'POST')) {
@@ -280,7 +277,7 @@ abstract class SystemFineUploadHandler
         }
 
         // check file error
-        if ($file['error']) {
+        if (!empty($file['error'])) {
             return ['error' => 'Upload Error #' . $file['error']];
         }
 
@@ -323,8 +320,8 @@ abstract class SystemFineUploadHandler
 
         // Save a chunk
         $totalParts = 1;
-        if (Request::hasVar('qqtotalparts')) {
-            $totalParts = (int) Request::getString('qqtotalparts');
+        if (Request::hasVar('qqtotalparts', 'POST')) {
+            $totalParts = Request::getInt('qqtotalparts', 1, 'POST');
         }
 
         $uuid = $this->safeUuid(Request::getString('qquuid', '', 'POST'));
@@ -337,7 +334,7 @@ abstract class SystemFineUploadHandler
                 throw new \RuntimeException('Invalid chunk metadata.');
             }
 
-            if (!is_writable($chunksFolder) && !is_executable($uploadDirectory)) {
+            if (!is_writable($chunksFolder) && !is_executable($chunksFolder)) {
                 return ['error' => "Server error. Chunks directory isn't writable or executable."];
             }
 
@@ -412,6 +409,7 @@ abstract class SystemFineUploadHandler
         }
 
         $uuid = false;
+        $url  = '';
         $method = Request::getString('REQUEST_METHOD', 'GET', 'SERVER');
 
         if ('DELETE' === $method) {

--- a/htdocs/modules/system/class/fineuploadhandler.php
+++ b/htdocs/modules/system/class/fineuploadhandler.php
@@ -338,7 +338,7 @@ abstract class SystemFineUploadHandler
                 throw new \RuntimeException('Invalid chunk metadata.');
             }
 
-            if (!is_writable($chunksFolder) && !is_executable($chunksFolder)) {
+            if ($this->isInaccessible($chunksFolder)) {
                 return ['error' => "Server error. Chunks directory isn't writable or executable."];
             }
 
@@ -429,6 +429,12 @@ abstract class SystemFineUploadHandler
             return ['success' => false,
                 'error'   => 'Invalid request method! ' . $method,
             ];
+        }
+
+        // Refuse a missing identifier: without it the target resolves to the
+        // upload root itself and removeDir() would wipe the whole directory.
+        if (false === $uuid || '' === $uuid) {
+            return ['success' => false, 'error' => 'Missing upload identifier.'];
         }
 
         $target = $this->assertWithin(

--- a/htdocs/modules/system/class/fineuploadhandler.php
+++ b/htdocs/modules/system/class/fineuploadhandler.php
@@ -87,9 +87,12 @@ abstract class SystemFineUploadHandler
      * @return string the validated leaf name
      * @throws \RuntimeException when the value is empty, hidden, or disallowed
      */
-    protected function safeLeafName($name)
+    protected function safeLeafName($name): string
     {
-        $name = basename(str_replace('\\', '/', (string) $name));
+        if (!is_string($name)) {
+            throw new \RuntimeException('Invalid file name.');
+        }
+        $name = basename(str_replace('\\', '/', $name));
         if ('' === $name || '.' === $name[0]
             || strlen($name) > 255
             || preg_match('/[\x00-\x1F\x7F]/', $name)) {
@@ -131,17 +134,18 @@ abstract class SystemFineUploadHandler
     /**
      * Get the original filename
      */
-    public function getName()
+    public function getName(): string
     {
         if (Request::hasVar('qqfilename', 'REQUEST')) {
-            $qqfilename = Request::getString('qqfilename', '', 'REQUEST');
-            return $qqfilename;
+            return Request::getString('qqfilename', '', 'REQUEST');
         }
 
         if (Request::hasVar($this->inputName, 'FILES')) {
-            $file = Request::getArray($this->inputName, null, 'FILES');
-            return $file ;
+            $file = Request::getArray($this->inputName, [], 'FILES');
+            return (is_array($file) && isset($file['name']) && is_string($file['name'])) ? $file['name'] : '';
         }
+
+        return '';
     }
 
     /**

--- a/htdocs/modules/system/class/fineuploadhandler.php
+++ b/htdocs/modules/system/class/fineuploadhandler.php
@@ -90,7 +90,9 @@ abstract class SystemFineUploadHandler
     protected function safeLeafName($name)
     {
         $name = basename(str_replace('\\', '/', (string) $name));
-        if ('' === $name || '.' === $name[0]) {
+        if ('' === $name || '.' === $name[0]
+            || strlen($name) > 255
+            || preg_match('/[\x00-\x1F\x7F]/', $name)) {
             throw new \RuntimeException('Invalid file name.');
         }
         if (!empty($this->allowedExtensions)) {

--- a/htdocs/modules/system/class/fineuploadhandler.php
+++ b/htdocs/modules/system/class/fineuploadhandler.php
@@ -163,7 +163,7 @@ abstract class SystemFineUploadHandler
      */
     public function combineChunks($uploadDirectory, $name = null)
     {
-        $uuid = $this->safeUuid(Request::getString('qquuid', '', 'POST'));
+        $uuid = $this->safeUuid(Request::getString('qquuid', '', 'REQUEST'));
         if (null === $name || '' === $name) {
             $name = $this->getName();
         }
@@ -172,7 +172,7 @@ abstract class SystemFineUploadHandler
             $this->chunksFolder . DIRECTORY_SEPARATOR . $uuid,
             $this->chunksFolder
         );
-        $totalParts = Request::getInt('qqtotalparts', 1, 'POST');
+        $totalParts = Request::getInt('qqtotalparts', 1, 'REQUEST');
         if ($totalParts < 1) {
             throw new \RuntimeException('Invalid chunk metadata.');
         }
@@ -320,16 +320,20 @@ abstract class SystemFineUploadHandler
 
         // Save a chunk
         $totalParts = 1;
-        if (Request::hasVar('qqtotalparts', 'POST')) {
-            $totalParts = Request::getInt('qqtotalparts', 1, 'POST');
+        if (Request::hasVar('qqtotalparts')) {
+            $totalParts = Request::getInt('qqtotalparts', 1, 'REQUEST');
         }
 
-        $uuid = $this->safeUuid(Request::getString('qquuid', '', 'POST'));
+        // FineUploader sends its qq* identifiers where the REQUEST hash finds them
+        // (query string or body depending on the client); do NOT pin these to POST
+        // or uploads break. safeUuid() validates the value regardless of source.
+        // Only qqtotalfilesize stays POST-only (above), where the source matters.
+        $uuid = $this->safeUuid(Request::getString('qquuid', '', 'REQUEST'));
         if ($totalParts > 1) {
             # chunked upload
 
             $chunksFolder = $this->chunksFolder;
-            $partIndex = Request::getInt('qqpartindex', -1, 'POST');
+            $partIndex = Request::getInt('qqpartindex', -1, 'REQUEST');
             if ($partIndex < 0 || $partIndex >= $totalParts) {
                 throw new \RuntimeException('Invalid chunk metadata.');
             }
@@ -420,7 +424,7 @@ abstract class SystemFineUploadHandler
                 $uuid = $this->safeUuid($tokens[count($tokens) - 1]);
             }
         } elseif ('POST' === $method) {
-            $uuid = $this->safeUuid(Request::getString('qquuid', '', 'POST'));
+            $uuid = $this->safeUuid(Request::getString('qquuid', '', 'REQUEST'));
         } else {
             return ['success' => false,
                 'error'   => 'Invalid request method! ' . $method,

--- a/htdocs/modules/system/class/fineuploadhandler.php
+++ b/htdocs/modules/system/class/fineuploadhandler.php
@@ -170,6 +170,9 @@ abstract class SystemFineUploadHandler
             $this->chunksFolder
         );
         $totalParts = Request::getInt('qqtotalparts', 1, 'POST');
+        if ($totalParts < 1) {
+            throw new \RuntimeException('Invalid chunk metadata.');
+        }
 
         $targetPath = $this->assertWithin(
             implode(DIRECTORY_SEPARATOR, [$uploadDirectory, $uuid, $name]),
@@ -177,8 +180,16 @@ abstract class SystemFineUploadHandler
         );
         $this->uploadName = $name;
 
+        // Confirm every expected chunk is present before writing the final file,
+        // so a combine request cannot produce an empty or partial target.
+        for ($i = 0; $i < $totalParts; $i++) {
+            if (!is_readable($targetFolder . DIRECTORY_SEPARATOR . $i)) {
+                throw new \RuntimeException('Missing upload chunk.');
+            }
+        }
+
         if (!file_exists($targetPath)) {
-            if (!mkdir($concurrentDirectory = dirname($targetPath), 0777, true) && !is_dir($concurrentDirectory)) {
+            if (!mkdir($concurrentDirectory = dirname($targetPath), 0775, true) && !is_dir($concurrentDirectory)) {
                 throw new \RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
             }
         }
@@ -252,8 +263,10 @@ abstract class SystemFineUploadHandler
         // Get size and name
         $file = Request::getArray($this->inputName, [], 'FILES');
         $size = $file['size'];
-        if (Request::hasVar('qqtotalfilesize')) {
-            $size = Request::getInt('qqtotalfilesize');
+        // Pin the declared total size to POST so a GET/cookie value cannot
+        // understate the size and slip past the size-limit check below.
+        if (Request::hasVar('qqtotalfilesize', 'POST')) {
+            $size = Request::getInt('qqtotalfilesize', 0, 'POST');
         }
 
         if (null === $name) {

--- a/htdocs/modules/system/js/admin.js
+++ b/htdocs/modules/system/js/admin.js
@@ -225,13 +225,17 @@ function blocks_preview() {
  *
  * @author  Kraven30
  */
+function xoAdminToken() {
+    var $t = $("input[name='XOOPS_TOKEN_REQUEST']").first();
+    return $t.length ? $t.val() : '';
+}
 function display_post(uid) {
     $('#display_post_' + uid).hide();
     $("#loading_" + uid).show();
     $.ajax({
         type: "POST",
         url: "./admin/users/jquery.php",
-        data: "op=display_post&uid=" + uid,
+        data: "op=display_post&uid=" + uid + "&XOOPS_TOKEN_REQUEST=" + encodeURIComponent(xoAdminToken()),
         success: function (msg) {
             $('#display_post_' + uid).html(msg);
             $('#loading_' + uid).hide();

--- a/htdocs/modules/system/js/admin.js
+++ b/htdocs/modules/system/js/admin.js
@@ -103,9 +103,14 @@ function _refreshToken(html, $tokenInput) {
 
 function system_setStatus(data, img, file) {
     const $form = $('form[name="moduleadmin"]');
-    const $tokenInput = $form.length
+    let $tokenInput = $form.length
         ? $form.find("input[name='XOOPS_TOKEN_REQUEST']").first()
         : $("input[name='XOOPS_TOKEN_REQUEST']").first();
+    // Fall back to any token on the page (e.g. the control-panel footer token)
+    // when the module-admin form does not carry one.
+    if (!$tokenInput.length) {
+        $tokenInput = $("input[name='XOOPS_TOKEN_REQUEST']").first();
+    }
     if ($tokenInput.length) {
         data[$tokenInput.attr('name')] = $tokenInput.val();
     }

--- a/htdocs/modules/system/js/blocks.js
+++ b/htdocs/modules/system/js/blocks.js
@@ -1,3 +1,9 @@
+// Read the control-panel request token so block AJAX actions can submit it.
+function xoBlocksToken() {
+    var $t = $("input[name='XOOPS_TOKEN_REQUEST']").first();
+    return $t.length ? $t.val() : '';
+}
+
 $(document).ready(
     function(){
         // Controls Drag + Drop
@@ -8,16 +14,16 @@ $(document).ready(
                 connectWith: '.xo-blocksection',
                 update: function(event, ui) {
                     var list = $(this).sortable( 'serialize');
-                    $.post( 'admin.php?fct=blocksadmin&op=order', list );
+                    $.post( 'admin.php?fct=blocksadmin&op=order', list + '&XOOPS_TOKEN_REQUEST=' + encodeURIComponent(xoBlocksToken()) );
                 },
                 receive: function(event, ui) {
                     var side = $(this).attr('side');
                     var bid = $(ui.item).attr('bid');
                     var list = $(this).sortable( 'serialize');
 
-                    $.post( 'admin.php', { fct: 'blocksadmin', op: 'drag', bid: bid, side: side } );
+                    $.post( 'admin.php', { fct: 'blocksadmin', op: 'drag', bid: bid, side: side, XOOPS_TOKEN_REQUEST: xoBlocksToken() } );
 
-                    $.post( 'admin.php?fct=blocksadmin&op=order', list );
+                    $.post( 'admin.php?fct=blocksadmin&op=order', list + '&XOOPS_TOKEN_REQUEST=' + encodeURIComponent(xoBlocksToken()) );
 
                 }
             }
@@ -31,16 +37,16 @@ $(document).ready(
                 connectWith: '.xo-blocksection'/*,
                 update: function(event, ui) {
                     var list = $(this).sortable( 'serialize');
-                    $.post( 'admin.php?fct=blocksadmin&op=order', list );
+                    $.post( 'admin.php?fct=blocksadmin&op=order', list + '&XOOPS_TOKEN_REQUEST=' + encodeURIComponent(xoBlocksToken()) );
                 },
                 receive: function(event, ui) {
                     var side = $(this).attr('side');
                     var bid = $(ui.item).attr('bid');
                     var list = $(this).sortable( 'serialize');
 
-                    $.post( 'admin.php', { fct: 'blocksadmin', op: 'drag', bid: bid, side: side } );
+                    $.post( 'admin.php', { fct: 'blocksadmin', op: 'drag', bid: bid, side: side, XOOPS_TOKEN_REQUEST: xoBlocksToken() } );
 
-                    $.post( 'admin.php?fct=blocksadmin&op=order', list );
+                    $.post( 'admin.php?fct=blocksadmin&op=order', list + '&XOOPS_TOKEN_REQUEST=' + encodeURIComponent(xoBlocksToken()) );
 
                 }*/
             }

--- a/htdocs/modules/system/templates/admin/system_users.tpl
+++ b/htdocs/modules/system/templates/admin/system_users.tpl
@@ -6,7 +6,7 @@
         <div class="floatleft"><{$form_sort}></div>
         <div class="floatright">
             <div class="xo-buttons">
-                <a class="ui-corner-all tooltip" href="admin.php?fct=users&amp;op=users_synchronize&amp;status=2"
+                <a class="ui-corner-all tooltip" href="admin.php?fct=users&amp;op=users_synchronize&amp;status=2&amp;XOOPS_TOKEN_REQUEST=<{$users_csrf}>"
                    title="<{$smarty.const._AM_SYSTEM_USERS_SYNCHRONIZE}>">
                     <img src="<{xoAdminIcons 'reload.png'}>" alt="<{$smarty.const._AM_SYSTEM_USERS_SYNCHRONIZE}>"/>
                     <{$smarty.const._AM_SYSTEM_USERS_SYNCHRONIZE}>
@@ -78,7 +78,7 @@
                                    title="<{$smarty.const._AM_SYSTEM_USERS_DEL}>">
                                     <img src="<{xoAdminIcons 'delete.png'}>" alt="<{$smarty.const._AM_SYSTEM_USERS_DEL}>"/></a>
                             <{else}>
-                                <a class="tooltip" href="admin.php?fct=users&amp;op=users_active&amp;uid=<{$user.uid}>"
+                                <a class="tooltip" href="admin.php?fct=users&amp;op=users_active&amp;uid=<{$user.uid}>&amp;XOOPS_TOKEN_REQUEST=<{$users_csrf}>"
                                    title="<{$smarty.const._AM_SYSTEM_USERS_ACTIVE}>">
                                     <img src="<{xoAdminIcons 'xoops/active_user.png'}>" alt="<{$smarty.const._AM_SYSTEM_USERS_ACTIVE}>"/></a>
                                 <img class="tooltip" onclick="display_dialog('<{$user.uid}>', true, true, 'slide', 'slide', 300, 400);"

--- a/htdocs/modules/system/themes/dark/modules/system/admin/system_users.tpl
+++ b/htdocs/modules/system/themes/dark/modules/system/admin/system_users.tpl
@@ -6,7 +6,7 @@
         <div class="floatleft"><{$form_sort}></div>
         <div class="floatright">
             <div class="xo-buttons">
-                <a class="ui-corner-all tooltip" href="admin.php?fct=users&amp;op=users_synchronize&amp;status=2"
+                <a class="ui-corner-all tooltip" href="admin.php?fct=users&amp;op=users_synchronize&amp;status=2&amp;XOOPS_TOKEN_REQUEST=<{$users_csrf}>"
                    title="<{$smarty.const._AM_SYSTEM_USERS_SYNCHRONIZE}>">
                     <img src="<{xoAdminIcons 'reload.png'}>" alt="<{$smarty.const._AM_SYSTEM_USERS_SYNCHRONIZE}>"/>
                     <{$smarty.const._AM_SYSTEM_USERS_SYNCHRONIZE}>
@@ -68,7 +68,7 @@
                                    title="<{$smarty.const._AM_SYSTEM_USERS_DEL}>">
                                     <img src="<{xoAdminIcons 'delete.png'}>" alt="<{$smarty.const._AM_SYSTEM_USERS_DEL}>"/></a>
                             <{else}>
-                                <a class="tooltip" href="admin.php?fct=users&amp;op=users_active&amp;uid=<{$user.uid}>"
+                                <a class="tooltip" href="admin.php?fct=users&amp;op=users_active&amp;uid=<{$user.uid}>&amp;XOOPS_TOKEN_REQUEST=<{$users_csrf}>"
                                    title="<{$smarty.const._AM_SYSTEM_USERS_ACTIVE}>">
                                     <img src="<{xoAdminIcons 'xoops/active_user.png'}>" alt="<{$smarty.const._AM_SYSTEM_USERS_ACTIVE}>"/></a>
                                 <img class="tooltip" onclick="display_dialog('<{$user.uid}>', true, true, 'slide', 'slide', 300, 400);"

--- a/htdocs/user.php
+++ b/htdocs/user.php
@@ -123,6 +123,9 @@ if ($op === 'delete') {
             xoops_confirm(['op' => 'delete', 'ok' => 1], 'user.php', _US_SURETODEL . '<br>' . _US_REMOVEINFO);
             include $GLOBALS['xoops']->path('footer.php');
         } else {
+            if (!$GLOBALS['xoopsSecurity']->check()) {
+                redirect_header('user.php', 3, implode('<br>', $GLOBALS['xoopsSecurity']->getErrors()));
+            }
             $del_uid        = $GLOBALS['xoopsUser']->getVar('uid');
             /** @var XoopsMemberHandler $member_handler */
             $member_handler = xoops_getHandler('member');

--- a/tests/unit/htdocs/BrowsePathContainmentTest.php
+++ b/tests/unit/htdocs/BrowsePathContainmentTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * browse.php must confine the resolved file to its root with a path-boundary
+ * match, not a substring match (finding A2-M-1). A substring match let a sibling
+ * directory whose name starts with the root's name (e.g. ".../htdocs-evil") pass.
+ */
+final class BrowsePathContainmentTest extends TestCase
+{
+    #[Test]
+    public function browseUsesBoundaryContainmentNotSubstring(): void
+    {
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/browse.php');
+        self::assertNotFalse($src);
+        self::assertSame(
+            0,
+            preg_match('/false\s*===\s*strpos\(\s*\$file\s*,/', $src),
+            'browse.php must not use a substring strpos() for path containment (A2-M-1).'
+        );
+        self::assertStringContainsString('str_starts_with($file', $src);
+    }
+
+    #[Test]
+    public function boundaryMatchRejectsSiblingPrefixDirectory(): void
+    {
+        // The exact semantics browse.php now relies on.
+        $prefix = '/srv/data/';
+        self::assertFalse(str_starts_with('/srv/data-evil/x/', $prefix), 'sibling-prefix dir must not be contained');
+        self::assertTrue(str_starts_with('/srv/data/sub/x/', $prefix), 'genuine child must be contained');
+        self::assertTrue(str_starts_with('/srv/data/', $prefix), 'the root itself must be contained');
+    }
+}

--- a/tests/unit/htdocs/class/MyTextSanitizerTest.php
+++ b/tests/unit/htdocs/class/MyTextSanitizerTest.php
@@ -228,6 +228,47 @@ class MyTextSanitizerTest extends TestCase
         }
     }
 
+    // ---------------------------------------------------------------------
+    // Output-encoding regression guards (finding C-1).
+    //
+    // displayTarea() encodes untrusted textarea content for safe display and
+    // then calls makeClickable() to linkify it. makeClickable() must keep that
+    // encoding intact for the surrounding text and only round-trip the URL/email
+    // tokens it linkifies, so encoded markup never becomes live markup again.
+    // ---------------------------------------------------------------------
+
+    public function testDisplayTareaWithHtmlDisabledKeepsMarkupEncoded()
+    {
+        $out = $this->sanitizer->displayTarea('<script>alert(1)</script> visit https://xoops.org', 0);
+
+        // displayTarea()'s legacy code path installs an error/exception handler it
+        // does not restore; drop them so this test does not leak handler state.
+        restore_error_handler();
+        restore_exception_handler();
+
+        $this->assertStringNotContainsString('<script>', $out);
+        $this->assertStringContainsString('&lt;script&gt;', $out);
+        $this->assertStringContainsString('href="https://xoops.org', $out);
+    }
+
+    public function testMakeClickableLeavesEncodedMarkupEncoded()
+    {
+        $out = $this->sanitizer->makeClickable('&lt;img src=x onerror=alert(1)&gt;');
+
+        $this->assertStringNotContainsString('<img', $out);
+        $this->assertStringContainsString('&lt;img', $out);
+    }
+
+    public function testMakeClickableDoesNotDoubleEncodeAmpersandInUrl()
+    {
+        // A URL arriving already-encoded (as it would after displayTarea) must
+        // render with a single &amp;, not &amp;amp;.
+        $out = $this->sanitizer->makeClickable('see https://example.com/?a=1&amp;b=2 here');
+
+        $this->assertStringContainsString('https://example.com/?a=1&amp;b=2', $out);
+        $this->assertStringNotContainsString('&amp;amp;', $out);
+    }
+
 
 //    public function testNestedTagsAndIncompleteTags()
 //    {

--- a/tests/unit/htdocs/class/MyTextSanitizerTest.php
+++ b/tests/unit/htdocs/class/MyTextSanitizerTest.php
@@ -241,8 +241,10 @@ class MyTextSanitizerTest extends TestCase
     {
         $out = $this->sanitizer->displayTarea('<script>alert(1)</script> visit https://xoops.org', 0);
 
-        // displayTarea()'s legacy code path installs an error/exception handler it
-        // does not restore; drop them so this test does not leak handler state.
+        // displayTarea()'s legacy path installs an error and an exception handler
+        // and never restores them. Confirmed by PHPUnit: removing these two calls
+        // makes this test "risky — did not remove its own error/exception
+        // handlers". Pop them so handler state does not leak into later tests.
         restore_error_handler();
         restore_exception_handler();
 

--- a/tests/unit/htdocs/class/auth/AuthLdapEscapeTest.php
+++ b/tests/unit/htdocs/class/auth/AuthLdapEscapeTest.php
@@ -32,10 +32,13 @@ final class AuthLdapEscapeTest extends KernelTestCase
         if (!function_exists('ldap_escape')) {
             self::markTestSkipped('ext-ldap not available');
         }
-        $filter = $this->ldap()->getFilter('a*)(uid=*');
+        $filter = strtolower($this->ldap()->getFilter('a*)(uid=*'));
         self::assertStringNotContainsString('*', $filter);
         self::assertStringNotContainsString(')(', $filter);
-        self::assertStringContainsString('\2a', strtolower($filter));
+        // every metacharacter is escaped to its \HEX form
+        self::assertStringContainsString('\2a', $filter); // *
+        self::assertStringContainsString('\28', $filter); // (
+        self::assertStringContainsString('\29', $filter); // )
     }
 
     #[Test]

--- a/tests/unit/htdocs/class/auth/AuthLdapEscapeTest.php
+++ b/tests/unit/htdocs/class/auth/AuthLdapEscapeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace xoopsauth;
+
+use kernel\KernelTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+require_once XOOPS_ROOT_PATH . '/class/auth/auth.php';
+require_once XOOPS_ROOT_PATH . '/class/auth/auth_ldap.php';
+
+/**
+ * LDAP login input must be escaped before it is placed in a search filter or a
+ * bind DN (finding H-6), so metacharacters cannot alter the directory query.
+ */
+final class AuthLdapEscapeTest extends KernelTestCase
+{
+    private function ldap(): \XoopsAuthLdap
+    {
+        $o = (new \ReflectionClass(\XoopsAuthLdap::class))->newInstanceWithoutConstructor();
+        $this->setProtectedProperty($o, 'ldap_filter_person', '');
+        $this->setProtectedProperty($o, 'ldap_loginldap_attr', 'uid');
+        $this->setProtectedProperty($o, 'ldap_base_dn', 'dc=x,dc=y');
+        $this->setProtectedProperty($o, 'ldap_loginname_asdn', true);
+        return $o;
+    }
+
+    #[Test]
+    public function filterEscapesMetacharacters(): void
+    {
+        if (!function_exists('ldap_escape')) {
+            self::markTestSkipped('ext-ldap not available');
+        }
+        $filter = $this->ldap()->getFilter('a*)(uid=*');
+        self::assertStringNotContainsString('*', $filter);
+        self::assertStringNotContainsString(')(', $filter);
+        self::assertStringContainsString('\2a', strtolower($filter));
+    }
+
+    #[Test]
+    public function userDnEscapesMetacharacters(): void
+    {
+        if (!function_exists('ldap_escape')) {
+            self::markTestSkipped('ext-ldap not available');
+        }
+        $dn = $this->ldap()->getUserDN('a,b+c');
+        self::assertStringNotContainsString('a,b+c', $dn);
+    }
+
+    #[Test]
+    public function sourceUsesContextSpecificLdapEscape(): void
+    {
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/class/auth/auth_ldap.php');
+        self::assertNotFalse($src);
+        self::assertStringContainsString('LDAP_ESCAPE_FILTER', $src);
+        self::assertStringContainsString('LDAP_ESCAPE_DN', $src);
+    }
+}

--- a/tests/unit/htdocs/class/auth/AuthLdapEscapeTest.php
+++ b/tests/unit/htdocs/class/auth/AuthLdapEscapeTest.php
@@ -47,8 +47,11 @@ final class AuthLdapEscapeTest extends KernelTestCase
         if (!function_exists('ldap_escape')) {
             self::markTestSkipped('ext-ldap not available');
         }
-        $dn = $this->ldap()->getUserDN('a,b+c');
+        $dn = strtolower($this->ldap()->getUserDN('a,b+c'));
         self::assertStringNotContainsString('a,b+c', $dn);
+        // metacharacters escaped to their \HEX forms
+        self::assertStringContainsString('\2c', $dn); // ,
+        self::assertStringContainsString('\2b', $dn); // +
     }
 
     #[Test]

--- a/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
+++ b/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
@@ -47,6 +47,9 @@ final class CsrfTokenGuardTest extends TestCase
             'mailusers send'      => [$base . '/modules/system/admin/mailusers/main.php', 'send',         '->send('],
             'comment delete_one'  => [$base . '/include/comment_delete.php',              'delete_one',   '->delete('],
             'comment delete_all'  => [$base . '/include/comment_delete.php',              'delete_all',   '->delete('],
+            'users_active'        => [$base . '/modules/system/admin/users/main.php',     'users_active', 'insertUser'],
+            'users_synchronize'   => [$base . '/modules/system/admin/users/main.php',     'users_synchronize', 'synchronize('],
+            'profile step toggle' => [$base . '/modules/profile/admin/step.php',          'toggle',       'profile_stepsave_toggle'],
         ];
     }
 
@@ -136,6 +139,20 @@ final class CsrfTokenGuardTest extends TestCase
         self::assertNotFalse($headerPos, 'images: xoops_cp_header() not found');
         self::assertLessThan($headerPos, $guardPos, 'images: token guard must precede page output');
         self::assertMatchesRegularExpression('/->\s*check\(\s*false\s*\)/', substr($src, $guardPos, 200));
+    }
+
+    #[Test]
+    public function getLinkTogglesEmbedTokenInTemplates(): void
+    {
+        $checks = [
+            '/modules/system/templates/admin/system_users.tpl'         => 'XOOPS_TOKEN_REQUEST=<{$users_csrf}>',
+            '/modules/profile/templates/profile_admin_steplist.tpl'    => 'XOOPS_TOKEN_REQUEST=<{$steps_csrf}>',
+        ];
+        foreach ($checks as $rel => $needle) {
+            $src = file_get_contents(XOOPS_ROOT_PATH . $rel);
+            self::assertNotFalse($src, $rel);
+            self::assertStringContainsString($needle, $src, "{$rel}: GET toggle link must carry the request token");
+        }
     }
 
     #[Test]

--- a/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
+++ b/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
@@ -103,4 +103,25 @@ final class CsrfTokenGuardTest extends TestCase
         self::assertNotFalse($src);
         self::assertStringContainsString('getTokenHTML()', $src);
     }
+
+    #[Test]
+    public function blocksAdminAjaxOpsValidateTokenBeforeOutput(): void
+    {
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/modules/system/admin/blocksadmin/main.php');
+        self::assertNotFalse($src);
+        $guardPos  = strpos($src, "in_array(\$op, ['display', 'drag', 'order']");
+        $headerPos = strpos($src, 'xoops_cp_header(');
+        self::assertNotFalse($guardPos, 'blocksadmin: missing AJAX op guard');
+        self::assertNotFalse($headerPos, 'blocksadmin: xoops_cp_header() not found');
+        self::assertLessThan($headerPos, $guardPos, 'blocksadmin: token guard must precede page output');
+        self::assertMatchesRegularExpression('/->\s*check\(\s*false\s*\)/', substr($src, $guardPos, 200));
+    }
+
+    #[Test]
+    public function blocksJsSubmitsRequestToken(): void
+    {
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/modules/system/js/blocks.js');
+        self::assertNotFalse($src);
+        self::assertStringContainsString('XOOPS_TOKEN_REQUEST', $src);
+    }
 }

--- a/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
+++ b/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
@@ -63,6 +63,21 @@ final class CsrfTokenGuardTest extends TestCase
     }
 
     #[Test]
+    public function commentDeleteRedirectsUseCanonicalItemParam(): void
+    {
+        // $redirect_page already ends with the item parameter name, so redirects
+        // must append "=<id>" (as the success path does), not "?itemName=<id>"
+        // which produces a malformed double-? URL on a failed check.
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/include/comment_delete.php');
+        self::assertNotFalse($src);
+        self::assertStringNotContainsString(
+            "redirect_page . '?' . \$comment_config['itemName']",
+            $src,
+            'comment_delete redirects must not build a malformed double-? URL'
+        );
+    }
+
+    #[Test]
     public function userSelfDeleteChecksTokenBeforeDeleteUser(): void
     {
         $src = file_get_contents(XOOPS_ROOT_PATH . '/user.php');

--- a/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
+++ b/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
@@ -23,7 +23,7 @@ final class CsrfTokenGuardTest extends TestCase
             self::fail("case '{$caseLabel}' not found");
         }
         $start = (int) $m[0][1];
-        if (preg_match("/\\n\\s*case\\s+'/", $source, $n, PREG_OFFSET_CAPTURE, $start + 1)) {
+        if (preg_match("/\\n\\s*(case\\s+'|default\\s*:)/", $source, $n, PREG_OFFSET_CAPTURE, $start + 1)) {
             return substr($source, $start, ((int) $n[0][1]) - $start);
         }
         return substr($source, $start);

--- a/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
+++ b/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
@@ -124,4 +124,29 @@ final class CsrfTokenGuardTest extends TestCase
         self::assertNotFalse($src);
         self::assertStringContainsString('XOOPS_TOKEN_REQUEST', $src);
     }
+
+    #[Test]
+    public function imagesDisplayTogglesValidateTokenBeforeOutput(): void
+    {
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/modules/system/admin/images/main.php');
+        self::assertNotFalse($src);
+        $guardPos  = strpos($src, "in_array(\$op, ['display_cat', 'display_img']");
+        $headerPos = strpos($src, 'xoops_cp_header(');
+        self::assertNotFalse($guardPos, 'images: missing toggle guard');
+        self::assertNotFalse($headerPos, 'images: xoops_cp_header() not found');
+        self::assertLessThan($headerPos, $guardPos, 'images: token guard must precede page output');
+        self::assertMatchesRegularExpression('/->\s*check\(\s*false\s*\)/', substr($src, $guardPos, 200));
+    }
+
+    #[Test]
+    public function usersJqueryPostCountValidatesTokenBeforeUpdate(): void
+    {
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/modules/system/admin/users/jquery.php');
+        self::assertNotFalse($src);
+        $guardPos = strpos($src, "xoopsSecurity']->check(");
+        $mutPos   = strpos($src, '->exec(');
+        self::assertNotFalse($guardPos, 'users/jquery: missing token check');
+        self::assertNotFalse($mutPos, 'users/jquery: exec() not found');
+        self::assertLessThan($mutPos, $guardPos, 'post-count update must validate the token first');
+    }
 }

--- a/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
+++ b/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace hardening;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Each state-changing admin action must validate a XOOPS token before it mutates
+ * (findings H-2, H-3, H-4, M-1). These procedural handlers cannot be executed in
+ * isolation, so the guard is asserted at the source level: the token check must
+ * be present AND appear before the first mutating call in that branch.
+ */
+final class CsrfTokenGuardTest extends TestCase
+{
+    private function extractCaseBlock(string $source, string $caseLabel): string
+    {
+        $pattern = "/case\\s+'" . preg_quote($caseLabel, '/') . "'\\s*:/";
+        if (!preg_match($pattern, $source, $m, PREG_OFFSET_CAPTURE)) {
+            self::fail("case '{$caseLabel}' not found");
+        }
+        $start = (int) $m[0][1];
+        if (preg_match("/\\n\\s*case\\s+'/", $source, $n, PREG_OFFSET_CAPTURE, $start + 1)) {
+            return substr($source, $start, ((int) $n[0][1]) - $start);
+        }
+        return substr($source, $start);
+    }
+
+    private function assertGuardBeforeMutation(string $block, string $mutation, string $label): void
+    {
+        $guardPos = strpos($block, "xoopsSecurity']->check(");
+        $mutPos   = strpos($block, $mutation);
+        self::assertNotFalse($guardPos, "{$label}: missing token check");
+        self::assertNotFalse($mutPos, "{$label}: mutation needle '{$mutation}' not found");
+        self::assertLessThan($mutPos, $guardPos, "{$label}: token check must precede the mutation");
+    }
+
+    /** @return array<string, array{string, string, string}> */
+    public static function guardedCases(): array
+    {
+        $base = XOOPS_ROOT_PATH;
+        return [
+            'groups action_group' => [$base . '/modules/system/admin/groups/main.php',   'action_group', 'addUserToGroup'],
+            'mailusers send'      => [$base . '/modules/system/admin/mailusers/main.php', 'send',         '->send('],
+            'comment delete_one'  => [$base . '/include/comment_delete.php',              'delete_one',   '->delete('],
+            'comment delete_all'  => [$base . '/include/comment_delete.php',              'delete_all',   '->delete('],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('guardedCases')]
+    public function tokenCheckPrecedesMutation(string $file, string $case, string $mutation): void
+    {
+        $src = file_get_contents($file);
+        self::assertNotFalse($src, $file);
+        $this->assertGuardBeforeMutation($this->extractCaseBlock($src, $case), $mutation, $case);
+    }
+
+    #[Test]
+    public function userSelfDeleteChecksTokenBeforeDeleteUser(): void
+    {
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/user.php');
+        self::assertNotFalse($src);
+        $guardPos = strpos($src, "xoopsSecurity']->check(");
+        $mutPos   = strpos($src, 'deleteUser(');
+        self::assertNotFalse($guardPos, 'user.php: missing token check');
+        self::assertNotFalse($mutPos, 'user.php: deleteUser() not found');
+        self::assertLessThan($mutPos, $guardPos, 'self-delete must validate the token before deleteUser()');
+    }
+}

--- a/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
+++ b/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
@@ -129,6 +129,18 @@ final class CsrfTokenGuardTest extends TestCase
     }
 
     #[Test]
+    public function adminJsDisplayPostSubmitsRequestToken(): void
+    {
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/modules/system/js/admin.js');
+        self::assertNotFalse($src);
+        self::assertMatchesRegularExpression(
+            '/op=display_post.*XOOPS_TOKEN_REQUEST/s',
+            $src,
+            'admin.js display_post must submit the request token'
+        );
+    }
+
+    #[Test]
     public function imagesDisplayTogglesValidateTokenBeforeOutput(): void
     {
         $src = file_get_contents(XOOPS_ROOT_PATH . '/modules/system/admin/images/main.php');
@@ -145,8 +157,9 @@ final class CsrfTokenGuardTest extends TestCase
     public function getLinkTogglesEmbedTokenInTemplates(): void
     {
         $checks = [
-            '/modules/system/templates/admin/system_users.tpl'         => 'XOOPS_TOKEN_REQUEST=<{$users_csrf}>',
-            '/modules/profile/templates/profile_admin_steplist.tpl'    => 'XOOPS_TOKEN_REQUEST=<{$steps_csrf}>',
+            '/modules/system/templates/admin/system_users.tpl'                       => 'XOOPS_TOKEN_REQUEST=<{$users_csrf}>',
+            '/modules/system/themes/dark/modules/system/admin/system_users.tpl'      => 'XOOPS_TOKEN_REQUEST=<{$users_csrf}>',
+            '/modules/profile/templates/profile_admin_steplist.tpl'                  => 'XOOPS_TOKEN_REQUEST=<{$steps_csrf}>',
         ];
         foreach ($checks as $rel => $needle) {
             $src = file_get_contents(XOOPS_ROOT_PATH . $rel);

--- a/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
+++ b/tests/unit/htdocs/hardening/CsrfTokenGuardTest.php
@@ -70,4 +70,37 @@ final class CsrfTokenGuardTest extends TestCase
         self::assertNotFalse($mutPos, 'user.php: deleteUser() not found');
         self::assertLessThan($mutPos, $guardPos, 'self-delete must validate the token before deleteUser()');
     }
+
+    /** @return array<string, array{string, string}> */
+    public static function ajaxToggleHandlers(): array
+    {
+        return [
+            'avatars display'   => ['/modules/system/admin/avatars/main.php',  "'display' === \$op"],
+            'smilies display'   => ['/modules/system/admin/smilies/main.php',  "'smilies_update_display' === \$op"],
+            'userrank special'  => ['/modules/system/admin/userrank/main.php', "'userrank_update_special' === \$op"],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('ajaxToggleHandlers')]
+    public function ajaxToggleValidatesTokenBeforeOutput(string $relPath, string $opGuard): void
+    {
+        $src = file_get_contents(XOOPS_ROOT_PATH . $relPath);
+        self::assertNotFalse($src, $relPath);
+        $guardPos  = strpos($src, $opGuard);
+        $headerPos = strpos($src, 'xoops_cp_header(');
+        self::assertNotFalse($guardPos, "{$relPath}: missing op guard");
+        self::assertNotFalse($headerPos, "{$relPath}: xoops_cp_header() not found");
+        self::assertLessThan($headerPos, $guardPos, "{$relPath}: token guard must precede page output");
+        $region = substr($src, $guardPos, 200);
+        self::assertMatchesRegularExpression('/->\s*check\(\s*false\s*\)/', $region, "{$relPath}: toggle must validate the token");
+    }
+
+    #[Test]
+    public function controlPanelFooterEmitsRequestToken(): void
+    {
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/include/cp_functions.php');
+        self::assertNotFalse($src);
+        self::assertStringContainsString('getTokenHTML()', $src);
+    }
 }

--- a/tests/unit/htdocs/include/RedirectValidationTest.php
+++ b/tests/unit/htdocs/include/RedirectValidationTest.php
@@ -30,6 +30,8 @@ final class RedirectValidationTest extends TestCase
             'raw crlf'      => ["https://localhost/\r\nX: y"],
             'encoded host'  => ['https://evil.test/%0d%0aSet-Cookie:x=y'],
             'javascript'    => ['javascript:alert(1)'],
+            'data scheme'   => ['data:text/html,<script>alert(1)</script>'],
+            'mailto'        => ['mailto:a@b.test'],
         ];
     }
 
@@ -46,6 +48,7 @@ final class RedirectValidationTest extends TestCase
         return [
             'same host'        => ['http://localhost/modules/news/index.php'],
             'same host w/port' => ['http://localhost'],
+            'default http port'=> ['http://localhost:80/admin.php'],
             'root relative'    => ['/admin.php?fct=preferences'],
         ];
     }

--- a/tests/unit/htdocs/include/RedirectValidationTest.php
+++ b/tests/unit/htdocs/include/RedirectValidationTest.php
@@ -32,6 +32,8 @@ final class RedirectValidationTest extends TestCase
             'javascript'    => ['javascript:alert(1)'],
             'data scheme'   => ['data:text/html,<script>alert(1)</script>'],
             'mailto'        => ['mailto:a@b.test'],
+            'scheme no host'  => ['http:/evil.test/'],
+            'scheme no host2' => ['https:/evil.test/path'],
         ];
     }
 

--- a/tests/unit/htdocs/include/RedirectValidationTest.php
+++ b/tests/unit/htdocs/include/RedirectValidationTest.php
@@ -46,10 +46,11 @@ final class RedirectValidationTest extends TestCase
     public static function safeUrls(): array
     {
         return [
-            'same host'        => ['http://localhost/modules/news/index.php'],
-            'same host w/port' => ['http://localhost'],
-            'default http port'=> ['http://localhost:80/admin.php'],
-            'root relative'    => ['/admin.php?fct=preferences'],
+            'same host'         => ['http://localhost/modules/news/index.php'],
+            'same host w/port'  => ['http://localhost'],
+            'default http port' => ['http://localhost:80/admin.php'],
+            'scheme-rel host'   => ['//localhost/admin.php'],
+            'root relative'     => ['/admin.php?fct=preferences'],
         ];
     }
 

--- a/tests/unit/htdocs/include/RedirectValidationTest.php
+++ b/tests/unit/htdocs/include/RedirectValidationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once XOOPS_ROOT_PATH . '/include/file_safety.php';
+
+/**
+ * Same-origin redirect validation (findings H-1 / M-13).
+ *
+ * redirect_header() is stubbed in the test bootstrap, so the host check it now
+ * relies on is exercised through its pure helper xoops_isLocalUrl(). XOOPS_URL is
+ * 'http://localhost' in the bootstrap.
+ */
+final class RedirectValidationTest extends TestCase
+{
+    /** @return array<string, array{string}> */
+    public static function unsafeUrls(): array
+    {
+        return [
+            'prefix host'   => ['http://localhost.evil.test/'],
+            'userinfo'      => ['http://localhost@evil.test/'],
+            'userinfo + pw' => ['http://user:pass@evil.test/'],
+            'other host'    => ['https://evil.test/'],
+            'scheme rel'    => ['//evil.test/'],
+            'port mismatch' => ['http://localhost:8443/'],
+            'raw crlf'      => ["https://localhost/\r\nX: y"],
+            'encoded host'  => ['https://evil.test/%0d%0aSet-Cookie:x=y'],
+            'javascript'    => ['javascript:alert(1)'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('unsafeUrls')]
+    public function rejectsNonLocalTargets(string $url): void
+    {
+        self::assertFalse(xoops_isLocalUrl($url), $url);
+    }
+
+    /** @return array<string, array{string}> */
+    public static function safeUrls(): array
+    {
+        return [
+            'same host'        => ['http://localhost/modules/news/index.php'],
+            'same host w/port' => ['http://localhost'],
+            'root relative'    => ['/admin.php?fct=preferences'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('safeUrls')]
+    public function acceptsSameOriginAndRootRelative(string $url): void
+    {
+        self::assertTrue(xoops_isLocalUrl($url), $url);
+    }
+
+    #[Test]
+    public function commentDeleteDoesNotRedirectToRawReferer(): void
+    {
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/include/comment_delete.php');
+        self::assertNotFalse($src);
+        self::assertSame(
+            0,
+            preg_match('/redirect_header\(\s*\$ref\b/', $src),
+            'comment_delete.php must not redirect to the raw HTTP_REFERER (M-13).'
+        );
+    }
+}

--- a/tests/unit/htdocs/modules/system/FineUploaderPathTest.php
+++ b/tests/unit/htdocs/modules/system/FineUploaderPathTest.php
@@ -102,11 +102,11 @@ final class FineUploaderPathTest extends TestCase
         // A zero (or negative) part count must be refused before any file is
         // opened, so a combine request cannot create an empty allowed-extension
         // file. The guard runs before any filesystem access.
-        // The handler reads these from the REQUEST hash, so seed $_REQUEST (not
-        // just $_POST) and assert the specific message, or the test would pass on
-        // the empty-UUID check instead of the chunk-count guard under test.
-        $_REQUEST['qquuid']       = 'abc123';
-        $_REQUEST['qqtotalparts'] = '0';
+        // Seed via the same Request facade the handler reads through (REQUEST
+        // hash) and assert the specific message, or the test would pass on the
+        // empty-UUID check instead of the chunk-count guard under test.
+        \Xmf\Request::setVar('qquuid', 'abc123', 'REQUEST');
+        \Xmf\Request::setVar('qqtotalparts', '0', 'REQUEST');
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Invalid chunk metadata.');
@@ -151,8 +151,8 @@ final class FineUploaderPathTest extends TestCase
         // upload root and wipe it; the guard returns an error, dir stays intact.
         $root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'fu_del_' . getmypid();
         @mkdir($root, 0775, true);
-        $_SERVER['REQUEST_METHOD'] = 'DELETE';
-        $_SERVER['REQUEST_URI']    = '';
+        \Xmf\Request::setVar('REQUEST_METHOD', 'DELETE', 'SERVER');
+        \Xmf\Request::setVar('REQUEST_URI', '', 'SERVER');
         try {
             $result = $this->handler()->handleDelete($root);
             self::assertIsArray($result);

--- a/tests/unit/htdocs/modules/system/FineUploaderPathTest.php
+++ b/tests/unit/htdocs/modules/system/FineUploaderPathTest.php
@@ -102,14 +102,18 @@ final class FineUploaderPathTest extends TestCase
         // A zero (or negative) part count must be refused before any file is
         // opened, so a combine request cannot create an empty allowed-extension
         // file. The guard runs before any filesystem access.
-        $_POST['qquuid']       = 'abc123';
-        $_POST['qqtotalparts'] = '0';
+        // The handler reads these from the REQUEST hash, so seed $_REQUEST (not
+        // just $_POST) and assert the specific message, or the test would pass on
+        // the empty-UUID check instead of the chunk-count guard under test.
+        $_REQUEST['qquuid']       = 'abc123';
+        $_REQUEST['qqtotalparts'] = '0';
 
         $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Invalid chunk metadata.');
         try {
             $this->handler()->combineChunks(sys_get_temp_dir(), 'photo.jpg');
         } finally {
-            unset($_POST['qquuid'], $_POST['qqtotalparts']);
+            unset($_REQUEST['qquuid'], $_REQUEST['qqtotalparts']);
         }
     }
 

--- a/tests/unit/htdocs/modules/system/FineUploaderPathTest.php
+++ b/tests/unit/htdocs/modules/system/FineUploaderPathTest.php
@@ -21,9 +21,11 @@ final class FineUploaderPathTest extends TestCase
 {
     private function handler(): \SystemFineUploadHandler
     {
-        return new class (new \stdClass()) extends \SystemFineUploadHandler {
-            public $allowedExtensions = ['jpg', 'png', 'gif'];
-        };
+        // allowedExtensions is a public property on the parent; set it on the
+        // instance rather than redeclaring it in the subclass.
+        $handler = new class (new \stdClass()) extends \SystemFineUploadHandler {};
+        $handler->allowedExtensions = ['jpg', 'png', 'gif'];
+        return $handler;
     }
 
     /**

--- a/tests/unit/htdocs/modules/system/FineUploaderPathTest.php
+++ b/tests/unit/htdocs/modules/system/FineUploaderPathTest.php
@@ -97,6 +97,37 @@ final class FineUploaderPathTest extends TestCase
     }
 
     #[Test]
+    public function combineChunksRejectsZeroTotalParts(): void
+    {
+        // A zero (or negative) part count must be refused before any file is
+        // opened, so a combine request cannot create an empty allowed-extension
+        // file. The guard runs before any filesystem access.
+        $_POST['qquuid']       = 'abc123';
+        $_POST['qqtotalparts'] = '0';
+
+        $this->expectException(\RuntimeException::class);
+        try {
+            $this->handler()->combineChunks(sys_get_temp_dir(), 'photo.jpg');
+        } finally {
+            unset($_POST['qquuid'], $_POST['qqtotalparts']);
+        }
+    }
+
+    #[Test]
+    public function declaredTotalSizeIsPinnedToPost(): void
+    {
+        // The declared total size must be read from POST only, so a GET/cookie
+        // value cannot understate it and bypass the size limit.
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/modules/system/class/fineuploadhandler.php');
+        self::assertNotFalse($src);
+        self::assertSame(
+            1,
+            preg_match("/Request::getInt\(\s*'qqtotalfilesize'\s*,\s*0\s*,\s*'POST'\s*\)/", $src),
+            'qqtotalfilesize must be read from POST.'
+        );
+    }
+
+    #[Test]
     public function subclassesInheritConfinedMethods(): void
     {
         require_once XOOPS_ROOT_PATH . '/modules/system/class/fineimuploadhandler.php';

--- a/tests/unit/htdocs/modules/system/FineUploaderPathTest.php
+++ b/tests/unit/htdocs/modules/system/FineUploaderPathTest.php
@@ -141,6 +141,26 @@ final class FineUploaderPathTest extends TestCase
     }
 
     #[Test]
+    public function handleDeleteRefusesMissingUuid(): void
+    {
+        // A DELETE with an empty URI must not let the target resolve to the
+        // upload root and wipe it; the guard returns an error, dir stays intact.
+        $root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'fu_del_' . getmypid();
+        @mkdir($root, 0775, true);
+        $_SERVER['REQUEST_METHOD'] = 'DELETE';
+        $_SERVER['REQUEST_URI']    = '';
+        try {
+            $result = $this->handler()->handleDelete($root);
+            self::assertIsArray($result);
+            self::assertArrayHasKey('error', $result);
+            self::assertDirectoryExists($root, 'upload root must not be deleted');
+        } finally {
+            @rmdir($root);
+            unset($_SERVER['REQUEST_METHOD'], $_SERVER['REQUEST_URI']);
+        }
+    }
+
+    #[Test]
     public function subclassesInheritConfinedMethods(): void
     {
         require_once XOOPS_ROOT_PATH . '/modules/system/class/fineimuploadhandler.php';

--- a/tests/unit/htdocs/modules/system/FineUploaderPathTest.php
+++ b/tests/unit/htdocs/modules/system/FineUploaderPathTest.php
@@ -128,6 +128,19 @@ final class FineUploaderPathTest extends TestCase
     }
 
     #[Test]
+    public function uploadIdentifiersAreNotPostPinned(): void
+    {
+        // FineUploader emits qq* identifiers in the query string; pinning them to
+        // POST returns empty and breaks every upload. Guard against re-pinning.
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/modules/system/class/fineuploadhandler.php');
+        self::assertNotFalse($src);
+        self::assertSame(0, preg_match("/getString\\(\\s*'qquuid'\\s*,\\s*''\\s*,\\s*'POST'\\s*\\)/", $src),
+            'qquuid must be read from REQUEST, not POST-only.');
+        self::assertSame(0, preg_match("/getInt\\(\\s*'qqtotalparts'\\s*,\\s*1\\s*,\\s*'POST'\\s*\\)/", $src),
+            'qqtotalparts must be read from REQUEST, not POST-only.');
+    }
+
+    #[Test]
     public function subclassesInheritConfinedMethods(): void
     {
         require_once XOOPS_ROOT_PATH . '/modules/system/class/fineimuploadhandler.php';

--- a/tests/unit/htdocs/modules/system/FineUploaderPathTest.php
+++ b/tests/unit/htdocs/modules/system/FineUploaderPathTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace modulessystem;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once XOOPS_ROOT_PATH . '/modules/system/class/fineuploadhandler.php';
+
+/**
+ * Path-confinement guards for the FineUploader handler (findings H-8 / A2-H-2).
+ *
+ * SystemFineUploadHandler is abstract, so we exercise its protected confinement
+ * helpers through a concrete subclass and reflection, and assert the image/avatar
+ * subclasses inherit (do not override) the confined methods.
+ */
+final class FineUploaderPathTest extends TestCase
+{
+    private function handler(): \SystemFineUploadHandler
+    {
+        return new class (new \stdClass()) extends \SystemFineUploadHandler {
+            public $allowedExtensions = ['jpg', 'png', 'gif'];
+        };
+    }
+
+    /**
+     * @param mixed ...$args
+     * @return mixed
+     */
+    private function call(object $obj, string $method, ...$args)
+    {
+        $m = new \ReflectionMethod($obj, $method);
+        $m->setAccessible(true);
+        return $m->invoke($obj, ...$args);
+    }
+
+    /** @return array<int, array{string}> */
+    public static function badUuids(): array
+    {
+        return [
+            ['../../etc'], ['..\\..\\x'], ['%2e%2e'], ['a/b'], ['a\\b'],
+            ['C:'], [''], [str_repeat('a', 65)], ['has space'], ['dot.dot'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('badUuids')]
+    public function safeUuidRejectsUnsafeValues(string $uuid): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->call($this->handler(), 'safeUuid', $uuid);
+    }
+
+    #[Test]
+    public function safeUuidAcceptsPlainIdentifier(): void
+    {
+        self::assertSame('abc-123_DEF', $this->call($this->handler(), 'safeUuid', 'abc-123_DEF'));
+    }
+
+    #[Test]
+    public function safeLeafNameStripsDirectoryAndKeepsAllowedExtension(): void
+    {
+        self::assertSame('photo.jpg', $this->call($this->handler(), 'safeLeafName', '../../photo.jpg'));
+    }
+
+    #[Test]
+    public function safeLeafNameRejectsDisallowedExtension(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->call($this->handler(), 'safeLeafName', 'shell.php');
+    }
+
+    #[Test]
+    public function safeLeafNameRejectsDotfile(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->call($this->handler(), 'safeLeafName', '.htaccess');
+    }
+
+    #[Test]
+    public function assertWithinRejectsParentTraversal(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->call($this->handler(), 'assertWithin', '/srv/uploads/../escape', '/srv/uploads');
+    }
+
+    #[Test]
+    public function assertWithinAllowsChildPath(): void
+    {
+        self::assertSame(
+            '/srv/uploads/u/file.bin',
+            $this->call($this->handler(), 'assertWithin', '/srv/uploads/u/file.bin', '/srv/uploads')
+        );
+    }
+
+    #[Test]
+    public function subclassesInheritConfinedMethods(): void
+    {
+        require_once XOOPS_ROOT_PATH . '/modules/system/class/fineimuploadhandler.php';
+        require_once XOOPS_ROOT_PATH . '/modules/system/class/fineavataruploadhandler.php';
+
+        foreach (['SystemFineImUploadHandler', 'SystemFineAvatarUploadHandler'] as $sub) {
+            foreach (['combineChunks', 'handleUpload', 'handleDelete'] as $method) {
+                $declaring = (new \ReflectionMethod($sub, $method))->getDeclaringClass()->getName();
+                self::assertSame(
+                    'SystemFineUploadHandler',
+                    $declaring,
+                    "{$sub}::{$method}() must inherit the base confinement, not override it"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Security / hardening pass

A focused pass hardening XOOPS 2.7 core against issues surfaced by a multi-reviewer security audit. Every fix lands with a regression test; the full **PHP 8.2 → 8.5** matrix, coverage, SonarCloud, Scrutinizer and Codecov are green.

### Findings addressed

**Critical**
- **C-1** — stored XSS: `MyTextSanitizer::makeClickable()` re-decoded text that `displayTarea()` had already encoded. It now decodes only each matched URL/email token (no whole-buffer decode, no `&amp;amp;` double-encode). `security(textsanitizer)`

**High**
- **H-8 / A2-H-2** — FineUploader built filesystem paths from raw `qquuid`/`qqfilename` (reachable anonymously where a category grants `imgcat_write` to the anonymous group). Now validates the identifier + leaf name, lexically confines every path, re-checks the extension on combine, range-checks chunk metadata, and pins reads to POST. `security(system/upload)`
- **H-1 / M-13** — `redirect_header()` used a prefix host comparison (open redirect). Now a full scheme/host/port match via `xoops_isLocalUrl()`, validating any scheme-bearing target (`data:`/`mailto:`/…) with default-port normalisation; `comment_delete` no longer redirects to the raw `Referer`. `security(redirect)`
- **H-2 / H-3 / H-4 / M-1** — request-token validation added to comment deletion, group-membership change, mass-mail send, and account self-deletion (the posting forms already carry a token). `security(system)`
- **H-5** — block visibility / drag / order changed state without a token. `security(system/blocks)`
- **H-6** — LDAP login input was unescaped in the search filter and bind DN. Now `ldap_escape()` with the context-correct flag. `security(auth/ldap)`

**Medium**
- **M-10** — admin status toggles (avatars, smilies, userrank, images) lacked token validation.
- **A2-M-1** — `browse.php` used substring containment → boundary match.
- **A2-M-8** — user post-count recalculation AJAX lacked a token.
- **A2-M-9** — profile registration-step toggle (GET) lacked a token.

### CSRF token infrastructure
`xoops_cp_footer()` emits one request token per control-panel page; `admin.js` / `blocks.js` submit it; idempotent toggles validate with `check(false)` (no consume) and reject with `http_response_code(403)` before any output; GET action links carry the token in both the default and dark admin templates.

### Tests
New / extended PHPUnit suites (86 tests, 169 assertions): text-sanitizer encoding, FineUploader path confinement, redirect validation, CSRF guard ordering, LDAP escaping, and `browse.php` containment.

### ⚠️ Needs an admin-UI smoke test before merge
Avatar / smilie / userrank / image display toggles, block show-hide + drag-reorder, post-count recalc icon, activate-user + synchronize links, profile step toggle — all should work normally; a forged request **without** a token returns 403 / redirects with a token error and makes **no** state change. Please also exercise the **dark** admin theme Users page.

### Deferred to follow-up PRs (need exercised flows or are separable)
- **H-7** installer already-installed lock (needs an install-flow check).
- **A2-H-1** upgrade-preflight token gate (needs an upgrade-flow check).
- **A2-M-5** profile search active-user filter.
- `makeClickable0..7` dead-variant removal (chore).
- Remaining Medium batch (renderer escaping, tplsets confinement, activation-token entropy).

### Review status
Resolved CodeRabbit (incl. a real undefined-variable bug in `comment_delete`), Sourcery, and external review (the `redirect_header` scheme-validation gap and default-port normalization). Two automated suggestions were verified **incorrect** and intentionally not applied: a PHPUnit-attribute "incompatibility" (the project runs PHPUnit 11.x and CI is green) and an "inverted" `assertLessThan` (the `($expected, $actual)` comparison is correct — it asserts guard-before-mutation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emit admin AJAX request token in control panel and include it from admin/block JS helpers
  * Strict same-origin redirect validation for safer external link handling

* **Bug Fixes / Hardening**
  * Improved upload/delete error handling, path confinement and filename sanitization
  * Escape LDAP inputs to prevent injection in queries
  * Prevent double-encoding during linkification
  * Enforce CSRF/security token checks across admin and deletion flows

* **Tests**
  * Add extensive unit tests for uploads, path containment, LDAP escaping, redirect safety, CSRF guards, and linkification
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Note: Protector + FineUploader (`ajaxfineupload.php`)

The image/avatar multi-upload endpoint runs **before** `mainfile.php` and is gated by a JWT. It defines `PROTECTOR_SKIP_DOS_CHECK` and `PROTECTOR_SKIP_FILESCHECKER` so Protector's pre-checks don't false-positive on a legitimate upload — the rapid concurrent POST burst trips the DoS filter, and `check_uploaded_files()` rejects ordinary image filenames with more than one dot (e.g. `pngkey.com-….png`) or any image `getimagesize()` cannot parse. The endpoint enforces its own extension + MIME allowlist and stores files under generated single-extension names, and the upload is only processed after the JWT validates, so these skips do not weaken the effective upload validation.
