### PR TITLE
Fix/profile search active filter

### DIFF
--- a/htdocs/modules/profile/search.php
+++ b/htdocs/modules/profile/search.php
@@ -192,49 +192,31 @@ switch ($op) {
                 redirect_header(XOOPS_URL . '/', 3, 'Invalid username provided.');
             }
 
-            // Adjust the search pattern based on the match type
+            // Build the LIKE pattern in a separate variable so $uname stays
+            // pristine for the search URL below.
+            $pattern = $uname;
             switch ($uname_match) {
                 case XOOPS_MATCH_START:
-                    $uname .= '%';
+                    $pattern .= '%';
                     break;
                 case XOOPS_MATCH_END:
-                    $uname = '%' . $uname;
+                    $pattern = '%' . $pattern;
                     break;
                 case XOOPS_MATCH_CONTAIN:
-                    $uname = '%' . $uname . '%';
+                    $pattern = '%' . $pattern . '%';
                     break;
             }
 
-            // Create criteria for the SQL query
-            $criteria = new Criteria('uname', $uname, 'LIKE');
-            [$clause, $params] = $criteria->render();
-
-            // Prepare and execute the SQL query
-            $sql = "SELECT * FROM " . $xoopsDB->prefix('users') . " WHERE " . $clause;
-            $stmt = $xoopsDB->prepare($sql);
-
-            foreach ($params as $placeholder => $value) {
-                $stmt->bindValue($placeholder, $value);
-            }
-
-            $stmt->execute();
-            $results = $stmt->fetchAll();
-
-            // Process results
-            $search_url = [];
-            $searchvars = [];
-
-            if ($results) {
-                foreach ($results as $row) {
-                    // Populate search URL and search variables based on the results
-                    $search_url[] = 'uname=' . urlencode($row['uname']);
-                    $search_url[] = 'uname_match=' . urlencode((string) $uname_match);
-                    $searchvars[] = 'uname';
-                }
-            }
-
-            // Further processing or usage of $search_url, $searchvars
-            // You might render a page or redirect the user based on these results
+            // AND the username into the compound criteria so the active-user
+            // filter (level > 0) built above is preserved — otherwise inactive
+            // accounts leak into the results. The search itself runs once at
+            // $profile_handler->search($criteria, ...) further down; adding to
+            // $criteria here (rather than reassigning it) also keeps the
+            // email/profile-field $criteria->add() calls below working.
+            $criteria->add(new Criteria('uname', $pattern, 'LIKE'));
+            $searchvars[] = 'uname';
+            $search_url[] = 'uname=' . urlencode($uname);
+            $search_url[] = 'uname_match=' . urlencode((string) $uname_match);
         }
 
         $email = Request::hasVar('email', 'GET') ? Request::getString('email', '', 'GET') : Request::getString('email', '', 'POST');

--- a/tests/unit/htdocs/modules/profile/ProfileSearchCriteriaTest.php
+++ b/tests/unit/htdocs/modules/profile/ProfileSearchCriteriaTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace modulesprofile;
+
+use Criteria;
+use CriteriaCompo;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for the active-user filter in
+ * htdocs/modules/profile/search.php (issue A2-M-5).
+ *
+ * The username branch used to reassign $criteria to a bare Criteria, which
+ * (a) discarded the base CriteriaCompo(level > 0) active-user filter so
+ * inactive/unconfirmed accounts leaked into search results, and (b) left
+ * $criteria without an add() method, so a username + email/profile-field
+ * search fataled on the later $criteria->add() calls.
+ *
+ * search.php is a procedural script driven by global bootstrap side effects,
+ * so — following the sibling ProfileVisibilityCsrfTest — these tests pin both
+ * the Criteria contract the fix relies on and the source shape of the fix
+ * itself.
+ *
+ * @see \Criteria
+ * @see \CriteriaCompo
+ */
+class ProfileSearchCriteriaTest extends TestCase
+{
+    /** @var \XoopsTestStubDatabase */
+    private $db;
+
+    protected function setUp(): void
+    {
+        $this->db = $GLOBALS['xoopsDB'];
+    }
+
+    private function readSearchSource(): string
+    {
+        $path   = XOOPS_ROOT_PATH . '/modules/profile/search.php';
+        $source = file_get_contents($path);
+        self::assertNotFalse($source, 'Unable to read ' . $path);
+
+        return (string) $source;
+    }
+
+    // ---------------------------------------------------------------
+    // Criteria contract the fix depends on
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function usernameSearchKeepsActiveUserFilter(): void
+    {
+        // Mirror search.php: base active-user filter, then AND the username in.
+        $criteria = new CriteriaCompo(new Criteria('level', 0, '>'));
+        $criteria->add(new Criteria('uname', 'john%', 'LIKE'));
+
+        $sql = $criteria->render($this->db);
+
+        self::assertStringContainsString('`level` > 0', $sql, 'active-user filter must survive');
+        self::assertStringContainsString("`uname` LIKE 'john%'", $sql);
+        self::assertStringContainsString(' AND ', $sql, 'predicates must be AND-combined');
+    }
+
+    #[Test]
+    public function usernamePlusEmailAndsAllPredicates(): void
+    {
+        // The combination that previously fataled (add() on a bare Criteria).
+        $criteria = new CriteriaCompo(new Criteria('level', 0, '>'));
+        $criteria->add(new Criteria('uname', 'john%', 'LIKE'));
+        $criteria->add(new Criteria('email', '%@example.com', 'LIKE'));
+
+        $sql = $criteria->render($this->db);
+
+        self::assertStringContainsString('`level` > 0', $sql);
+        self::assertStringContainsString("`uname` LIKE 'john%'", $sql);
+        self::assertStringContainsString("`email` LIKE '%@example.com'", $sql);
+    }
+
+    // ---------------------------------------------------------------
+    // Source shape of the fix
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function searchSourceAddsUsernameRatherThanReassigningCriteria(): void
+    {
+        $source = $this->readSearchSource();
+
+        self::assertStringContainsString(
+            "\$criteria->add(new Criteria('uname'",
+            $source,
+            'username must be AND-ed into the compound criteria'
+        );
+        self::assertStringNotContainsString(
+            "\$criteria = new Criteria('uname'",
+            $source,
+            'reassigning $criteria drops the level > 0 active-user filter (A2-M-5 regression)'
+        );
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Preserve the active-user filter in profile username search and cover the regression with tests.

Bug Fixes:
- Ensure profile username searches respect the active-user (level > 0) filter instead of including inactive accounts.
- Prevent fatal errors when combining username search with email or profile-field filters by keeping criteria composable.

Enhancements:
- Keep the raw username value intact for building search URLs while using a separate pattern for SQL LIKE matching.

Tests:
- Add regression tests to verify username search criteria retain the active-user filter and correctly AND with email/profile-field predicates.
- Add a source-level test to ensure the username condition is added to the compound criteria rather than replacing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile search to correctly combine username search criteria with other active filters, ensuring all search parameters are applied simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->