### PR TITLE
dark-mode for xbootstrap5/xswatch5/xtailwind2 + register smartyextensions

### DIFF
--- a/htdocs/modules/system/preloads/smartyextensions.php
+++ b/htdocs/modules/system/preloads/smartyextensions.php
@@ -6,8 +6,8 @@
  * so no edit to class/template.php is needed. ExtensionRegistry::registerAll() auto-detects
  * the Smarty version (Smarty 4 -> registerPlugin, Smarty 5 -> addExtension via Smarty5Adapter).
  *
- * Collision policy (see docs/rector-fixes/smarty-claude.md §12): register the full catalogue
- * EXCEPT RayDebugExtension, which duplicates core's class/smarty3_plugins/{function,modifier}.ray*.
+ * Collision policy: register the full catalogue EXCEPT RayDebugExtension, which
+ * duplicates core's class/smarty3_plugins/{function,modifier}.ray*.
  *
  * @copyright (c) 2000-2026 XOOPS Project (https://xoops.org)
  * @license   GNU GPL 2.0 or later (https://www.gnu.org/licenses/gpl-2.0.html)
@@ -25,6 +25,13 @@ use Xoops\SmartyExtensions\Extension\XoopsCoreExtension;
 
 /**
  * Class SystemSmartyextensionsPreload
+ *
+ * @category  Preload
+ * @package   system
+ * @author    XOOPS Project (https://xoops.org)
+ * @copyright (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2.0 or later (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @link      https://xoops.org
  */
 class SystemSmartyextensionsPreload extends XoopsPreloadItem
 {
@@ -46,7 +53,12 @@ class SystemSmartyextensionsPreload extends XoopsPreloadItem
             if (null === self::$registry) {
                 /** @var \XoopsSecurity|null $security */
                 $security = $GLOBALS['xoopsSecurity'] ?? null;
+                // xoops_getHandler() returns false on failure; SecurityExtension expects
+                // ?XoopsGroupPermHandler, so normalise anything else to null.
                 $permHandler = function_exists('xoops_getHandler') ? xoops_getHandler('groupperm') : null;
+                if (!($permHandler instanceof \XoopsGroupPermHandler)) {
+                    $permHandler = null;
+                }
 
                 $registry = new ExtensionRegistry();
                 $registry->add(new TextExtension());
@@ -64,10 +76,9 @@ class SystemSmartyextensionsPreload extends XoopsPreloadItem
 
             self::$registry->registerAll($tpl);
         } catch (\Throwable $e) {
-            // A plugin-registration problem must not white-screen the site.
-            if (isset($GLOBALS['xoopsLogger']) && is_object($GLOBALS['xoopsLogger'])) {
-                $GLOBALS['xoopsLogger']->addExtra('SmartyExtensions', 'registration failed: ' . $e->getMessage());
-            }
+            // A plugin-registration problem must not white-screen the site; surface it
+            // as a non-fatal warning for the error handler / log instead.
+            trigger_error('SmartyExtensions registration failed: ' . $e->getMessage(), E_USER_WARNING);
         }
     }
 }

--- a/htdocs/modules/system/preloads/smartyextensions.php
+++ b/htdocs/modules/system/preloads/smartyextensions.php
@@ -76,9 +76,13 @@ class SystemSmartyextensionsPreload extends XoopsPreloadItem
 
             self::$registry->registerAll($tpl);
         } catch (\Throwable $e) {
-            // A plugin-registration problem must not white-screen the site; surface it
-            // as a non-fatal warning for the error handler / log instead.
-            trigger_error('SmartyExtensions registration failed: ' . $e->getMessage(), E_USER_WARNING);
+            // Non-fatal: a registration problem must never white-screen the site. Emit a
+            // generic warning for the error handler and keep the exception detail in the
+            // debug log only, so internals are never leaked into displayed warning text.
+            trigger_error('SmartyExtensions registration failed.', E_USER_WARNING);
+            if (isset($GLOBALS['xoopsLogger']) && \is_object($GLOBALS['xoopsLogger'])) {
+                $GLOBALS['xoopsLogger']->addExtra('SmartyExtensions', $e->getMessage());
+            }
         }
     }
 }

