### PR TITLE
ci(codecov): make patch coverage informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,16 @@
+# Codecov configuration — https://docs.codecov.com/docs/codecovyml-reference
+#
+# Patch coverage is informational only (reported, never blocking). Many XOOPS
+# core fixes touch procedural entry-point scripts (e.g. modules/*/search.php)
+# that cannot be unit-executed without a full request bootstrap, so an enforced
+# patch status would block otherwise-correct, well-reviewed changes. Overall
+# project coverage stays enforced with a small tolerance so total coverage
+# cannot quietly regress.
+coverage:
+  status:
+    patch:
+      default:
+        informational: true
+    project:
+      default:
+        threshold: 0.5%


### PR DESCRIPTION
Procedural entry-point scripts (e.g. modules/*/search.php) cannot be unit-executed without a full request bootstrap, so an enforced codecov/patch status blocks otherwise-correct, well-reviewed fixes (surfaced by the A2-M-5 profile-search fix in #98). Patch coverage is now reported but non-blocking; project coverage stays enforced with a 0.5% tolerance so overall coverage cannot quietly regress.

## Summary by Sourcery

Build:
- Add Codecov configuration to treat patch coverage as non-blocking and enforce project coverage with a 0.5% threshold.