--- a/htdocs/modules/system/preloads/smartyextensions.php
+++ b/htdocs/modules/system/preloads/smartyextensions.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Register xoops/smartyextensions on every XoopsTpl (Smarty 4 today, Smarty 5 later).
+ *
+ * Hooks the core.class.template.new event fired at the end of XoopsTpl::__construct(),
+ * so no edit to class/template.php is needed. ExtensionRegistry::registerAll() auto-detects
+ * the Smarty version (Smarty 4 -> registerPlugin, Smarty 5 -> addExtension via Smarty5Adapter).
+ *
+ * Collision policy (see docs/rector-fixes/smarty-claude.md §12): register the full catalogue
+ * EXCEPT RayDebugExtension, which duplicates core's class/smarty3_plugins/{function,modifier}.ray*.
+ *
+ * @copyright (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2.0 or later (https://www.gnu.org/licenses/gpl-2.0.html)
+ */
+
+use Xoops\SmartyExtensions\ExtensionRegistry;
+use Xoops\SmartyExtensions\Extension\AssetExtension;
+use Xoops\SmartyExtensions\Extension\DataExtension;
+use Xoops\SmartyExtensions\Extension\FormatExtension;
+use Xoops\SmartyExtensions\Extension\FormExtension;
+use Xoops\SmartyExtensions\Extension\NavigationExtension;
+use Xoops\SmartyExtensions\Extension\SecurityExtension;
+use Xoops\SmartyExtensions\Extension\TextExtension;
+use Xoops\SmartyExtensions\Extension\XoopsCoreExtension;
+
+/**
+ * Class SystemSmartyextensionsPreload
+ */
+class SystemSmartyextensionsPreload extends XoopsPreloadItem
+{
+    /** @var ExtensionRegistry|null built once per request (Asset queue is shared across templates) */
+    private static ?ExtensionRegistry $registry = null;
+
+    /**
+     * @param array $args $args[0] is the new XoopsTpl (Smarty) instance
+     * @return void
+     */
+    public static function eventCoreClassTemplateNew($args)
+    {
+        $tpl = $args[0] ?? null;
+        if (!is_object($tpl) || !class_exists(ExtensionRegistry::class)) {
+            return; // package absent or unexpected arg — fail safe, never break rendering
+        }
+
+        try {
+            if (null === self::$registry) {
+                /** @var \XoopsSecurity|null $security */
+                $security = $GLOBALS['xoopsSecurity'] ?? null;
+                $permHandler = function_exists('xoops_getHandler') ? xoops_getHandler('groupperm') : null;
+
+                $registry = new ExtensionRegistry();
+                $registry->add(new TextExtension());
+                $registry->add(new FormatExtension());
+                $registry->add(new NavigationExtension());
+                $registry->add(new SecurityExtension($security, $permHandler));
+                $registry->add(new FormExtension($security));
+                $registry->add(new DataExtension());
+                $registry->add(new AssetExtension());
+                $registry->add(new XoopsCoreExtension());
+                // RayDebugExtension intentionally omitted — duplicates core ray plugins.
+
+                self::$registry = $registry;
+            }
+
+            self::$registry->registerAll($tpl);
+        } catch (\Throwable $e) {
+            // A plugin-registration problem must not white-screen the site.
+            if (isset($GLOBALS['xoopsLogger']) && is_object($GLOBALS['xoopsLogger'])) {
+                $GLOBALS['xoopsLogger']->addExtra('SmartyExtensions', 'registration failed: ' . $e->getMessage());
+            }
+        }
+    }
+}

--- a/htdocs/themes/xbootstrap5/css/dark-mode.css
+++ b/htdocs/themes/xbootstrap5/css/dark-mode.css
@@ -1,0 +1,269 @@
+/*
+ * Dark-mode compatibility for XOOPS legacy module output.
+ * Loaded after module CSS so theme dark mode can override hard-coded light surfaces.
+ */
+
+html[data-theme="dark"],
+html[data-bs-theme="dark"] {
+    color-scheme: dark;
+}
+
+html[data-theme="dark"] body,
+html[data-bs-theme="dark"] body {
+    background-color: var(--bs-body-bg, #111827);
+    color: var(--bs-body-color, #e5e7eb);
+}
+
+html[data-theme="dark"] .maincontainer,
+html[data-bs-theme="dark"] .maincontainer {
+    color: var(--bs-body-color, #e5e7eb);
+}
+
+html[data-theme="dark"] a,
+html[data-bs-theme="dark"] a {
+    color: var(--bs-link-color, #60a5fa);
+}
+
+html[data-theme="dark"] a:hover,
+html[data-bs-theme="dark"] a:hover {
+    color: var(--bs-link-hover-color, #93c5fd);
+}
+
+html[data-theme="dark"] .card,
+html[data-theme="dark"] .panel,
+html[data-theme="dark"] .panel-default,
+html[data-theme="dark"] .well,
+html[data-theme="dark"] .jumbotron,
+html[data-theme="dark"] .modal-content,
+html[data-theme="dark"] .dropdown-menu,
+html[data-theme="dark"] .list-group-item,
+html[data-theme="dark"] .accordion-item,
+html[data-theme="dark"] .tab-content,
+html[data-theme="dark"] .xoopscontents,
+html[data-theme="dark"] .xoops-content,
+html[data-theme="dark"] .module-content,
+html[data-theme="dark"] .item,
+html[data-theme="dark"] .newbb-thread,
+html[data-theme="dark"] .newbb-user-data,
+html[data-theme="dark"] .newbb-message-area,
+html[data-theme="dark"] .newbb-links,
+html[data-theme="dark"] .pagenav,
+html[data-theme="dark"] .block-content,
+html[data-theme="dark"] .block-title,
+html[data-theme="dark"] .bottom-blocks,
+html[data-theme="dark"] .footer-blocks,
+html[data-bs-theme="dark"] .card,
+html[data-bs-theme="dark"] .panel,
+html[data-bs-theme="dark"] .panel-default,
+html[data-bs-theme="dark"] .well,
+html[data-bs-theme="dark"] .jumbotron,
+html[data-bs-theme="dark"] .modal-content,
+html[data-bs-theme="dark"] .dropdown-menu,
+html[data-bs-theme="dark"] .list-group-item,
+html[data-bs-theme="dark"] .accordion-item,
+html[data-bs-theme="dark"] .tab-content,
+html[data-bs-theme="dark"] .xoopscontents,
+html[data-bs-theme="dark"] .xoops-content,
+html[data-bs-theme="dark"] .module-content,
+html[data-bs-theme="dark"] .item,
+html[data-bs-theme="dark"] .newbb-thread,
+html[data-bs-theme="dark"] .newbb-user-data,
+html[data-bs-theme="dark"] .newbb-message-area,
+html[data-bs-theme="dark"] .newbb-links,
+html[data-bs-theme="dark"] .pagenav,
+html[data-bs-theme="dark"] .block-content,
+html[data-bs-theme="dark"] .block-title,
+html[data-bs-theme="dark"] .bottom-blocks,
+html[data-bs-theme="dark"] .footer-blocks {
+    background-color: var(--bs-tertiary-bg, #1f2937);
+    color: var(--bs-body-color, #e5e7eb);
+    border-color: var(--bs-border-color, rgba(255, 255, 255, .16));
+}
+
+html[data-theme="dark"] .newbb-thread,
+html[data-bs-theme="dark"] .newbb-thread {
+    margin-bottom: 1.25rem;
+    border: 1px solid var(--bs-border-color, rgba(255, 255, 255, .16));
+    border-radius: .75rem;
+    overflow: hidden;
+}
+
+html[data-theme="dark"] .newbb-user-data,
+html[data-theme="dark"] .newbb-message-area,
+html[data-bs-theme="dark"] .newbb-user-data,
+html[data-bs-theme="dark"] .newbb-message-area {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+}
+
+html[data-theme="dark"] .newbb-forum-title,
+html[data-bs-theme="dark"] .newbb-forum-title {
+    color: var(--bs-emphasis-color, #fff);
+}
+
+html[data-theme="dark"] .newbb-message-area :where(p, li, div),
+html[data-bs-theme="dark"] .newbb-message-area :where(p, li, div) {
+    color: var(--bs-body-color, #e5e7eb);
+}
+
+html[data-theme="dark"] .newbb-user-signature,
+html[data-theme="dark"] .newbb-thread-attachment,
+html[data-bs-theme="dark"] .newbb-user-signature,
+html[data-bs-theme="dark"] .newbb-thread-attachment {
+    border-top: 1px solid var(--bs-border-color, rgba(255, 255, 255, .16));
+    color: var(--bs-secondary-color, #aab4c0);
+}
+
+html[data-theme="dark"] .card-header,
+html[data-theme="dark"] .card-footer,
+html[data-theme="dark"] .panel-heading,
+html[data-theme="dark"] .panel-footer,
+html[data-theme="dark"] .modal-header,
+html[data-theme="dark"] .modal-footer,
+html[data-bs-theme="dark"] .card-header,
+html[data-bs-theme="dark"] .card-footer,
+html[data-bs-theme="dark"] .panel-heading,
+html[data-bs-theme="dark"] .panel-footer,
+html[data-bs-theme="dark"] .modal-header,
+html[data-bs-theme="dark"] .modal-footer {
+    background-color: var(--bs-secondary-bg, #273244);
+    color: var(--bs-body-color, #e5e7eb);
+    border-color: var(--bs-border-color, rgba(255, 255, 255, .16));
+}
+
+html[data-theme="dark"] table,
+html[data-theme="dark"] .table,
+html[data-bs-theme="dark"] table,
+html[data-bs-theme="dark"] .table {
+    color: var(--bs-body-color, #e5e7eb);
+    border-color: var(--bs-border-color, rgba(255, 255, 255, .16));
+}
+
+html[data-theme="dark"] th,
+html[data-theme="dark"] td,
+html[data-theme="dark"] .outer,
+html[data-theme="dark"] .inner,
+html[data-theme="dark"] .head,
+html[data-theme="dark"] .even,
+html[data-theme="dark"] .odd,
+html[data-theme="dark"] .foot,
+html[data-bs-theme="dark"] th,
+html[data-bs-theme="dark"] td,
+html[data-bs-theme="dark"] .outer,
+html[data-bs-theme="dark"] .inner,
+html[data-bs-theme="dark"] .head,
+html[data-bs-theme="dark"] .even,
+html[data-bs-theme="dark"] .odd,
+html[data-bs-theme="dark"] .foot {
+    color: var(--bs-body-color, #e5e7eb);
+    border-color: var(--bs-border-color, rgba(255, 255, 255, .16));
+}
+
+html[data-theme="dark"] .outer,
+html[data-theme="dark"] .inner,
+html[data-bs-theme="dark"] .outer,
+html[data-bs-theme="dark"] .inner {
+    background-color: var(--bs-tertiary-bg, #1f2937);
+}
+
+html[data-theme="dark"] .head,
+html[data-theme="dark"] .foot,
+html[data-bs-theme="dark"] .head,
+html[data-bs-theme="dark"] .foot {
+    background-color: var(--bs-secondary-bg, #273244);
+}
+
+html[data-theme="dark"] .even,
+html[data-bs-theme="dark"] .even {
+    background-color: rgba(255, 255, 255, .035);
+}
+
+html[data-theme="dark"] .odd,
+html[data-bs-theme="dark"] .odd {
+    background-color: rgba(255, 255, 255, .06);
+}
+
+html[data-theme="dark"] input:not([type="button"]):not([type="submit"]):not([type="reset"]):not([type="checkbox"]):not([type="radio"]),
+html[data-theme="dark"] select,
+html[data-theme="dark"] textarea,
+html[data-theme="dark"] .form-control,
+html[data-theme="dark"] .form-select,
+html[data-theme="dark"] .custom-select,
+html[data-bs-theme="dark"] input:not([type="button"]):not([type="submit"]):not([type="reset"]):not([type="checkbox"]):not([type="radio"]),
+html[data-bs-theme="dark"] select,
+html[data-bs-theme="dark"] textarea,
+html[data-bs-theme="dark"] .form-control,
+html[data-bs-theme="dark"] .form-select,
+html[data-bs-theme="dark"] .custom-select {
+    background-color: var(--bs-body-bg, #111827);
+    color: var(--bs-body-color, #e5e7eb);
+    border-color: var(--bs-border-color, rgba(255, 255, 255, .2));
+}
+
+html[data-theme="dark"] option,
+html[data-theme="dark"] optgroup,
+html[data-bs-theme="dark"] option,
+html[data-bs-theme="dark"] optgroup {
+    background-color: var(--bs-body-bg, #111827);
+    color: var(--bs-body-color, #e5e7eb);
+}
+
+html[data-theme="dark"] input::placeholder,
+html[data-theme="dark"] textarea::placeholder,
+html[data-theme="dark"] .form-control::placeholder,
+html[data-bs-theme="dark"] input::placeholder,
+html[data-bs-theme="dark"] textarea::placeholder,
+html[data-bs-theme="dark"] .form-control::placeholder {
+    color: var(--bs-secondary-color, #94a3b8);
+    opacity: 1;
+}
+
+html[data-theme="dark"] .input-group-text,
+html[data-bs-theme="dark"] .input-group-text {
+    background-color: var(--bs-secondary-bg, #273244);
+    color: var(--bs-body-color, #e5e7eb);
+    border-color: var(--bs-border-color, rgba(255, 255, 255, .2));
+}
+
+html[data-theme="dark"] .text-muted,
+html[data-bs-theme="dark"] .text-muted {
+    color: var(--bs-secondary-color, #aab4c0) !important;
+}
+
+html[data-theme="dark"] hr,
+html[data-bs-theme="dark"] hr {
+    border-color: var(--bs-border-color, rgba(255, 255, 255, .16));
+    opacity: 1;
+}
+
+html[data-theme="dark"] pre,
+html[data-theme="dark"] code,
+html[data-theme="dark"] blockquote,
+html[data-theme="dark"] .quote,
+html[data-theme="dark"] .comText,
+html[data-theme="dark"] .comTitle,
+html[data-theme="dark"] .xoopsCode,
+html[data-bs-theme="dark"] pre,
+html[data-bs-theme="dark"] code,
+html[data-bs-theme="dark"] blockquote,
+html[data-bs-theme="dark"] .quote,
+html[data-bs-theme="dark"] .comText,
+html[data-bs-theme="dark"] .comTitle,
+html[data-bs-theme="dark"] .xoopsCode {
+    background-color: #0f172a;
+    color: #e5e7eb;
+    border-color: rgba(255, 255, 255, .16);
+}
+
+html[data-theme="dark"] .breadcrumb,
+html[data-theme="dark"] .pagination,
+html[data-bs-theme="dark"] .breadcrumb,
+html[data-bs-theme="dark"] .pagination {
+    --bs-breadcrumb-divider-color: var(--bs-secondary-color, #aab4c0);
+    color: var(--bs-body-color, #e5e7eb);
+}
+
+html[data-theme="dark"] img,
+html[data-bs-theme="dark"] img {
+    color: transparent;
+}

--- a/htdocs/themes/xbootstrap5/js/theme-toggle.js
+++ b/htdocs/themes/xbootstrap5/js/theme-toggle.js
@@ -7,6 +7,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
     applyTheme(savedTheme);
 
+    if (!toggleBtn) {
+        return;
+    }
+
     toggleBtn.innerHTML = savedTheme === "dark" ? "☀️" : "🌙";
 
     toggleBtn.addEventListener("click", () => {
@@ -17,6 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     function applyTheme(theme) {
         document.documentElement.setAttribute("data-theme", theme);
+        document.documentElement.setAttribute("data-bs-theme", theme);
         localStorage.setItem("theme", theme);
     }
 });

--- a/htdocs/themes/xbootstrap5/js/theme-toggle.js
+++ b/htdocs/themes/xbootstrap5/js/theme-toggle.js
@@ -1,9 +1,11 @@
 // theme-toggle.js
 
 document.addEventListener("DOMContentLoaded", () => {
+    const safeGet = (key) => { try { return localStorage.getItem(key); } catch (e) { return null; } };
+    const safeSet = (key, value) => { try { localStorage.setItem(key, value); } catch (e) {} };
     const toggleBtn = document.getElementById("theme-toggle");
     const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    const savedTheme = localStorage.getItem("theme") || (prefersDark ? "dark" : "light");
+    const savedTheme = safeGet("theme") || (prefersDark ? "dark" : "light");
 
     applyTheme(savedTheme);
 
@@ -22,6 +24,6 @@ document.addEventListener("DOMContentLoaded", () => {
     function applyTheme(theme) {
         document.documentElement.setAttribute("data-theme", theme);
         document.documentElement.setAttribute("data-bs-theme", theme);
-        localStorage.setItem("theme", theme);
+        safeSet("theme", theme);
     }
 });

--- a/htdocs/themes/xbootstrap5/modules/system/system_popup_header.tpl
+++ b/htdocs/themes/xbootstrap5/modules/system/system_popup_header.tpl
@@ -5,7 +5,8 @@
     <meta name="robots" content="noindex, nofollow"/>
     <script>
         (function() {
-            var stored = localStorage.getItem('theme');
+            var stored = null;
+            try { stored = localStorage.getItem('theme'); } catch (e) {}
             var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
             var theme = stored || (prefersDark ? 'dark' : 'light');
             document.documentElement.setAttribute('data-theme', theme);

--- a/htdocs/themes/xbootstrap5/modules/system/system_popup_header.tpl
+++ b/htdocs/themes/xbootstrap5/modules/system/system_popup_header.tpl
@@ -1,8 +1,17 @@
 <!doctype html>
-<html lang="<{$xoops_langcode}>">
+<html lang="<{$xoops_langcode}>" data-theme="light" data-bs-theme="light">
 <head>
     <meta charset="<{$xoops_charset}>">
     <meta name="robots" content="noindex, nofollow"/>
+    <script>
+        (function() {
+            var stored = localStorage.getItem('theme');
+            var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            var theme = stored || (prefersDark ? 'dark' : 'light');
+            document.documentElement.setAttribute('data-theme', theme);
+            document.documentElement.setAttribute('data-bs-theme', theme);
+        })();
+    </script>
     <title><{$xoops_sitename|escape:'html':'UTF-8'}></title>
     <{section name=item loop=$headItems}>
         <{$headItems[item]}>
@@ -10,6 +19,7 @@
     <link rel="stylesheet" type="text/css" href="<{$themeUrl}>css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="<{$themeUrl}>css/xoops.css">
     <link rel="stylesheet" type="text/css" href="<{$themeUrl}>css/reset.css">
+    <link rel="stylesheet" type="text/css" href="<{$themeUrl}>css/dark-mode.css">
     <script src="<{$xoops_url}>/browse.php?Frameworks/jquery/jquery.js"></script>
     <script src="<{$themeUrl}>js/bootstrap.min.js"></script>
 

--- a/htdocs/themes/xbootstrap5/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/xbootstrap5/modules/system/system_siteclosed.tpl
@@ -13,7 +13,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script>
         (function() {
-            var stored = localStorage.getItem('theme');
+            var stored = null;
+            try { stored = localStorage.getItem('theme'); } catch (e) {}
             var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
             var theme = stored || (prefersDark ? 'dark' : 'light');
             document.documentElement.setAttribute('data-theme', theme);

--- a/htdocs/themes/xbootstrap5/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/xbootstrap5/modules/system/system_siteclosed.tpl
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="no-js" lang="<{$xoops_langcode}>">
+<html class="no-js" lang="<{$xoops_langcode}>" data-theme="light" data-bs-theme="light">
 <head>
     <{assign var=theme_name value=$xoTheme->folderName}>
     <meta charset="<{$xoops_charset}>">
@@ -11,6 +11,15 @@
     <meta name="generator" content="XOOPS">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>
+        (function() {
+            var stored = localStorage.getItem('theme');
+            var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            var theme = stored || (prefersDark ? 'dark' : 'light');
+            document.documentElement.setAttribute('data-theme', theme);
+            document.documentElement.setAttribute('data-bs-theme', theme);
+        })();
+    </script>
     <!-- disable zoom in mobile devices:
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     -->
@@ -27,6 +36,7 @@
         !=''}><{$xoops_pagetitle}> - <{$xoops_sitename}><{/if}><{/if}></title>
     <{include file="$theme_name/tpl/shareaholic-script.tpl"}>
     <{$xoops_module_header|default:''}>
+    <link rel="stylesheet" type="text/css" href="<{$xoops_imageurl}>css/dark-mode.css">
 </head>
 <body class="site-closed-body">
 <div class="container">

--- a/htdocs/themes/xbootstrap5/theme.tpl
+++ b/htdocs/themes/xbootstrap5/theme.tpl
@@ -1,7 +1,7 @@
 <!-- theme.tpl (XOOPS + Bootstrap 5 layout example) -->
 
 <!DOCTYPE html>
-<html lang="<{$xoops_langcode}>" data-theme="light">
+<html lang="<{$xoops_langcode}>" dir="<{$xoops_text_direction|default:'ltr'}>" data-theme="light" data-bs-theme="light">
 <head>
     <{assign var=theme_name value=$xoTheme->folderName}>
     <meta charset="<{$xoops_charset}>">
@@ -12,6 +12,15 @@
     <meta name="author" content="<{$xoops_meta_author}>">
     <meta name="generator" content="XOOPS">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>
+        (function() {
+            var stored = localStorage.getItem('theme');
+            var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            var theme = stored || (prefersDark ? 'dark' : 'light');
+            document.documentElement.setAttribute('data-theme', theme);
+            document.documentElement.setAttribute('data-bs-theme', theme);
+        })();
+    </script>
     <!-- Owl Carousel Assets -->
     <link href="<{xoImgUrl}>js/owl/assets/owl.carousel.css" rel="stylesheet">
     <link href="<{xoImgUrl}>js/owl/assets/owl.theme.default.css" rel="stylesheet">
@@ -53,7 +62,7 @@
     <{include file="$theme_name/tpl/shareaholic-script.tpl"}>
 
     <{$xoops_module_header}>
-
+    <link rel="stylesheet" type="text/css" href="<{xoImgUrl}>css/dark-mode.css">
 
 </head>
 <body id="<{$xoops_dirname}>">

--- a/htdocs/themes/xbootstrap5/theme.tpl
+++ b/htdocs/themes/xbootstrap5/theme.tpl
@@ -14,7 +14,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script>
         (function() {
-            var stored = localStorage.getItem('theme');
+            var stored = null;
+            try { stored = localStorage.getItem('theme'); } catch (e) {}
             var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
             var theme = stored || (prefersDark ? 'dark' : 'light');
             document.documentElement.setAttribute('data-theme', theme);

--- a/htdocs/themes/xswatch5/css/dark-mode.css
+++ b/htdocs/themes/xswatch5/css/dark-mode.css
@@ -1,0 +1,269 @@
+/*
+ * Dark-mode compatibility for XOOPS legacy module output.
+ * Loaded after module CSS so theme dark mode can override hard-coded light surfaces.
+ */
+
+html[data-theme="dark"],
+html[data-bs-theme="dark"] {
+    color-scheme: dark;
+}
+
+html[data-theme="dark"] body,
+html[data-bs-theme="dark"] body {
+    background-color: var(--bs-body-bg, #111827);
+    color: var(--bs-body-color, #e5e7eb);
+}
+
+html[data-theme="dark"] .maincontainer,
+html[data-bs-theme="dark"] .maincontainer {
+    color: var(--bs-body-color, #e5e7eb);
+}
+
+html[data-theme="dark"] a,
+html[data-bs-theme="dark"] a {
+    color: var(--bs-link-color, #60a5fa);
+}
+
+html[data-theme="dark"] a:hover,
+html[data-bs-theme="dark"] a:hover {
+    color: var(--bs-link-hover-color, #93c5fd);
+}
+
+html[data-theme="dark"] .card,
+html[data-theme="dark"] .panel,
+html[data-theme="dark"] .panel-default,
+html[data-theme="dark"] .well,
+html[data-theme="dark"] .jumbotron,
+html[data-theme="dark"] .modal-content,
+html[data-theme="dark"] .dropdown-menu,
+html[data-theme="dark"] .list-group-item,
+html[data-theme="dark"] .accordion-item,
+html[data-theme="dark"] .tab-content,
+html[data-theme="dark"] .xoopscontents,
+html[data-theme="dark"] .xoops-content,
+html[data-theme="dark"] .module-content,
+html[data-theme="dark"] .item,
+html[data-theme="dark"] .newbb-thread,
+html[data-theme="dark"] .newbb-user-data,
+html[data-theme="dark"] .newbb-message-area,
+html[data-theme="dark"] .newbb-links,
+html[data-theme="dark"] .pagenav,
+html[data-theme="dark"] .block-content,
+html[data-theme="dark"] .block-title,
+html[data-theme="dark"] .bottom-blocks,
+html[data-theme="dark"] .footer-blocks,
+html[data-bs-theme="dark"] .card,
+html[data-bs-theme="dark"] .panel,
+html[data-bs-theme="dark"] .panel-default,
+html[data-bs-theme="dark"] .well,
+html[data-bs-theme="dark"] .jumbotron,
+html[data-bs-theme="dark"] .modal-content,
+html[data-bs-theme="dark"] .dropdown-menu,
+html[data-bs-theme="dark"] .list-group-item,
+html[data-bs-theme="dark"] .accordion-item,
+html[data-bs-theme="dark"] .tab-content,
+html[data-bs-theme="dark"] .xoopscontents,
+html[data-bs-theme="dark"] .xoops-content,
+html[data-bs-theme="dark"] .module-content,
+html[data-bs-theme="dark"] .item,
+html[data-bs-theme="dark"] .newbb-thread,
+html[data-bs-theme="dark"] .newbb-user-data,
+html[data-bs-theme="dark"] .newbb-message-area,
+html[data-bs-theme="dark"] .newbb-links,
+html[data-bs-theme="dark"] .pagenav,
+html[data-bs-theme="dark"] .block-content,
+html[data-bs-theme="dark"] .block-title,
+html[data-bs-theme="dark"] .bottom-blocks,
+html[data-bs-theme="dark"] .footer-blocks {
+    background-color: var(--bs-tertiary-bg, #1f2937);
+    color: var(--bs-body-color, #e5e7eb);
+    border-color: var(--bs-border-color, rgba(255, 255, 255, .16));
+}
+
+html[data-theme="dark"] .newbb-thread,
+html[data-bs-theme="dark"] .newbb-thread {
+    margin-bottom: 1.25rem;
+    border: 1px solid var(--bs-border-color, rgba(255, 255, 255, .16));
+    border-radius: .75rem;
+    overflow: hidden;
+}
+
+html[data-theme="dark"] .newbb-user-data,
+html[data-theme="dark"] .newbb-message-area,
+html[data-bs-theme="dark"] .newbb-user-data,
+html[data-bs-theme="dark"] .newbb-message-area {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+}
+
+html[data-theme="dark"] .newbb-forum-title,
+html[data-bs-theme="dark"] .newbb-forum-title {
+    color: var(--bs-emphasis-color, #fff);
+}
+
+html[data-theme="dark"] .newbb-message-area :where(p, li, div),
+html[data-bs-theme="dark"] .newbb-message-area :where(p, li, div) {
+    color: var(--bs-body-color, #e5e7eb);
+}
+
+html[data-theme="dark"] .newbb-user-signature,
+html[data-theme="dark"] .newbb-thread-attachment,
+html[data-bs-theme="dark"] .newbb-user-signature,
+html[data-bs-theme="dark"] .newbb-thread-attachment {
+    border-top: 1px solid var(--bs-border-color, rgba(255, 255, 255, .16));
+    color: var(--bs-secondary-color, #aab4c0);
+}
+
+html[data-theme="dark"] .card-header,
+html[data-theme="dark"] .card-footer,
+html[data-theme="dark"] .panel-heading,
+html[data-theme="dark"] .panel-footer,
+html[data-theme="dark"] .modal-header,
+html[data-theme="dark"] .modal-footer,
+html[data-bs-theme="dark"] .card-header,
+html[data-bs-theme="dark"] .card-footer,
+html[data-bs-theme="dark"] .panel-heading,
+html[data-bs-theme="dark"] .panel-footer,
+html[data-bs-theme="dark"] .modal-header,
+html[data-bs-theme="dark"] .modal-footer {
+    background-color: var(--bs-secondary-bg, #273244);
+    color: var(--bs-body-color, #e5e7eb);
+    border-color: var(--bs-border-color, rgba(255, 255, 255, .16));
+}
+
+html[data-theme="dark"] table,
+html[data-theme="dark"] .table,
+html[data-bs-theme="dark"] table,
+html[data-bs-theme="dark"] .table {
+    color: var(--bs-body-color, #e5e7eb);
+    border-color: var(--bs-border-color, rgba(255, 255, 255, .16));
+}
+
+html[data-theme="dark"] th,
+html[data-theme="dark"] td,
+html[data-theme="dark"] .outer,
+html[data-theme="dark"] .inner,
+html[data-theme="dark"] .head,
+html[data-theme="dark"] .even,
+html[data-theme="dark"] .odd,
+html[data-theme="dark"] .foot,
+html[data-bs-theme="dark"] th,
+html[data-bs-theme="dark"] td,
+html[data-bs-theme="dark"] .outer,
+html[data-bs-theme="dark"] .inner,
+html[data-bs-theme="dark"] .head,
+html[data-bs-theme="dark"] .even,
+html[data-bs-theme="dark"] .odd,
+html[data-bs-theme="dark"] .foot {
+    color: var(--bs-body-color, #e5e7eb);
+    border-color: var(--bs-border-color, rgba(255, 255, 255, .16));
+}
+
+html[data-theme="dark"] .outer,
+html[data-theme="dark"] .inner,
+html[data-bs-theme="dark"] .outer,
+html[data-bs-theme="dark"] .inner {
+    background-color: var(--bs-tertiary-bg, #1f2937);
+}
+
+html[data-theme="dark"] .head,
+html[data-theme="dark"] .foot,
+html[data-bs-theme="dark"] .head,
+html[data-bs-theme="dark"] .foot {
+    background-color: var(--bs-secondary-bg, #273244);
+}
+
+html[data-theme="dark"] .even,
+html[data-bs-theme="dark"] .even {
+    background-color: rgba(255, 255, 255, .035);
+}
+
+html[data-theme="dark"] .odd,
+html[data-bs-theme="dark"] .odd {
+    background-color: rgba(255, 255, 255, .06);
+}
+
+html[data-theme="dark"] input:not([type="button"]):not([type="submit"]):not([type="reset"]):not([type="checkbox"]):not([type="radio"]),
+html[data-theme="dark"] select,
+html[data-theme="dark"] textarea,
+html[data-theme="dark"] .form-control,
+html[data-theme="dark"] .form-select,
+html[data-theme="dark"] .custom-select,
+html[data-bs-theme="dark"] input:not([type="button"]):not([type="submit"]):not([type="reset"]):not([type="checkbox"]):not([type="radio"]),
+html[data-bs-theme="dark"] select,
+html[data-bs-theme="dark"] textarea,
+html[data-bs-theme="dark"] .form-control,
+html[data-bs-theme="dark"] .form-select,
+html[data-bs-theme="dark"] .custom-select {
+    background-color: var(--bs-body-bg, #111827);
+    color: var(--bs-body-color, #e5e7eb);
+    border-color: var(--bs-border-color, rgba(255, 255, 255, .2));
+}
+
+html[data-theme="dark"] option,
+html[data-theme="dark"] optgroup,
+html[data-bs-theme="dark"] option,
+html[data-bs-theme="dark"] optgroup {
+    background-color: var(--bs-body-bg, #111827);
+    color: var(--bs-body-color, #e5e7eb);
+}
+
+html[data-theme="dark"] input::placeholder,
+html[data-theme="dark"] textarea::placeholder,
+html[data-theme="dark"] .form-control::placeholder,
+html[data-bs-theme="dark"] input::placeholder,
+html[data-bs-theme="dark"] textarea::placeholder,
+html[data-bs-theme="dark"] .form-control::placeholder {
+    color: var(--bs-secondary-color, #94a3b8);
+    opacity: 1;
+}
+
+html[data-theme="dark"] .input-group-text,
+html[data-bs-theme="dark"] .input-group-text {
+    background-color: var(--bs-secondary-bg, #273244);
+    color: var(--bs-body-color, #e5e7eb);
+    border-color: var(--bs-border-color, rgba(255, 255, 255, .2));
+}
+
+html[data-theme="dark"] .text-muted,
+html[data-bs-theme="dark"] .text-muted {
+    color: var(--bs-secondary-color, #aab4c0) !important;
+}
+
+html[data-theme="dark"] hr,
+html[data-bs-theme="dark"] hr {
+    border-color: var(--bs-border-color, rgba(255, 255, 255, .16));
+    opacity: 1;
+}
+
+html[data-theme="dark"] pre,
+html[data-theme="dark"] code,
+html[data-theme="dark"] blockquote,
+html[data-theme="dark"] .quote,
+html[data-theme="dark"] .comText,
+html[data-theme="dark"] .comTitle,
+html[data-theme="dark"] .xoopsCode,
+html[data-bs-theme="dark"] pre,
+html[data-bs-theme="dark"] code,
+html[data-bs-theme="dark"] blockquote,
+html[data-bs-theme="dark"] .quote,
+html[data-bs-theme="dark"] .comText,
+html[data-bs-theme="dark"] .comTitle,
+html[data-bs-theme="dark"] .xoopsCode {
+    background-color: #0f172a;
+    color: #e5e7eb;
+    border-color: rgba(255, 255, 255, .16);
+}
+
+html[data-theme="dark"] .breadcrumb,
+html[data-theme="dark"] .pagination,
+html[data-bs-theme="dark"] .breadcrumb,
+html[data-bs-theme="dark"] .pagination {
+    --bs-breadcrumb-divider-color: var(--bs-secondary-color, #aab4c0);
+    color: var(--bs-body-color, #e5e7eb);
+}
+
+html[data-theme="dark"] img,
+html[data-bs-theme="dark"] img {
+    color: transparent;
+}

--- a/htdocs/themes/xswatch5/modules/system/system_popup_header.tpl
+++ b/htdocs/themes/xswatch5/modules/system/system_popup_header.tpl
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="<{$xoops_langcode}>" dir="<{$xoops_text_direction|default:'ltr'}>">
+<html lang="<{$xoops_langcode}>" dir="<{$xoops_text_direction|default:'ltr'}>" data-theme="light" data-bs-theme="light">
 <head>
     <meta charset="<{$xoops_charset}>">
     <meta name="robots" content="noindex, nofollow" />
@@ -13,12 +13,14 @@
     <{include file="$themePath/tpl/xswatchCss.tpl" assign="xswatchCss"}>
     <link rel="stylesheet" type="text/css" href="<{$themeUrl}><{$xswatchCss}>/xoops.css">
     <link rel="stylesheet" type="text/css" href="<{$themeUrl}><{$xswatchCss}>/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="<{$themeUrl}>css/dark-mode.css">
 
     <script>
     (function() {
         const stored = localStorage.getItem('xswatch-theme');
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         const theme = stored || (prefersDark ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', theme);
         document.documentElement.setAttribute('data-bs-theme', theme);
     })();
     </script>

--- a/htdocs/themes/xswatch5/modules/system/system_popup_header.tpl
+++ b/htdocs/themes/xswatch5/modules/system/system_popup_header.tpl
@@ -17,7 +17,8 @@
 
     <script>
     (function() {
-        const stored = localStorage.getItem('xswatch-theme');
+        let stored = null;
+        try { stored = localStorage.getItem('xswatch-theme'); } catch (e) {}
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         const theme = stored || (prefersDark ? 'dark' : 'light');
         document.documentElement.setAttribute('data-theme', theme);

--- a/htdocs/themes/xswatch5/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/xswatch5/modules/system/system_siteclosed.tpl
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="<{$xoops_langcode}>" dir="<{$xoops_text_direction|default:'ltr'}>">
+<html lang="<{$xoops_langcode}>" dir="<{$xoops_text_direction|default:'ltr'}>" data-theme="light" data-bs-theme="light">
 <head>
     <{assign var=theme_name value=$xoTheme->folderName}>
     <meta charset="<{$xoops_charset}>">
@@ -21,6 +21,7 @@
         const stored = localStorage.getItem('xswatch-theme');
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         const theme = stored || (prefersDark ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', theme);
         document.documentElement.setAttribute('data-bs-theme', theme);
     })();
     </script>
@@ -36,6 +37,7 @@
 
     <title><{if isset($xoops_dirname) && $xoops_dirname == "system"}><{$xoops_sitename}><{if !empty($xoops_pagetitle)}> - <{$xoops_pagetitle}><{/if}><{else}><{if !empty($xoops_pagetitle)}><{$xoops_pagetitle}> - <{$xoops_sitename}><{/if}><{/if}></title>
     <{$xoops_module_header|default:''}>
+    <link rel="stylesheet" type="text/css" href="<{$xoops_imageurl}>css/dark-mode.css">
 </head>
 <body class="site-closed-body">
 <div class="container">

--- a/htdocs/themes/xswatch5/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/xswatch5/modules/system/system_siteclosed.tpl
@@ -18,7 +18,8 @@
 
     <script>
     (function() {
-        const stored = localStorage.getItem('xswatch-theme');
+        let stored = null;
+        try { stored = localStorage.getItem('xswatch-theme'); } catch (e) {}
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         const theme = stored || (prefersDark ? 'dark' : 'light');
         document.documentElement.setAttribute('data-theme', theme);

--- a/htdocs/themes/xswatch5/theme.tpl
+++ b/htdocs/themes/xswatch5/theme.tpl
@@ -27,13 +27,14 @@
     <{* Color mode + variant: localStorage > OS preference > server default *}>
     <script>
     (function() {
-        const stored = localStorage.getItem('xswatch-theme');
+        var safeGet = function(key) { try { return localStorage.getItem(key); } catch (e) { return null; } };
+        const stored = safeGet('xswatch-theme');
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         const theme = stored || (prefersDark ? 'dark' : 'light');
         document.documentElement.setAttribute('data-theme', theme);
         document.documentElement.setAttribute('data-bs-theme', theme);
 
-        const savedVariant = localStorage.getItem('xswatch-variant');
+        const savedVariant = safeGet('xswatch-variant');
         if (savedVariant) {
             const base = document.getElementById('xswatch-bootstrap-css').href.replace(/css-[^/]+/, savedVariant);
             document.getElementById('xswatch-bootstrap-css').href = base;

--- a/htdocs/themes/xswatch5/theme.tpl
+++ b/htdocs/themes/xswatch5/theme.tpl
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="<{$xoops_langcode}>" dir="<{$xoops_text_direction|default:'ltr'}>">
+<html lang="<{$xoops_langcode}>" dir="<{$xoops_text_direction|default:'ltr'}>" data-theme="light" data-bs-theme="light">
 <head>
 <{assign var=theme_name value=$xoTheme->folderName}>
     <meta charset="<{$xoops_charset}>">
@@ -30,6 +30,7 @@
         const stored = localStorage.getItem('xswatch-theme');
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         const theme = stored || (prefersDark ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-theme', theme);
         document.documentElement.setAttribute('data-bs-theme', theme);
 
         const savedVariant = localStorage.getItem('xswatch-variant');
@@ -54,6 +55,7 @@
 
 <{$xoops_module_header}>
     <link rel="stylesheet" type="text/css" media="all" href="<{$xoops_themecss}>">
+    <link rel="stylesheet" type="text/css" href="<{xoImgUrl}>css/dark-mode.css">
 </head>
 
 <body id="<{$xoops_dirname}>">

--- a/htdocs/themes/xswatch5/tpl/nav-menu.tpl
+++ b/htdocs/themes/xswatch5/tpl/nav-menu.tpl
@@ -184,6 +184,7 @@ function xswatchToggleTheme() {
     const html = document.documentElement;
     const current = html.getAttribute('data-bs-theme');
     const next = current === 'dark' ? 'light' : 'dark';
+    html.setAttribute('data-theme', next);
     html.setAttribute('data-bs-theme', next);
     localStorage.setItem('xswatch-theme', next);
     xswatchUpdateModeUI(next);

--- a/htdocs/themes/xswatch5/tpl/nav-menu.tpl
+++ b/htdocs/themes/xswatch5/tpl/nav-menu.tpl
@@ -180,13 +180,16 @@ function xswatchUpdateModeUI(mode) {
     }
 }
 
+function xswatchSafeSet(key, value) { try { localStorage.setItem(key, value); } catch (e) {} }
+function xswatchSafeGet(key) { try { return localStorage.getItem(key); } catch (e) { return null; } }
+
 function xswatchToggleTheme() {
     const html = document.documentElement;
     const current = html.getAttribute('data-bs-theme');
     const next = current === 'dark' ? 'light' : 'dark';
     html.setAttribute('data-theme', next);
     html.setAttribute('data-bs-theme', next);
-    localStorage.setItem('xswatch-theme', next);
+    xswatchSafeSet('xswatch-theme', next);
     xswatchUpdateModeUI(next);
 }
 
@@ -197,7 +200,7 @@ function xswatchSwitchVariant(variant) {
     if (bsCss) { bsCss.href = bsCss.href.replace(/css-[^/]+/, variant); }
     if (xoCss) { xoCss.href = xoCss.href.replace(/css-[^/]+/, variant); }
     if (ccCss) { ccCss.href = ccCss.href.replace(/css-[^/]+/, variant); }
-    localStorage.setItem('xswatch-variant', variant);
+    xswatchSafeSet('xswatch-variant', variant);
     xswatchHighlightActiveVariant(variant);
 }
 
@@ -224,7 +227,7 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    const currentVariant = localStorage.getItem('xswatch-variant')
+    const currentVariant = xswatchSafeGet('xswatch-variant')
         || document.getElementById('xswatch-bootstrap-css').href.match(/css-[^/]+/)?.[0]
         || 'css-cerulean';
     xswatchHighlightActiveVariant(currentVariant);

--- a/htdocs/themes/xtailwind2/css/dark-mode.css
+++ b/htdocs/themes/xtailwind2/css/dark-mode.css
@@ -1,0 +1,114 @@
+/*
+ * Dark-mode compatibility for XOOPS legacy module output.
+ * Loaded after module CSS so xtailwind2 dark palettes override hard-coded light controls.
+ */
+
+:where(
+    [data-theme="noctis"],
+    [data-theme="velvet"],
+    [data-theme="graphite"]
+) {
+    color-scheme: dark;
+}
+
+:where(
+    [data-theme="noctis"],
+    [data-theme="velvet"],
+    [data-theme="graphite"]
+) :where(
+    input:not([type="button"]):not([type="submit"]):not([type="reset"]):not([type="checkbox"]):not([type="radio"]),
+    select,
+    textarea,
+    .form-control,
+    .form-select,
+    .custom-select
+) {
+    background-color: hsl(var(--b1));
+    color: hsl(var(--bc));
+    border: 1px solid hsl(var(--b3));
+    border-radius: 0.75rem;
+    box-shadow: none;
+}
+
+:where(
+    [data-theme="noctis"],
+    [data-theme="velvet"],
+    [data-theme="graphite"]
+) :where(select[size], select[multiple]) {
+    background-color: hsl(var(--b1));
+}
+
+:where(
+    [data-theme="noctis"],
+    [data-theme="velvet"],
+    [data-theme="graphite"]
+) :where(option, optgroup) {
+    background-color: hsl(var(--b1));
+    color: hsl(var(--bc));
+}
+
+:where(
+    [data-theme="noctis"],
+    [data-theme="velvet"],
+    [data-theme="graphite"]
+) :where(input::placeholder, textarea::placeholder, .form-control::placeholder) {
+    color: hsl(var(--bc) / 0.52);
+    opacity: 1;
+}
+
+.xoops-content :where(
+    .outer,
+    .inner,
+    .head,
+    .even,
+    .odd,
+    .foot,
+    .item,
+    .newbb-thread,
+    .newbb-user-data,
+    .newbb-message-area,
+    .newbb-links,
+    .pagenav
+) {
+    border-color: hsl(var(--b3) / 0.8);
+    color: hsl(var(--bc));
+}
+
+.xoops-content :where(
+    .outer,
+    .inner,
+    .item,
+    .newbb-thread,
+    .newbb-user-data,
+    .newbb-message-area,
+    .newbb-links,
+    .pagenav
+) {
+    background-color: hsl(var(--b1) / 0.78);
+}
+
+.xoops-content :where(.head, .foot, .newbb-forum-title) {
+    background-color: hsl(var(--b2) / 0.82);
+    color: hsl(var(--bc));
+}
+
+.xoops-content :where(.newbb-thread) {
+    margin-bottom: 1.25rem;
+    overflow: hidden;
+    border-width: 1px;
+    border-radius: 1.25rem;
+}
+
+.xoops-content :where(.newbb-user-data, .newbb-message-area) {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+}
+
+.xoops-content :where(.newbb-message-area p, .newbb-message-area li, .newbb-message-area div) {
+    color: hsl(var(--bc) / 0.88);
+}
+
+.xoops-content :where(.newbb-user-signature, .newbb-thread-attachment) {
+    border-top: 1px solid hsl(var(--b3) / 0.75);
+    color: hsl(var(--bc) / 0.68);
+}

--- a/htdocs/themes/xtailwind2/css/dark-mode.css
+++ b/htdocs/themes/xtailwind2/css/dark-mode.css
@@ -56,7 +56,7 @@
     opacity: 1;
 }
 
-.xoops-content :where(
+:where([data-theme="noctis"], [data-theme="velvet"], [data-theme="graphite"]) .xoops-content :where(
     .outer,
     .inner,
     .head,
@@ -74,7 +74,7 @@
     color: hsl(var(--bc));
 }
 
-.xoops-content :where(
+:where([data-theme="noctis"], [data-theme="velvet"], [data-theme="graphite"]) .xoops-content :where(
     .outer,
     .inner,
     .item,
@@ -87,28 +87,28 @@
     background-color: hsl(var(--b1) / 0.78);
 }
 
-.xoops-content :where(.head, .foot, .newbb-forum-title) {
+:where([data-theme="noctis"], [data-theme="velvet"], [data-theme="graphite"]) .xoops-content :where(.head, .foot, .newbb-forum-title) {
     background-color: hsl(var(--b2) / 0.82);
     color: hsl(var(--bc));
 }
 
-.xoops-content :where(.newbb-thread) {
+:where([data-theme="noctis"], [data-theme="velvet"], [data-theme="graphite"]) .xoops-content :where(.newbb-thread) {
     margin-bottom: 1.25rem;
     overflow: hidden;
     border-width: 1px;
     border-radius: 1.25rem;
 }
 
-.xoops-content :where(.newbb-user-data, .newbb-message-area) {
+:where([data-theme="noctis"], [data-theme="velvet"], [data-theme="graphite"]) .xoops-content :where(.newbb-user-data, .newbb-message-area) {
     padding-top: 1rem;
     padding-bottom: 1rem;
 }
 
-.xoops-content :where(.newbb-message-area p, .newbb-message-area li, .newbb-message-area div) {
+:where([data-theme="noctis"], [data-theme="velvet"], [data-theme="graphite"]) .xoops-content :where(.newbb-message-area p, .newbb-message-area li, .newbb-message-area div) {
     color: hsl(var(--bc) / 0.88);
 }
 
-.xoops-content :where(.newbb-user-signature, .newbb-thread-attachment) {
+:where([data-theme="noctis"], [data-theme="velvet"], [data-theme="graphite"]) .xoops-content :where(.newbb-user-signature, .newbb-thread-attachment) {
     border-top: 1px solid hsl(var(--b3) / 0.75);
     color: hsl(var(--bc) / 0.68);
 }

--- a/htdocs/themes/xtailwind2/modules/system/system_popup_header.tpl
+++ b/htdocs/themes/xtailwind2/modules/system/system_popup_header.tpl
@@ -6,7 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script>
         (function() {
-            var stored = localStorage.getItem('xtailwind2-theme');
+            var stored = null;
+            try { stored = localStorage.getItem('xtailwind2-theme'); } catch (e) {}
             var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
             var theme = stored || (prefersDark ? 'noctis' : 'atelier');
             document.documentElement.setAttribute('data-theme', theme);

--- a/htdocs/themes/xtailwind2/modules/system/system_popup_header.tpl
+++ b/htdocs/themes/xtailwind2/modules/system/system_popup_header.tpl
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="<{$xoops_langcode}>" dir="<{$xoops_text_direction|default:'ltr'}>" data-theme="atelier">
+<head>
+    <meta charset="<{$xoops_charset}>">
+    <meta name="robots" content="noindex, nofollow">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script>
+        (function() {
+            var stored = localStorage.getItem('xtailwind2-theme');
+            var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            var theme = stored || (prefersDark ? 'noctis' : 'atelier');
+            document.documentElement.setAttribute('data-theme', theme);
+        })();
+    </script>
+    <title><{$xoops_sitename|escape:'html':'UTF-8'}></title>
+    <{section name=item loop=$headItems}>
+        <{$headItems[item]}>
+    <{/section}>
+    <link rel="stylesheet" type="text/css" href="<{$themeUrl}>css/styles.css">
+    <link rel="stylesheet" type="text/css" media="all" href="<{$xoops_themecss}>">
+    <link rel="stylesheet" type="text/css" href="<{$themeUrl}>css/dark-mode.css">
+    <script src="<{$xoops_url}>/browse.php?Frameworks/jquery/jquery.js"></script>
+
+    <{if $closeHead|default:false}>
+</head>
+<body class="min-h-screen bg-base-100 p-4 text-base-content antialiased">
+<{/if}>

--- a/htdocs/themes/xtailwind2/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/xtailwind2/modules/system/system_siteclosed.tpl
@@ -9,7 +9,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script>
         (function() {
-            var stored = localStorage.getItem('xtailwind2-theme');
+            var stored = null;
+            try { stored = localStorage.getItem('xtailwind2-theme'); } catch (e) {}
             var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
             var theme = stored || (prefersDark ? 'noctis' : 'atelier');
             document.documentElement.setAttribute('data-theme', theme);

--- a/htdocs/themes/xtailwind2/modules/system/system_siteclosed.tpl
+++ b/htdocs/themes/xtailwind2/modules/system/system_siteclosed.tpl
@@ -1,0 +1,65 @@
+<!doctype html>
+<html class="no-js" lang="<{$xoops_langcode}>" dir="<{$xoops_text_direction|default:'ltr'}>" data-theme="atelier">
+<head>
+    <meta charset="<{$xoops_charset}>">
+    <meta name="keywords" content="<{$xoops_meta_keywords}>">
+    <meta name="description" content="<{$xoops_meta_description}>">
+    <meta name="robots" content="<{$xoops_meta_robots}>">
+    <meta name="generator" content="XOOPS">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>
+        (function() {
+            var stored = localStorage.getItem('xtailwind2-theme');
+            var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            var theme = stored || (prefersDark ? 'noctis' : 'atelier');
+            document.documentElement.setAttribute('data-theme', theme);
+        })();
+    </script>
+    <link href="<{$xoops_url}>/favicon.ico" rel="shortcut icon">
+    <link rel="stylesheet" type="text/css" href="<{$xoops_imageurl}>css/styles.css">
+    <link rel="stylesheet" type="text/css" media="all" href="<{$xoops_themecss}>">
+    <script src="<{$xoops_url}>/browse.php?Frameworks/jquery/jquery.js"></script>
+    <link rel="alternate" type="application/rss+xml" title="" href="<{xoAppUrl 'backend.php'}>">
+    <title><{if $xoops_dirname == "system"}><{$xoops_sitename}><{if !empty($xoops_pagetitle)}> - <{$xoops_pagetitle}><{/if}><{else}><{if !empty($xoops_pagetitle)}><{$xoops_pagetitle}> - <{$xoops_sitename}><{/if}><{/if}></title>
+    <{$xoops_module_header|default:''}>
+    <link rel="stylesheet" type="text/css" href="<{$xoops_imageurl}>css/dark-mode.css">
+</head>
+
+<body id="siteclosed" class="min-h-screen bg-base-100 text-base-content antialiased">
+<div class="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+    <div class="absolute left-[-12rem] top-[-10rem] h-[28rem] w-[28rem] rounded-full bg-primary/12 blur-3xl"></div>
+    <div class="absolute right-[-8rem] bottom-[-10rem] h-[24rem] w-[24rem] rounded-full bg-secondary/12 blur-3xl"></div>
+</div>
+
+<main class="flex min-h-screen items-center justify-center px-4 py-10">
+    <div class="card w-full max-w-md border border-base-300 bg-base-200/60 shadow-xl backdrop-blur">
+        <div class="card-body gap-5">
+            <h1 class="text-center text-xl font-semibold"><{$xoops_sitename|escape:'html':'UTF-8'}></h1>
+
+            <div class="alert alert-warning text-sm">
+                <span><{$lang_siteclosemsg}></span>
+            </div>
+
+            <form action="<{xoAppUrl 'user.php'}>" method="post" class="space-y-4">
+                <label class="form-control w-full">
+                    <span class="label-text"><{$lang_username}></span>
+                    <input type="text" name="uname" class="input input-bordered w-full" placeholder="<{$lang_username}>">
+                </label>
+
+                <label class="form-control w-full">
+                    <span class="label-text"><{$lang_password}></span>
+                    <input type="password" name="pass" class="input input-bordered w-full" placeholder="<{$lang_password}>">
+                </label>
+
+                <input type="hidden" name="xoops_redirect" value="<{$xoops_requesturi}>">
+                <input type="hidden" name="xoops_login" value="1">
+
+                <div class="pt-2">
+                    <button type="submit" class="btn btn-primary w-full"><{$lang_login}></button>
+                </div>
+            </form>
+        </div>
+    </div>
+</main>
+</body>
+</html>

--- a/htdocs/themes/xtailwind2/theme.tpl
+++ b/htdocs/themes/xtailwind2/theme.tpl
@@ -31,6 +31,7 @@
 
 <{$xoops_module_header}>
     <link rel="stylesheet" type="text/css" media="all" href="<{$xoops_themecss}>">
+    <link rel="stylesheet" type="text/css" href="<{xoImgUrl 'css/dark-mode.css'}>">
 </head>
 
 <body id="<{$xoops_dirname}>" class="min-h-screen text-base-content antialiased">

--- a/htdocs/themes/xtailwind2/theme.tpl
+++ b/htdocs/themes/xtailwind2/theme.tpl
@@ -17,7 +17,8 @@
 
     <script>
     (function() {
-        const stored = localStorage.getItem('xtailwind2-theme');
+        let stored = null;
+        try { stored = localStorage.getItem('xtailwind2-theme'); } catch (e) {}
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         const theme = stored || (prefersDark ? 'noctis' : 'atelier');
         document.documentElement.setAttribute('data-theme', theme);
@@ -179,10 +180,13 @@ function xtailwind2CurrentMode() {
     return XTAILWIND2_THEME_MODES[xtailwind2CurrentTheme()] || 'light';
 }
 
+function xtailwind2SafeSet(key, value) { try { localStorage.setItem(key, value); } catch (e) {} }
+function xtailwind2SafeGet(key) { try { return localStorage.getItem(key); } catch (e) { return null; } }
+
 function xtailwind2RememberTheme(theme) {
-    localStorage.setItem('xtailwind2-theme', theme);
+    xtailwind2SafeSet('xtailwind2-theme', theme);
     const mode = XTAILWIND2_THEME_MODES[theme] || 'light';
-    localStorage.setItem('xtailwind2-' + mode + '-theme', theme);
+    xtailwind2SafeSet('xtailwind2-' + mode + '-theme', theme);
 }
 
 function xtailwind2SetTheme(theme) {
@@ -195,7 +199,7 @@ function xtailwind2ToggleMode() {
     const currentMode = xtailwind2CurrentMode();
     const nextMode = currentMode === 'dark' ? 'light' : 'dark';
     const fallback = nextMode === 'dark' ? 'noctis' : 'atelier';
-    const nextTheme = localStorage.getItem('xtailwind2-' + nextMode + '-theme') || fallback;
+    const nextTheme = xtailwind2SafeGet('xtailwind2-' + nextMode + '-theme') || fallback;
     xtailwind2SetTheme(nextTheme);
 }
 


### PR DESCRIPTION
1. feat(themes): Bootstrap-native dark mode for xbootstrap5/xswatch5 and palette-aware
   dark mode for xtailwind2 — data-bs-theme kept in sync with data-theme, an early
   no-FOUC script, and a per-theme css/dark-mode.css loaded last (no rebuild). System
   popup + site-closed overlays updated for all three themes so admin overlays follow
   the selected mode/palette.
2. feat(system): a preload registering the bundled xoops/smartyextensions catalogue
   (#97) on every Smarty template via core.class.template.new — class_exists-guarded
   and try/catch-wrapped so it can never white-screen. RayDebugExtension omitted
   (duplicates core Ray plugins).

dark-mode.css is duplicated across xbootstrap5/xswatch5 by design — XOOPS themes are
self-contained. A separate BS5 "comment view options" feature (THEME_COMMENT_OPTIONS +
system_comments_controls.tpl) is intentionally out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dark mode now available with automatic system color scheme detection
  * User theme preferences are saved and restored across sessions

* **Style**
  * Comprehensive dark mode styling applied consistently across all themes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->