### PR TITLE
Security: medium-tier hardening pass (pass 2)

### DIFF
--- a/htdocs/class/captcha/image/scripts/image.php
+++ b/htdocs/class/captcha/image/scripts/image.php
@@ -67,9 +67,10 @@ class XoopsCaptchaImageHandler
 
         if ($this->mode === 'bmp') {
             $this->config['num_chars'] = 4;
-            $this->code                = mt_rand(10 ** ($this->config['num_chars'] - 1), (int)str_pad('9', $this->config['num_chars'], '9'));
+            $this->code                = random_int(10 ** ($this->config['num_chars'] - 1), (int)str_pad('9', $this->config['num_chars'], '9'));
         } else {
-            $raw_code = md5(uniqid(mt_rand(), true));
+            // CSPRNG hex challenge string (was md5(uniqid(mt_rand()))); SECURITY.md M-15.
+            $raw_code = bin2hex(random_bytes(16));
             if (!empty($this->config['skip_characters'])) {
                 $valid_code = str_replace($this->config['skip_characters'], '', $raw_code);
                 $this->code = substr($valid_code, 0, $this->config['num_chars']);

--- a/htdocs/class/captcha/text.php
+++ b/htdocs/class/captcha/text.php
@@ -65,8 +65,9 @@ class XoopsCaptchaText extends XoopsCaptchaMethod
 
     protected function buildQuestion()
     {
-        $val_a = mt_rand(0, 9);
-        $val_b = mt_rand(0, 9);
+        // CSPRNG for the challenge operands (SECURITY.md M-15).
+        $val_a = random_int(0, 9);
+        $val_b = random_int(0, 9);
         if ($val_a > $val_b) {
             $expression = "{$val_a} - {$val_b} = ?";
             $this->code = $val_a - $val_b;

--- a/htdocs/class/textsanitizer/iframe/iframe.php
+++ b/htdocs/class/textsanitizer/iframe/iframe.php
@@ -30,7 +30,11 @@ class MytsIframe extends MyTextSanitizerExtension
      */
     public function load(MyTextSanitizer $myts)
     {
-        $myts->patterns[]     = "/\[iframe=(['\"]?)([^\"']*)\\1]([^\"]*)\[\/iframe\]/sU";
+        // The src (group 3) is rendered into a single-quoted src='...' attribute, so
+        // it must exclude BOTH quote types and angle brackets — otherwise a ' breaks
+        // out of the attribute and can inject markup (SECURITY.md M-7). The height
+        // (group 2) already excludes quotes.
+        $myts->patterns[]     = "/\[iframe=(['\"]?)([^\"']*)\\1]([^\"'<>]*)\[\/iframe\]/sU";
         $myts->replacements[] = "<iframe src='\\3' width='100%' height='\\2' scrolling='auto' frameborder='yes' marginwidth='0' marginheight='0' noresize></iframe>";
 
         return true;

--- a/htdocs/class/textsanitizer/iframe/iframe.php
+++ b/htdocs/class/textsanitizer/iframe/iframe.php
@@ -30,11 +30,12 @@ class MytsIframe extends MyTextSanitizerExtension
      */
     public function load(MyTextSanitizer $myts)
     {
-        // The src (group 3) is rendered into a single-quoted src='...' attribute, so
-        // it must exclude BOTH quote types and angle brackets — otherwise a ' breaks
-        // out of the attribute and can inject markup (SECURITY.md M-7). The height
-        // (group 2) already excludes quotes.
-        $myts->patterns[]     = "/\[iframe=(['\"]?)([^\"']*)\\1]([^\"'<>]*)\[\/iframe\]/sU";
+        // The src (group 3) is rendered into a single-quoted src='...' attribute and
+        // must (a) exclude both quote types and angle brackets so a ' cannot break out
+        // of the attribute (SECURITY.md M-7), and (b) start with http://, https://, or
+        // a protocol-relative // — otherwise a javascript:/data: URI would execute in
+        // the page context. The height (group 2) already excludes quotes.
+        $myts->patterns[]     = "/\[iframe=(['\"]?)([^\"']*)\\1]((?:https?:\/\/|\/\/)[^\"'<>]*)\[\/iframe\]/sU";
         $myts->replacements[] = "<iframe src='\\3' width='100%' height='\\2' scrolling='auto' frameborder='yes' marginwidth='0' marginheight='0' noresize></iframe>";
 
         return true;

--- a/htdocs/class/xoopshttpget.php
+++ b/htdocs/class/xoopshttpget.php
@@ -72,7 +72,7 @@ class XoopsHttpGet
     protected function resolveAllowed(string $url): ?array
     {
         $parts = parse_url($url);
-        if (!is_array($parts) || !isset($parts['scheme'], $parts['host'])) {
+        if ($parts === false || !isset($parts['scheme'], $parts['host'])) {
             return null;
         }
         $scheme = strtolower($parts['scheme']);

--- a/htdocs/class/xoopshttpget.php
+++ b/htdocs/class/xoopshttpget.php
@@ -184,18 +184,43 @@ class XoopsHttpGet
     }
 
     /**
-     * Use stream wrapper to GET the specified URL. Redirect following is disabled so a
-     * 30x cannot send the request to an internal target (the fopen path cannot pin the
-     * resolved IP the way the curl path does).
+     * Use stream wrapper to GET the specified URL. The request is sent to the IP that
+     * resolveAllowed() just validated (host rewritten to the pinned IP, Host header and
+     * TLS peer_name kept as the original host), so the stream wrapper cannot re-resolve
+     * to an internal address (DNS rebinding). Redirects are disabled (SECURITY.md M-5).
      *
      * @return string|false response or false on error
      */
     protected function fetchFopen()
     {
+        $url = (string) $this->url;
+        $pin = $this->resolveAllowed($url);
+        if ($pin === null) {
+            $this->error = 'URL rejected: only public http(s) targets are allowed.';
+            return false;
+        }
+        $parts  = parse_url($url);
+        $scheme = strtolower((string) ($parts['scheme'] ?? 'http'));
+        $ipHost = str_contains($pin['ip'], ':') ? '[' . $pin['ip'] . ']' : $pin['ip'];
+        $target = $scheme . '://' . $ipHost . ':' . $pin['port']
+            . ($parts['path'] ?? '/')
+            . (isset($parts['query']) ? '?' . $parts['query'] : '');
+
         $context  = stream_context_create([
-            'http' => ['follow_location' => 0, 'max_redirects' => 0, 'timeout' => 10],
+            'http' => [
+                'follow_location' => 0,
+                'max_redirects'   => 0,
+                'timeout'         => 10,
+                'header'          => 'Host: ' . $pin['host'],
+            ],
+            'ssl' => [
+                'peer_name'        => $pin['host'], // verify the cert against the real host, not the IP
+                'verify_peer'      => true,
+                'verify_peer_name' => true,
+                'SNI_enabled'      => true,
+            ],
         ]);
-        $response = file_get_contents((string) $this->url, false, $context);
+        $response = file_get_contents($target, false, $context);
         if (false === $response) {
             $this->error = 'file_get_contents() failed.';
         }

--- a/htdocs/class/xoopshttpget.php
+++ b/htdocs/class/xoopshttpget.php
@@ -58,27 +58,33 @@ class XoopsHttpGet
     }
 
     /**
-     * SSRF guard: allow only public http(s) targets (SECURITY.md M-5). Blocks
-     * non-http schemes (file://, php://, gopher://, …), userinfo URLs, and hosts
-     * that resolve to private, loopback, link-local, or reserved addresses.
+     * SSRF guard (SECURITY.md M-5): allow only public http(s) targets. Returns the
+     * validated host/port plus a safe resolved IP to pin the connection to, or null
+     * if the URL must be refused. Blocks non-http schemes (file://, php://, …),
+     * userinfo URLs, and hosts that resolve to private/loopback/link-local/reserved
+     * addresses. Returning the resolved IP lets the caller pin the connection, which
+     * also closes the DNS-rebinding window.
      *
      * @param string $url
      *
-     * @return bool
+     * @return array{host:string,port:int,ip:string}|null
      */
-    protected function isAllowedUrl(string $url): bool
+    protected function resolveAllowed(string $url): ?array
     {
         $parts = parse_url($url);
         if (!is_array($parts) || !isset($parts['scheme'], $parts['host'])) {
-            return false;
+            return null;
         }
-        if (!in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
-            return false;
+        $scheme = strtolower($parts['scheme']);
+        if (!in_array($scheme, ['http', 'https'], true)) {
+            return null;
         }
         if (isset($parts['user']) || isset($parts['pass'])) {
-            return false; // userinfo form can mislead host parsing
+            return null; // userinfo form can mislead host parsing
         }
         $host = $parts['host'];
+        $port = isset($parts['port']) ? (int) $parts['port'] : ($scheme === 'https' ? 443 : 80);
+
         if (filter_var($host, FILTER_VALIDATE_IP)) {
             $ips = [$host];
         } else {
@@ -86,64 +92,110 @@ class XoopsHttpGet
             // warning whose false return we handle immediately (fail closed, R-030).
             $ips = @gethostbynamel($host);
             if ($ips === false || $ips === []) {
-                return false;
+                return null;
             }
         }
+        $safeIp = null;
         foreach ($ips as $ip) {
+            // Reject if ANY resolved address is private/reserved (defeats split-horizon DNS).
             if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
-                return false; // private / loopback / link-local / reserved target
+                return null;
             }
+            if ($safeIp === null) {
+                $safeIp = $ip;
+            }
+        }
+        if ($safeIp === null) {
+            return null;
         }
 
-        return true;
+        return ['host' => $host, 'port' => $port, 'ip' => $safeIp];
     }
 
     /**
-     * Use curl to GET the specified URL.
+     * Thin boolean wrapper around {@see resolveAllowed()} (used by fetch() and tests).
+     *
+     * @param string $url
+     *
+     * @return bool
+     */
+    protected function isAllowedUrl(string $url): bool
+    {
+        return $this->resolveAllowed($url) !== null;
+    }
+
+    /**
+     * Use curl to GET the specified URL. Redirects are followed manually so each hop
+     * is re-validated against the SSRF allowlist and pinned to its resolved IP — an
+     * attacker URL cannot 30x-redirect to 127.0.0.1 / 169.254.169.254 / RFC1918, and
+     * the pin closes the DNS-rebinding window (SECURITY.md M-5).
      *
      * @return string|bool response or false on error
      */
     protected function fetchCurl()
     {
-        $curlHandle = curl_init($this->url);
-        if (false === $curlHandle) {
-            $this->error = 'curl_init failed';
-            return false;
-        }
-        $options = [
-            CURLOPT_RETURNTRANSFER => 1,
-            CURLOPT_HEADER         => 0,
-            CURLOPT_CONNECTTIMEOUT => 10,
-            CURLOPT_FOLLOWLOCATION => 1,
-            CURLOPT_MAXREDIRS      => 4,
-            // Restrict to HTTP(S) so a redirect cannot pivot to file://, gopher://, etc.
-            CURLOPT_PROTOCOLS       => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
-        ];
-        curl_setopt_array($curlHandle, $options);
+        $url       = (string) $this->url;
+        $maxRedirs = 4;
 
-        $response = curl_exec($curlHandle);
-        if (false === $response) {
-            $this->error = curl_error($curlHandle);
-        } else {
-            $httpcode = curl_getinfo($curlHandle, CURLINFO_HTTP_CODE);
-            if (200 != $httpcode) {
-                $this->error = $response;
-                $response = false;
+        for ($hop = 0; $hop <= $maxRedirs; ++$hop) {
+            $pin = $this->resolveAllowed($url);
+            if ($pin === null) {
+                $this->error = 'URL rejected: only public http(s) targets are allowed.';
+                return false;
             }
+            $curlHandle = curl_init($url);
+            if (false === $curlHandle) {
+                $this->error = 'curl_init failed';
+                return false;
+            }
+            curl_setopt_array($curlHandle, [
+                CURLOPT_RETURNTRANSFER => 1,
+                CURLOPT_HEADER         => 0,
+                CURLOPT_CONNECTTIMEOUT => 10,
+                CURLOPT_FOLLOWLOCATION => 0, // follow manually so each hop is re-validated
+                CURLOPT_PROTOCOLS      => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+                // Pin the connection to the address we just validated (no DNS rebinding).
+                CURLOPT_RESOLVE        => [$pin['host'] . ':' . $pin['port'] . ':' . $pin['ip']],
+            ]);
+
+            $response    = curl_exec($curlHandle);
+            $httpcode    = (int) curl_getinfo($curlHandle, CURLINFO_HTTP_CODE);
+            $redirectUrl = (string) curl_getinfo($curlHandle, CURLINFO_REDIRECT_URL);
+            $curlError   = curl_error($curlHandle);
+            curl_close($curlHandle);
+
+            if (false === $response) {
+                $this->error = $curlError;
+                return false;
+            }
+            if ($httpcode >= 300 && $httpcode < 400 && $redirectUrl !== '') {
+                $url = $redirectUrl; // re-validated + re-pinned at the top of the next iteration
+                continue;
+            }
+            if (200 !== $httpcode) {
+                $this->error = $response;
+                return false;
+            }
+            return $response;
         }
-        curl_close($curlHandle);
-        return $response;
+
+        $this->error = 'Too many redirects';
+        return false;
     }
 
     /**
-     * Use stream wrapper to GET the specified URL.
+     * Use stream wrapper to GET the specified URL. Redirect following is disabled so a
+     * 30x cannot send the request to an internal target (the fopen path cannot pin the
+     * resolved IP the way the curl path does).
      *
      * @return string|false response or false on error
      */
     protected function fetchFopen()
     {
-        $response = file_get_contents($this->url);
+        $context  = stream_context_create([
+            'http' => ['follow_location' => 0, 'max_redirects' => 0, 'timeout' => 10],
+        ]);
+        $response = file_get_contents((string) $this->url, false, $context);
         if (false === $response) {
             $this->error = 'file_get_contents() failed.';
         }

--- a/htdocs/class/xoopshttpget.php
+++ b/htdocs/class/xoopshttpget.php
@@ -50,7 +50,52 @@ class XoopsHttpGet
      */
     public function fetch()
     {
+        if (!$this->isAllowedUrl((string) $this->url)) {
+            $this->error = 'URL rejected: only public http(s) targets are allowed.';
+            return false;
+        }
         return ($this->useCurl) ? $this->fetchCurl() : $this->fetchFopen();
+    }
+
+    /**
+     * SSRF guard: allow only public http(s) targets (SECURITY.md M-5). Blocks
+     * non-http schemes (file://, php://, gopher://, …), userinfo URLs, and hosts
+     * that resolve to private, loopback, link-local, or reserved addresses.
+     *
+     * @param string $url
+     *
+     * @return bool
+     */
+    protected function isAllowedUrl(string $url): bool
+    {
+        $parts = parse_url($url);
+        if (!is_array($parts) || !isset($parts['scheme'], $parts['host'])) {
+            return false;
+        }
+        if (!in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
+            return false;
+        }
+        if (isset($parts['user']) || isset($parts['pass'])) {
+            return false; // userinfo form can mislead host parsing
+        }
+        $host = $parts['host'];
+        if (filter_var($host, FILTER_VALIDATE_IP)) {
+            $ips = [$host];
+        } else {
+            // @-suppressed: an unresolvable host emits a benign "host not found"
+            // warning whose false return we handle immediately (fail closed, R-030).
+            $ips = @gethostbynamel($host);
+            if ($ips === false || $ips === []) {
+                return false;
+            }
+        }
+        foreach ($ips as $ip) {
+            if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+                return false; // private / loopback / link-local / reserved target
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -71,6 +116,9 @@ class XoopsHttpGet
             CURLOPT_CONNECTTIMEOUT => 10,
             CURLOPT_FOLLOWLOCATION => 1,
             CURLOPT_MAXREDIRS      => 4,
+            // Restrict to HTTP(S) so a redirect cannot pivot to file://, gopher://, etc.
+            CURLOPT_PROTOCOLS       => CURLPROTO_HTTP | CURLPROTO_HTTPS,
+            CURLOPT_REDIR_PROTOCOLS => CURLPROTO_HTTP | CURLPROTO_HTTPS,
         ];
         curl_setopt_array($curlHandle, $options);
 

--- a/htdocs/class/xoopshttpget.php
+++ b/htdocs/class/xoopshttpget.php
@@ -85,6 +85,11 @@ class XoopsHttpGet
         $host = $parts['host'];
         $port = isset($parts['port']) ? (int) $parts['port'] : ($scheme === 'https' ? 443 : 80);
 
+        // IPv6 literals are intentionally unsupported: parse_url() keeps the [..] brackets,
+        // which fail FILTER_VALIDATE_IP and DNS below, so every IPv6 literal (public or
+        // private) is rejected. This is deliberate — the resolver is IPv4-only, and
+        // reliably classifying private/reserved IPv6 (mapped/loopback/ULA) across the PHP
+        // 8.2 floor is error-prone, so we fail closed rather than risk an SSRF gap.
         if (filter_var($host, FILTER_VALIDATE_IP)) {
             $ips = [$host];
         } else {
@@ -199,19 +204,25 @@ class XoopsHttpGet
             $this->error = 'URL rejected: only public http(s) targets are allowed.';
             return false;
         }
-        $parts  = parse_url($url);
+        $parts  = parse_url($url) ?: [];
         $scheme = strtolower((string) ($parts['scheme'] ?? 'http'));
         $ipHost = str_contains($pin['ip'], ':') ? '[' . $pin['ip'] . ']' : $pin['ip'];
         $target = $scheme . '://' . $ipHost . ':' . $pin['port']
             . ($parts['path'] ?? '/')
             . (isset($parts['query']) ? '?' . $parts['query'] : '');
 
+        // Include the port in the Host header when it is non-default (RFC 7230).
+        $hostHeader = $pin['host'];
+        if (('http' === $scheme && 80 !== $pin['port']) || ('https' === $scheme && 443 !== $pin['port'])) {
+            $hostHeader .= ':' . $pin['port'];
+        }
+
         $context  = stream_context_create([
             'http' => [
                 'follow_location' => 0,
                 'max_redirects'   => 0,
                 'timeout'         => 10,
-                'header'          => 'Host: ' . $pin['host'],
+                'header'          => 'Host: ' . $hostHeader,
             ],
             'ssl' => [
                 'peer_name'        => $pin['host'], // verify the cert against the real host, not the IP

--- a/htdocs/class/xoopssecurity.php
+++ b/htdocs/class/xoopssecurity.php
@@ -187,11 +187,22 @@ class XoopsSecurity
         if ($ref == '') {
             return false;
         }
-        // Compare the referer host exactly. A prefix match (strpos === 0) accepts
-        // sibling hosts such as example.com.attacker.test (SECURITY.md M-3).
-        $refHost  = parse_url($ref, PHP_URL_HOST);
-        $baseHost = parse_url(XOOPS_URL, PHP_URL_HOST);
-        return !empty($refHost) && !empty($baseHost) && strcasecmp((string) $refHost, (string) $baseHost) === 0;
+        // Compare scheme, host, and effective port exactly. A prefix match
+        // (strpos === 0) accepts sibling hosts such as example.com.attacker.test, and a
+        // host-only match would accept http vs https or an alternate port (SECURITY.md L-5).
+        $refParts  = parse_url($ref);
+        $baseParts = parse_url(XOOPS_URL);
+        if (!is_array($refParts) || !is_array($baseParts) || empty($refParts['host']) || empty($baseParts['host'])) {
+            return false;
+        }
+        $refScheme  = strtolower($refParts['scheme'] ?? '');
+        $baseScheme = strtolower($baseParts['scheme'] ?? 'http');
+        $refPort    = (int) ($refParts['port'] ?? ('https' === $refScheme ? 443 : 80));
+        $basePort   = (int) ($baseParts['port'] ?? ('https' === $baseScheme ? 443 : 80));
+
+        return strcasecmp((string) $refParts['host'], (string) $baseParts['host']) === 0
+            && $refScheme === $baseScheme
+            && $refPort === $basePort;
     }
 
     /**

--- a/htdocs/class/xoopssecurity.php
+++ b/htdocs/class/xoopssecurity.php
@@ -60,7 +60,10 @@ class XoopsSecurity
             $expire  = @ini_get('session.gc_maxlifetime');
             $timeout = ($expire > 0) ? $expire : 900;
         }
-        $token_id = md5(uniqid(mt_rand(), true));
+        // CSPRNG token id — the framework-wide CSRF boundary must not rest on
+        // mt_rand()/uniqid() (SECURITY.md M-4). The public token format below is
+        // unchanged for BC; only the entropy source is hardened.
+        $token_id = bin2hex(random_bytes(32));
         // save token data on the server
         if (!isset($_SESSION[$name . '_SESSION'])) {
             $_SESSION[$name . '_SESSION'] = [];
@@ -104,7 +107,7 @@ class XoopsSecurity
         $validFound = false;
         $token_data = &$_SESSION[$name . '_SESSION'];
         foreach (array_keys($token_data) as $i) {
-            if ($token === md5($token_data[$i]['id'] . $_SERVER['HTTP_USER_AGENT'] . XOOPS_DB_PREFIX)) {
+            if (hash_equals(md5($token_data[$i]['id'] . $_SERVER['HTTP_USER_AGENT'] . XOOPS_DB_PREFIX), (string) $token)) {
                 if ($this->filterToken($token_data[$i])) {
                     if ($clearIfValid) {
                         // token should be valid once, so clear it once validated
@@ -184,7 +187,11 @@ class XoopsSecurity
         if ($ref == '') {
             return false;
         }
-        return !(strpos($ref, XOOPS_URL) !== 0);
+        // Compare the referer host exactly. A prefix match (strpos === 0) accepts
+        // sibling hosts such as example.com.attacker.test (SECURITY.md M-3).
+        $refHost  = parse_url($ref, PHP_URL_HOST);
+        $baseHost = parse_url(XOOPS_URL, PHP_URL_HOST);
+        return !empty($refHost) && !empty($baseHost) && strcasecmp((string) $refHost, (string) $baseHost) === 0;
     }
 
     /**

--- a/htdocs/class/xoopssecurity.php
+++ b/htdocs/class/xoopssecurity.php
@@ -192,7 +192,7 @@ class XoopsSecurity
         // host-only match would accept http vs https or an alternate port (SECURITY.md L-5).
         $refParts  = parse_url($ref);
         $baseParts = parse_url(XOOPS_URL);
-        if (!is_array($refParts) || !is_array($baseParts) || empty($refParts['host']) || empty($baseParts['host'])) {
+        if ($refParts === false || $baseParts === false || empty($refParts['host']) || empty($baseParts['host'])) {
             return false;
         }
         $refScheme  = strtolower($refParts['scheme'] ?? '');

--- a/htdocs/image.php
+++ b/htdocs/image.php
@@ -595,7 +595,7 @@ if (ENABLE_IMAGEFILTER && !empty($filter)) {
         'IMG_FILTER_SELECTIVE_BLUR' => [IMG_FILTER_SELECTIVE_BLUR, [0]],
         'IMG_FILTER_MEAN_REMOVAL'   => [IMG_FILTER_MEAN_REMOVAL, [0]],
         'IMG_FILTER_SMOOTH'         => [IMG_FILTER_SMOOTH, [1]],
-        'IMG_FILTER_PIXELATE'       => [IMG_FILTER_PIXELATE, [2]],
+        'IMG_FILTER_PIXELATE'       => [IMG_FILTER_PIXELATE, [1, 2]], // block size required, advanced-mode flag optional
     ];
     $filterSet = (array) $filter;
     foreach ($filterSet as $currentFilter) {

--- a/htdocs/image.php
+++ b/htdocs/image.php
@@ -368,15 +368,28 @@ if (!Request::hasVar('nocache', 'GET') && !Request::hasVar('noservercache', 'GET
 $width = Request::getInt('width', 0, 'GET');
 // height
 $height = Request::getInt('height', 0, 'GET');
-// If either a max width or max height are not specified, we default to something large so the unspecified
-// dimension isn't a constraint on our resized image.
+
+// Hard caps to prevent resource exhaustion via attacker-chosen sizes (SECURITY.md
+// M-14). Reject negative/oversized dimensions before any allocation, and cap the
+// total destination area below.
+$imgMaxDim    = 5000;        // max pixels per side
+$imgMaxPixels = 20000000;    // ~20 MP total destination area
+if ($width < 0 || $width > $imgMaxDim) {
+    $width = 0;
+}
+if ($height < 0 || $height > $imgMaxDim) {
+    $height = 0;
+}
+
+// If either a max width or max height are not specified, we default to the per-side
+// cap so the unspecified dimension isn't a constraint on our resized image.
 // If neither are specified but the color is, we aren't going to be resizing at all, just coloring.
 $max_width = $width;
 $max_height = $height;
 if (!$max_width && $max_height) {
-    $max_width = PHP_INT_MAX;
+    $max_width = $imgMaxDim;   // was PHP_INT_MAX
 } elseif ($max_width && !$max_height) {
-    $max_height = PHP_INT_MAX;
+    $max_height = $imgMaxDim;  // was PHP_INT_MAX
 } elseif (!$max_width && !$max_height) {
     $max_width = $imageWidth;
     $max_height = $imageHeight;
@@ -453,6 +466,12 @@ $quality = Request::getInt('quality', DEFAULT_IMAGE_QUALITY, 'GET') ;
 ini_set('memory_limit', MEMORY_TO_ALLOCATE);
 
 // Set up a blank canvas for our resized image (destination)
+// Final guard before allocation: reject non-positive or over-area destinations so a
+// crafted request cannot drive a huge imagecreatetruecolor() allocation (SECURITY.md M-14).
+if ($tn_width < 1 || $tn_height < 1 || ($tn_width * $tn_height) > $imgMaxPixels) {
+    http_response_code(400);
+    exit();
+}
 $destination_image = imagecreatetruecolor($tn_width, $tn_height);
 
 imagealphablending($destination_image, false);

--- a/htdocs/image.php
+++ b/htdocs/image.php
@@ -577,22 +577,25 @@ if (in_array($imageMimetype, ['image/gif', 'image/png', 'image/webp'])) {
 
 // Imagefilter
 if (ENABLE_IMAGEFILTER && !empty($filter)) {
-    // Allowlist the supported imagefilter constants. NEVER resolve a request-controlled
-    // filter name with constant(): on PHP 8 an unknown constant throws a fatal Error
-    // (DoS), and constant() would also resolve unrelated constants (SECURITY.md M-1).
+    // Allowlist the supported imagefilter constants and their valid extra-argument
+    // arities. NEVER resolve a request-controlled filter name with constant(): on PHP 8
+    // an unknown constant throws a fatal Error (DoS) and constant() would also resolve
+    // unrelated constants (SECURITY.md L-1). Validating the arg count additionally
+    // prevents an ArgumentCountError from a valid filter with wrong arity.
+    // [filterId, [allowed extra-arg counts]]
     $allowedFilters = [
-        'IMG_FILTER_NEGATE'         => IMG_FILTER_NEGATE,
-        'IMG_FILTER_GRAYSCALE'      => IMG_FILTER_GRAYSCALE,
-        'IMG_FILTER_BRIGHTNESS'     => IMG_FILTER_BRIGHTNESS,
-        'IMG_FILTER_CONTRAST'       => IMG_FILTER_CONTRAST,
-        'IMG_FILTER_COLORIZE'       => IMG_FILTER_COLORIZE,
-        'IMG_FILTER_EDGEDETECT'     => IMG_FILTER_EDGEDETECT,
-        'IMG_FILTER_EMBOSS'         => IMG_FILTER_EMBOSS,
-        'IMG_FILTER_GAUSSIAN_BLUR'  => IMG_FILTER_GAUSSIAN_BLUR,
-        'IMG_FILTER_SELECTIVE_BLUR' => IMG_FILTER_SELECTIVE_BLUR,
-        'IMG_FILTER_MEAN_REMOVAL'   => IMG_FILTER_MEAN_REMOVAL,
-        'IMG_FILTER_SMOOTH'         => IMG_FILTER_SMOOTH,
-        'IMG_FILTER_PIXELATE'       => IMG_FILTER_PIXELATE,
+        'IMG_FILTER_NEGATE'         => [IMG_FILTER_NEGATE, [0]],
+        'IMG_FILTER_GRAYSCALE'      => [IMG_FILTER_GRAYSCALE, [0]],
+        'IMG_FILTER_BRIGHTNESS'     => [IMG_FILTER_BRIGHTNESS, [1]],
+        'IMG_FILTER_CONTRAST'       => [IMG_FILTER_CONTRAST, [1]],
+        'IMG_FILTER_COLORIZE'       => [IMG_FILTER_COLORIZE, [3, 4]],
+        'IMG_FILTER_EDGEDETECT'     => [IMG_FILTER_EDGEDETECT, [0]],
+        'IMG_FILTER_EMBOSS'         => [IMG_FILTER_EMBOSS, [0]],
+        'IMG_FILTER_GAUSSIAN_BLUR'  => [IMG_FILTER_GAUSSIAN_BLUR, [0]],
+        'IMG_FILTER_SELECTIVE_BLUR' => [IMG_FILTER_SELECTIVE_BLUR, [0]],
+        'IMG_FILTER_MEAN_REMOVAL'   => [IMG_FILTER_MEAN_REMOVAL, [0]],
+        'IMG_FILTER_SMOOTH'         => [IMG_FILTER_SMOOTH, [1]],
+        'IMG_FILTER_PIXELATE'       => [IMG_FILTER_PIXELATE, [2]],
     ];
     $filterSet = (array) $filter;
     foreach ($filterSet as $currentFilter) {
@@ -601,11 +604,12 @@ if (ENABLE_IMAGEFILTER && !empty($filter)) {
         if (!isset($allowedFilters[$filterName])) {
             continue; // unknown/unsupported filter — skip cleanly, never fatal
         }
-        $filterArgs = [$destination_image, $allowedFilters[$filterName]];
-        foreach ($rawFilterArgs as $tempValue) {
-            $filterArgs[] = (int) trim($tempValue); // imagefilter numeric args
+        [$filterId, $validArgCounts] = $allowedFilters[$filterName];
+        $extraArgs = array_map(static fn($v): int => (int) trim((string) $v), $rawFilterArgs);
+        if (!in_array(count($extraArgs), $validArgCounts, true)) {
+            continue; // wrong arity → skip, avoid ArgumentCountError
         }
-        call_user_func_array('imagefilter', $filterArgs);
+        call_user_func_array('imagefilter', array_merge([$destination_image, $filterId], $extraArgs));
     }
 }
 

--- a/htdocs/image.php
+++ b/htdocs/image.php
@@ -577,19 +577,35 @@ if (in_array($imageMimetype, ['image/gif', 'image/png', 'image/webp'])) {
 
 // Imagefilter
 if (ENABLE_IMAGEFILTER && !empty($filter)) {
+    // Allowlist the supported imagefilter constants. NEVER resolve a request-controlled
+    // filter name with constant(): on PHP 8 an unknown constant throws a fatal Error
+    // (DoS), and constant() would also resolve unrelated constants (SECURITY.md M-1).
+    $allowedFilters = [
+        'IMG_FILTER_NEGATE'         => IMG_FILTER_NEGATE,
+        'IMG_FILTER_GRAYSCALE'      => IMG_FILTER_GRAYSCALE,
+        'IMG_FILTER_BRIGHTNESS'     => IMG_FILTER_BRIGHTNESS,
+        'IMG_FILTER_CONTRAST'       => IMG_FILTER_CONTRAST,
+        'IMG_FILTER_COLORIZE'       => IMG_FILTER_COLORIZE,
+        'IMG_FILTER_EDGEDETECT'     => IMG_FILTER_EDGEDETECT,
+        'IMG_FILTER_EMBOSS'         => IMG_FILTER_EMBOSS,
+        'IMG_FILTER_GAUSSIAN_BLUR'  => IMG_FILTER_GAUSSIAN_BLUR,
+        'IMG_FILTER_SELECTIVE_BLUR' => IMG_FILTER_SELECTIVE_BLUR,
+        'IMG_FILTER_MEAN_REMOVAL'   => IMG_FILTER_MEAN_REMOVAL,
+        'IMG_FILTER_SMOOTH'         => IMG_FILTER_SMOOTH,
+        'IMG_FILTER_PIXELATE'       => IMG_FILTER_PIXELATE,
+    ];
     $filterSet = (array) $filter;
     foreach ($filterSet as $currentFilter) {
-        $rawFilterArgs = explode(',', $currentFilter);
-        $filterConst = constant(array_shift($rawFilterArgs));
-        if (null !== $filterConst) { // skip if unknown constant
-            $filterArgs = [];
-            $filterArgs[] = $destination_image;
-            $filterArgs[] = $filterConst;
-            foreach ($rawFilterArgs as $tempValue) {
-                $filterArgs[] = trim($tempValue);
-            }
-            call_user_func_array('imagefilter', $filterArgs);
+        $rawFilterArgs = explode(',', (string) $currentFilter);
+        $filterName    = trim((string) array_shift($rawFilterArgs));
+        if (!isset($allowedFilters[$filterName])) {
+            continue; // unknown/unsupported filter — skip cleanly, never fatal
         }
+        $filterArgs = [$destination_image, $allowedFilters[$filterName]];
+        foreach ($rawFilterArgs as $tempValue) {
+            $filterArgs[] = (int) trim($tempValue); // imagefilter numeric args
+        }
+        call_user_func_array('imagefilter', $filterArgs);
     }
 }
 

--- a/htdocs/include/comment_view.php
+++ b/htdocs/include/comment_view.php
@@ -189,19 +189,24 @@ if (XOOPS_COMMENT_APPROVENONE != $xoopsModuleConfig['com_rule']) {
         $link_extra = '';
         if (isset($comment_config['extraParams']) && \is_array($comment_config['extraParams'])) {
             foreach ($comment_config['extraParams'] as $extra_param) {
-                if (isset(${$extra_param})) {
-                    $link_extra .= '&amp;' . $extra_param . '=' . ${$extra_param};
-                    $hidden_value    = htmlspecialchars(${$extra_param}, ENT_QUOTES | ENT_HTML5);
-                    $extra_param_val = ${$extra_param};
+                $extra_param_val = null;
+                if (isset($GLOBALS[$extra_param])) {
+                    $extra_param_val = $GLOBALS[$extra_param];
                 } elseif (Request::hasVar($extra_param, 'POST')) {
                     $extra_param_val = Request::getString($extra_param, '', 'POST');
                 } elseif (Request::hasVar($extra_param, 'GET')) {
                     $extra_param_val = Request::getString($extra_param, '', 'GET');
                 }
-                if (isset($extra_param_val)) {
-                    $link_extra .= '&amp;' . $extra_param . '=' . $extra_param_val;
-                    $hidden_value = htmlspecialchars($extra_param_val, ENT_QUOTES | ENT_HTML5);
-                    $commentBarHidden .= '<input type="hidden" name="' . $extra_param . '" value="' . $hidden_value . '" />';
+                if (null !== $extra_param_val) {
+                    $extra_param_val = (string) $extra_param_val;
+                    // The value is concatenated into the onclick JS-string href below
+                    // (a JS string inside an HTML attribute). URL-encode it: htmlspecialchars
+                    // is unsafe here because &#039; would be HTML-decoded back to ' inside
+                    // the attribute and break out of the JS string. (SECURITY.md M-2)
+                    $link_extra .= '&amp;' . $extra_param . '=' . rawurlencode($extra_param_val);
+                    // Hidden-input value is a plain HTML attribute → HTML-escape.
+                    $commentBarHidden .= '<input type="hidden" name="' . $extra_param
+                        . '" value="' . htmlspecialchars($extra_param_val, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" />';
                 }
             }
         }

--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -621,11 +621,13 @@ function xoops_makepass()
         'be',
         'se',
     ];
+    // Use a CSPRNG: generated passwords must not be predictable (SECURITY.md M-3).
+    $syllableCount = count($syllables);
     for ($count = 1; $count <= 4; ++$count) {
-        if (mt_rand() % 10 == 1) {
-            $makepass .= sprintf('%0.0f', (mt_rand() % 50) + 1);
+        if (random_int(0, 9) === 1) {
+            $makepass .= sprintf('%0.0f', random_int(1, 50));
         } else {
-            $makepass .= sprintf('%s', $syllables[mt_rand() % 62]);
+            $makepass .= sprintf('%s', $syllables[random_int(0, $syllableCount - 1)]);
         }
     }
 

--- a/htdocs/modules/system/admin/comments/main.php
+++ b/htdocs/modules/system/admin/comments/main.php
@@ -290,8 +290,18 @@ switch ($op) {
                         $comments_poster_uname = '<a href="' . XOOPS_URL . '/userinfo.php?uid=' . $comments_arr[$i]->getVar('com_uid') . '">' . $poster->getVar('uname') . '</a>';
                     }
                 } elseif ($comments_arr[$i]->getVar('com_uid') == 0 && $comments_arr[$i]->getVar('com_user') != '') {
-                    if ($comments_arr[$i]->getVar('com_url') != '') {
-                        $comments_poster_uname = '<div class="pad2 marg2"><a href="' . $comments_arr[$i]->getVar('com_url') . '">' . $comments_arr[$i]->getVar('com_user') . '</a> ( <a href="mailto:' . $comments_arr[$i]->getVar('com_email') . '">' . $comments_arr[$i]->getVar('com_email') . '</a> ) ' . '</div>';
+                    // Validate the com_url scheme before emitting it as a clickable admin
+                    // link: a stored "javascript:" URL would otherwise become a script link
+                    // in the admin comment list (SECURITY.md M-11). Allow http/https/mailto
+                    // and relative (empty scheme); drop the link otherwise.
+                    $comUrl     = (string) $comments_arr[$i]->getVar('com_url'); // HTML-escaped by getVar('s')
+                    $comScheme  = strtolower((string) parse_url(
+                        html_entity_decode($comUrl, ENT_QUOTES | ENT_HTML5, 'UTF-8'),
+                        PHP_URL_SCHEME
+                    ));
+                    $safeComUrl = in_array($comScheme, ['http', 'https', 'mailto', ''], true) ? $comUrl : '';
+                    if ($safeComUrl !== '') {
+                        $comments_poster_uname = '<div class="pad2 marg2"><a href="' . $safeComUrl . '">' . $comments_arr[$i]->getVar('com_user') . '</a> ( <a href="mailto:' . $comments_arr[$i]->getVar('com_email') . '">' . $comments_arr[$i]->getVar('com_email') . '</a> ) ' . '</div>';
                     } else {
                         $comments_poster_uname = '<div class="pad2 marg2">' . $comments_arr[$i]->getVar('com_user') . ' ( <a href="mailto:' . $comments_arr[$i]->getVar('com_email') . '">' . $comments_arr[$i]->getVar('com_email') . '</a> ) ' . '</div>';
                     }

--- a/htdocs/modules/system/admin/comments/main.php
+++ b/htdocs/modules/system/admin/comments/main.php
@@ -300,9 +300,17 @@ switch ($op) {
                     // resolving a URL (e.g. "\tjavascript:" -> "javascript:"), so strip them
                     // before the scheme check — otherwise a control-char prefix yields an
                     // empty scheme that the allowlist would wrongly permit (SECURITY.md M-11).
-                    $strippedUrl = (string) preg_replace('/[\x00-\x20]+/', '', $decodedUrl);
-                    $comScheme   = strtolower((string) parse_url($strippedUrl, PHP_URL_SCHEME));
-                    $safeComUrl  = in_array($comScheme, ['http', 'https', 'mailto', ''], true) ? $comUrl : '';
+                    // Include \x7F (DEL) per the xoops_isLocalUrl() pattern in file_safety.php.
+                    $strippedUrl  = (string) preg_replace('/[\x00-\x20\x7F]+/', '', $decodedUrl);
+                    $parsedScheme = parse_url($strippedUrl, PHP_URL_SCHEME);
+                    if (false === $parsedScheme) {
+                        // Malformed URL — reject outright rather than letting the
+                        // string cast turn it into an empty (allowed) scheme.
+                        $safeComUrl = '';
+                    } else {
+                        $comScheme  = strtolower((string) $parsedScheme);
+                        $safeComUrl = in_array($comScheme, ['http', 'https', 'mailto', ''], true) ? $comUrl : '';
+                    }
                     if ($safeComUrl !== '') {
                         $comments_poster_uname = '<div class="pad2 marg2"><a href="' . $safeComUrl . '">' . $comments_arr[$i]->getVar('com_user') . '</a> ( <a href="mailto:' . $comments_arr[$i]->getVar('com_email') . '">' . $comments_arr[$i]->getVar('com_email') . '</a> ) ' . '</div>';
                     } else {

--- a/htdocs/modules/system/admin/comments/main.php
+++ b/htdocs/modules/system/admin/comments/main.php
@@ -295,11 +295,14 @@ switch ($op) {
                     // in the admin comment list (SECURITY.md M-11). Allow http/https/mailto
                     // and relative (empty scheme); drop the link otherwise.
                     $comUrl     = (string) $comments_arr[$i]->getVar('com_url'); // HTML-escaped by getVar('s')
-                    $comScheme  = strtolower((string) parse_url(
-                        html_entity_decode($comUrl, ENT_QUOTES | ENT_HTML5, 'UTF-8'),
-                        PHP_URL_SCHEME
-                    ));
-                    $safeComUrl = in_array($comScheme, ['http', 'https', 'mailto', ''], true) ? $comUrl : '';
+                    $decodedUrl = html_entity_decode($comUrl, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                    // Browsers strip leading/embedded whitespace and control chars before
+                    // resolving a URL (e.g. "\tjavascript:" -> "javascript:"), so strip them
+                    // before the scheme check — otherwise a control-char prefix yields an
+                    // empty scheme that the allowlist would wrongly permit (SECURITY.md M-11).
+                    $strippedUrl = (string) preg_replace('/[\x00-\x20]+/', '', $decodedUrl);
+                    $comScheme   = strtolower((string) parse_url($strippedUrl, PHP_URL_SCHEME));
+                    $safeComUrl  = in_array($comScheme, ['http', 'https', 'mailto', ''], true) ? $comUrl : '';
                     if ($safeComUrl !== '') {
                         $comments_poster_uname = '<div class="pad2 marg2"><a href="' . $safeComUrl . '">' . $comments_arr[$i]->getVar('com_user') . '</a> ( <a href="mailto:' . $comments_arr[$i]->getVar('com_email') . '">' . $comments_arr[$i]->getVar('com_email') . '</a> ) ' . '</div>';
                     } else {

--- a/htdocs/modules/system/admin/tplsets/jquery.php
+++ b/htdocs/modules/system/admin/tplsets/jquery.php
@@ -178,8 +178,11 @@ switch ($op) {
         $themesRoot  = realpath(XOOPS_ROOT_PATH . '/themes');
         $resolved    = realpath($restorePath);
 
-        // Strict prefix check to prevent directory traversal
-        $valid_dir = ($resolved !== false && $themesRoot !== false && strpos($resolved, $themesRoot) === 0);
+        // Require root-plus-separator containment, not a bare prefix: strpos(...) === 0
+        // accepts a sibling dir whose path starts with the themes-root string, e.g.
+        // ".../themes-evil/..." (SECURITY.md A2-M-3). Mirrors the tpls_save guard.
+        $valid_dir = ($resolved !== false && $themesRoot !== false
+            && str_starts_with($resolved, $themesRoot . DIRECTORY_SEPARATOR));
 
         $old_file = $resolved . '.back';
         $new_file = $resolved;

--- a/htdocs/modules/system/admin/tplsets/main.php
+++ b/htdocs/modules/system/admin/tplsets/main.php
@@ -371,13 +371,18 @@ switch ($op) {
         }
         $clean_path_file = Request::getString('path_file', '', 'POST');
         if (!empty($clean_path_file)) {
-            $path_file = realpath(XOOPS_ROOT_PATH.'/themes'.trim($clean_path_file));
-            $path_file = str_replace('\\','/',$path_file);
-            // Confine writes to the themes/ tree: realpath() above resolves any ../
-            // traversal in path_file, so reject anything that escapes themes/ — otherwise
-            // the editor can overwrite files anywhere under the XOOPS root (SECURITY.md M-9).
-            $themesRoot = str_replace('\\', '/', (string) realpath(XOOPS_ROOT_PATH . '/themes'));
-            if ($themesRoot === '' || $path_file === '' || !str_starts_with($path_file, $themesRoot . '/')) {
+            // Confine writes to the themes/ tree: realpath() resolves any ../ traversal
+            // in path_file, so reject anything that escapes themes/ — otherwise the editor
+            // can overwrite files anywhere under the XOOPS root (SECURITY.md M-9).
+            $path_file  = realpath(XOOPS_ROOT_PATH . '/themes' . trim($clean_path_file));
+            $themesRoot = realpath(XOOPS_ROOT_PATH . '/themes');
+            if ($path_file === false || $themesRoot === false) {
+                redirect_header('admin.php?fct=tplsets', 3, _AM_SYSTEM_TEMPLATES_ERROR);
+                exit();
+            }
+            $path_file  = str_replace('\\', '/', $path_file);
+            $themesRoot = str_replace('\\', '/', $themesRoot);
+            if (!str_starts_with($path_file, $themesRoot . '/')) {
                 redirect_header('admin.php?fct=tplsets', 3, _AM_SYSTEM_TEMPLATES_ERROR);
                 exit();
             }

--- a/htdocs/modules/system/admin/tplsets/main.php
+++ b/htdocs/modules/system/admin/tplsets/main.php
@@ -373,6 +373,14 @@ switch ($op) {
         if (!empty($clean_path_file)) {
             $path_file = realpath(XOOPS_ROOT_PATH.'/themes'.trim($clean_path_file));
             $path_file = str_replace('\\','/',$path_file);
+            // Confine writes to the themes/ tree: realpath() above resolves any ../
+            // traversal in path_file, so reject anything that escapes themes/ — otherwise
+            // the editor can overwrite files anywhere under the XOOPS root (SECURITY.md M-9).
+            $themesRoot = str_replace('\\', '/', (string) realpath(XOOPS_ROOT_PATH . '/themes'));
+            if ($themesRoot === '' || $path_file === '' || !str_starts_with($path_file, $themesRoot . '/')) {
+                redirect_header('admin.php?fct=tplsets', 3, _AM_SYSTEM_TEMPLATES_ERROR);
+                exit();
+            }
             $pathInfo = pathinfo($path_file);
             if (!in_array($pathInfo['extension'], ['css', 'html', 'tpl'])) {
                 redirect_header('admin.php?fct=tplsets', 2, _AM_SYSTEM_TEMPLATES_ERROR);

--- a/htdocs/modules/system/admin/tplsets/main.php
+++ b/htdocs/modules/system/admin/tplsets/main.php
@@ -105,13 +105,13 @@ switch ($op) {
         $selectModules = Request::getString('select_modules', '0');
         $activeModules = Request::getString('active_modules', '0');
         $selectTheme = Request::getString('select_theme', '');
-        // Confine select_theme to a real installed theme leaf name — a separator or
-        // ../ would let the generate/write paths below (theme_surcharge = themes/<x>/
-        // modules) escape XOOPS_THEME_PATH (SECURITY.md A2-M-2). Validated once here so
-        // every downstream write that derives from $selectTheme is covered.
-        if ($selectTheme !== ''
-            && (!preg_match('/^[a-zA-Z0-9_-]+$/', $selectTheme)
-                || !is_dir(XOOPS_THEME_PATH . '/' . $selectTheme))) {
+        // Confine select_theme to a real installed theme leaf name — a separator, ../, or
+        // an EMPTY value would let the generate/write paths below (theme_surcharge =
+        // themes/<x>/modules) escape XOOPS_THEME_PATH or write to the themes/ root
+        // (SECURITY.md A2-M-2). This generate op always requires a valid theme, so the
+        // check is unconditional ('' fails the `+` regex). Covers every downstream write.
+        if (!preg_match('/^[a-zA-Z0-9_-]+$/', $selectTheme)
+            || !is_dir(XOOPS_THEME_PATH . '/' . $selectTheme)) {
             redirect_header('admin.php?fct=tplsets', 3, _AM_SYSTEM_TEMPLATES_ERROR);
             exit();
         }

--- a/htdocs/modules/system/admin/tplsets/main.php
+++ b/htdocs/modules/system/admin/tplsets/main.php
@@ -105,6 +105,16 @@ switch ($op) {
         $selectModules = Request::getString('select_modules', '0');
         $activeModules = Request::getString('active_modules', '0');
         $selectTheme = Request::getString('select_theme', '');
+        // Confine select_theme to a real installed theme leaf name — a separator or
+        // ../ would let the generate/write paths below (theme_surcharge = themes/<x>/
+        // modules) escape XOOPS_THEME_PATH (SECURITY.md A2-M-2). Validated once here so
+        // every downstream write that derives from $selectTheme is covered.
+        if ($selectTheme !== ''
+            && (!preg_match('/^[a-zA-Z0-9_-]+$/', $selectTheme)
+                || !is_dir(XOOPS_THEME_PATH . '/' . $selectTheme))) {
+            redirect_header('admin.php?fct=tplsets', 3, _AM_SYSTEM_TEMPLATES_ERROR);
+            exit();
+        }
         $forceGenerated = Request::getInt('force_generated', 0);
         if (  '0' === $selectModules ||  '1' === $activeModules) {
             //Generate modules

--- a/htdocs/xoops_lib/modules/protector/class/gtickets.php
+++ b/htdocs/xoops_lib/modules/protector/class/gtickets.php
@@ -200,14 +200,14 @@ if (!class_exists('XoopsGTicket')) {
             foreach ($stubs_tmp as $stub) {
                 // default lifetime 30min
                 if ($stub['expire'] >= time()) {
-                    if (md5($stub['token'] . XOOPS_DB_PREFIX) === $ticket) {
+                    if (hash_equals(md5($stub['token'] . XOOPS_DB_PREFIX), (string) $ticket)) {
                         $found_stub = $stub;
                     } else {
                         // store the other valid stubs into session
                         $_SESSION['XOOPS_G_STUBS'][] = $stub;
                     }
                 } else {
-                    if (md5($stub['token'] . XOOPS_DB_PREFIX) === $ticket) {
+                    if (hash_equals(md5($stub['token'] . XOOPS_DB_PREFIX), (string) $ticket)) {
                         // not CSRF but Time-Out
                         $timeout_flag = true;
                     }

--- a/tests/unit/htdocs/class/IframeBreakoutTest.php
+++ b/tests/unit/htdocs/class/IframeBreakoutTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace xoopsclass;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression test for the iframe BBCode single-quote breakout (SECURITY.md M-7).
+ *
+ * The src capture must exclude both quote types and angle brackets so a ' cannot
+ * break out of the single-quoted src='...' attribute it is rendered into.
+ *
+ * @see \MytsIframe
+ */
+final class IframeBreakoutTest extends TestCase
+{
+    /** The hardened pattern, mirroring MytsIframe::load(). */
+    private const PATTERN = '/\[iframe=([\'"]?)([^"\']*)\1]([^"\'<>]*)\[\/iframe\]/sU';
+
+    #[Test]
+    public function sourcePatternExcludesQuotesAndAngleBracketsFromSrc(): void
+    {
+        $src = (string) file_get_contents(XOOPS_ROOT_PATH . '/class/textsanitizer/iframe/iframe.php');
+        // The src group (3rd capture) must use the [^"'<>] character class.
+        self::assertStringContainsString('([^\\"\'<>]*)', $src, 'iframe src capture is not hardened');
+    }
+
+    #[Test]
+    public function benignIframeStillMatches(): void
+    {
+        $ok = preg_match(self::PATTERN, '[iframe=300]https://example.com/embed[/iframe]', $m);
+        self::assertSame(1, $ok);
+        self::assertSame('https://example.com/embed', $m[3]);
+    }
+
+    #[Test]
+    public function singleQuoteBreakoutNoLongerMatches(): void
+    {
+        // The ' breaks the [^"'<>] class, so the tag no longer matches the closing
+        // [/iframe] and is left as inert text instead of becoming an iframe src.
+        self::assertSame(0, preg_match(self::PATTERN, "[iframe=300]https://x/' onload='alert(1)[/iframe]"));
+    }
+
+    #[Test]
+    public function angleBracketInjectionNoLongerMatches(): void
+    {
+        self::assertSame(0, preg_match(self::PATTERN, '[iframe=300]https://x/"><script>[/iframe]'));
+    }
+}

--- a/tests/unit/htdocs/class/IframeBreakoutTest.php
+++ b/tests/unit/htdocs/class/IframeBreakoutTest.php
@@ -18,14 +18,16 @@ use PHPUnit\Framework\TestCase;
 final class IframeBreakoutTest extends TestCase
 {
     /** The hardened pattern, mirroring MytsIframe::load(). */
-    private const PATTERN = '/\[iframe=([\'"]?)([^"\']*)\1]([^"\'<>]*)\[\/iframe\]/sU';
+    private const PATTERN = '/\[iframe=([\'"]?)([^"\']*)\1]((?:https?:\/\/|\/\/)[^"\'<>]*)\[\/iframe\]/sU';
 
     #[Test]
-    public function sourcePatternExcludesQuotesAndAngleBracketsFromSrc(): void
+    public function sourcePatternHardensSrc(): void
     {
         $src = (string) file_get_contents(XOOPS_ROOT_PATH . '/class/textsanitizer/iframe/iframe.php');
-        // The src group (3rd capture) must use the [^"'<>] character class.
-        self::assertStringContainsString('([^\\"\'<>]*)', $src, 'iframe src capture is not hardened');
+        // The src group (3rd capture) must exclude quotes/angle brackets AND require an
+        // http(s):// or // scheme prefix.
+        self::assertStringContainsString('[^\\"\'<>]*', $src, 'iframe src capture is not quote-hardened');
+        self::assertStringContainsString('(?:https?:\/\/|\/\/)', $src, 'iframe src is not scheme-restricted');
     }
 
     #[Test]
@@ -48,5 +50,21 @@ final class IframeBreakoutTest extends TestCase
     public function angleBracketInjectionNoLongerMatches(): void
     {
         self::assertSame(0, preg_match(self::PATTERN, '[iframe=300]https://x/"><script>[/iframe]'));
+    }
+
+    #[Test]
+    public function dangerousSchemeNoLongerMatches(): void
+    {
+        // javascript:/data: do not start with http(s):// or // → no match → inert text.
+        self::assertSame(0, preg_match(self::PATTERN, '[iframe=300]javascript:alert(1)[/iframe]'));
+        self::assertSame(0, preg_match(self::PATTERN, '[iframe=300]data:text/html,1[/iframe]'));
+    }
+
+    #[Test]
+    public function protocolRelativeSrcStillMatches(): void
+    {
+        $ok = preg_match(self::PATTERN, '[iframe=300]//example.com/embed[/iframe]', $m);
+        self::assertSame(1, $ok);
+        self::assertSame('//example.com/embed', $m[3]);
     }
 }

--- a/tests/unit/htdocs/class/XoopsHttpGetSsrfTest.php
+++ b/tests/unit/htdocs/class/XoopsHttpGetSsrfTest.php
@@ -53,6 +53,14 @@ final class XoopsHttpGetSsrfTest extends TestCase
             'userinfo form'       => ['http://user:pass@example.com/'],
             'scheme-relative'     => ['//example.com/'],
             'no scheme/host'      => ['/relative/path'],
+            // IPv6 literals: parse_url keeps the [..] brackets, which fail FILTER_VALIDATE_IP
+            // and DNS resolution, so these are rejected without relying on the IPv6 coverage
+            // of FILTER_FLAG_NO_PRIV_RANGE / NO_RES_RANGE.
+            'ipv6 loopback'       => ['http://[::1]/'],
+            'ipv6 mapped loopback'=> ['http://[::ffff:127.0.0.1]/'],
+            'ipv6 mapped metadata'=> ['http://[::ffff:169.254.169.254]/'],
+            'ipv6 link-local'     => ['http://[fe80::1]/'],
+            'ipv6 ula private'    => ['http://[fd00::1]/'],
         ];
     }
 

--- a/tests/unit/htdocs/class/XoopsHttpGetSsrfTest.php
+++ b/tests/unit/htdocs/class/XoopsHttpGetSsrfTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace xoopsclass;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use XoopsHttpGet;
+
+require_once XOOPS_ROOT_PATH . '/class/xoopshttpget.php';
+
+/**
+ * Exposes the protected SSRF guard and bypasses the constructor's curl/fopen
+ * requirement (isAllowedUrl() is pure: parse_url + filter_var + DNS).
+ */
+final class HttpGetSsrfProbe extends XoopsHttpGet
+{
+    public function __construct() {} // intentionally skip parent (no transport needed)
+
+    public function allowed(string $url): bool
+    {
+        return $this->isAllowedUrl($url);
+    }
+}
+
+/**
+ * Regression tests for the XoopsHttpGet SSRF guard (SECURITY.md M-5).
+ *
+ * Only rejection cases are asserted — they use literal IPs / schemes and need no
+ * network. The "allowed public host" path depends on live DNS and is not unit-tested.
+ *
+ * @see \XoopsHttpGet
+ */
+final class XoopsHttpGetSsrfTest extends TestCase
+{
+    /**
+     * @return array<string, array{0:string}>
+     */
+    public static function rejectedUrls(): array
+    {
+        return [
+            'file scheme'         => ['file:///etc/passwd'],
+            'php wrapper'         => ['php://filter/resource=/etc/passwd'],
+            'gopher scheme'       => ['gopher://127.0.0.1:6379/'],
+            'loopback ipv4'       => ['http://127.0.0.1/'],
+            'loopback name-ish'   => ['http://127.1/'],
+            'link-local metadata' => ['http://169.254.169.254/latest/meta-data/'],
+            'private 10/8'        => ['http://10.0.0.5/'],
+            'private 172.16/12'   => ['http://172.16.0.1/'],
+            'private 192.168/16'  => ['http://192.168.1.1/'],
+            'userinfo form'       => ['http://user:pass@example.com/'],
+            'scheme-relative'     => ['//example.com/'],
+            'no scheme/host'      => ['/relative/path'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('rejectedUrls')]
+    public function rejectsUnsafeTargets(string $url): void
+    {
+        $probe = new HttpGetSsrfProbe();
+        self::assertFalse($probe->allowed($url), $url . ' must be rejected by the SSRF guard');
+    }
+}

--- a/tests/unit/htdocs/class/XoopsSecurityTest.php
+++ b/tests/unit/htdocs/class/XoopsSecurityTest.php
@@ -145,7 +145,20 @@ class TestableXoopsSecurity extends \XoopsSecurity
         if ($ref == '') {
             return false;
         }
-        return !(strpos($ref, XOOPS_URL) !== 0);
+        // Mirror of the real XoopsSecurity::checkReferer() — exact scheme/host/port compare.
+        $refParts  = parse_url($ref);
+        $baseParts = parse_url(XOOPS_URL);
+        if (!is_array($refParts) || !is_array($baseParts) || empty($refParts['host']) || empty($baseParts['host'])) {
+            return false;
+        }
+        $refScheme  = strtolower($refParts['scheme'] ?? '');
+        $baseScheme = strtolower($baseParts['scheme'] ?? 'http');
+        $refPort    = (int) ($refParts['port'] ?? ('https' === $refScheme ? 443 : 80));
+        $basePort   = (int) ($baseParts['port'] ?? ('https' === $baseScheme ? 443 : 80));
+
+        return strcasecmp((string) $refParts['host'], (string) $baseParts['host']) === 0
+            && $refScheme === $baseScheme
+            && $refPort === $basePort;
     }
 
     public function setErrors($error)
@@ -549,6 +562,27 @@ class XoopsSecurityTest extends TestCase
     public function testCheckRefererReturnsFalseForNonMatchingUrl(): void
     {
         $_SERVER['HTTP_REFERER'] = 'http://evil.example.com/attack.php';
+        $this->assertFalse($this->security->checkReferer(1));
+    }
+
+    public function testCheckRefererRejectsSiblingHostPrefix(): void
+    {
+        // XOOPS_URL is http://localhost; the old strpos()-prefix check accepted this
+        // sibling host, the exact-origin compare must reject it (L-5).
+        $_SERVER['HTTP_REFERER'] = XOOPS_URL . '.attacker.test/attack.php';
+        $this->assertFalse($this->security->checkReferer(1));
+    }
+
+    public function testCheckRefererRejectsSchemeMismatch(): void
+    {
+        // http://localhost vs https://localhost are different origins.
+        $_SERVER['HTTP_REFERER'] = 'https://localhost/modules/test/index.php';
+        $this->assertFalse($this->security->checkReferer(1));
+    }
+
+    public function testCheckRefererRejectsPortMismatch(): void
+    {
+        $_SERVER['HTTP_REFERER'] = 'http://localhost:8080/modules/test/index.php';
         $this->assertFalse($this->security->checkReferer(1));
     }
 

--- a/tests/unit/htdocs/class/XoopsSecurityTest.php
+++ b/tests/unit/htdocs/class/XoopsSecurityTest.php
@@ -148,7 +148,7 @@ class TestableXoopsSecurity extends \XoopsSecurity
         // Mirror of the real XoopsSecurity::checkReferer() — exact scheme/host/port compare.
         $refParts  = parse_url($ref);
         $baseParts = parse_url(XOOPS_URL);
-        if (!is_array($refParts) || !is_array($baseParts) || empty($refParts['host']) || empty($baseParts['host'])) {
+        if ($refParts === false || $baseParts === false || empty($refParts['host']) || empty($baseParts['host'])) {
             return false;
         }
         $refScheme  = strtolower($refParts['scheme'] ?? '');


### PR DESCRIPTION
## Summary

Second hardening pass over the **medium-tier** findings from the security review
(`docs/SECURITY.md`), following the high-tier batch in #92. Each change is an
independently reviewable commit and maps to a finding ID. No new language constants;
public token/URL formats unchanged for backward compatibility.

## Findings addressed

| ID | Area | Change |
|----|------|--------|
| M-2 | comment bar | URL-encode `extraParams` before the inline `onclick` href |
| M-3 | password generation | `random_int()` in `xoops_makepass()` |
| M-4 | request token | `random_bytes(32)` seed + `hash_equals()` validation |
| M-5 | outbound HTTP | `XoopsHttpGet` allows only public `http(s)` targets; curl follows redirects manually with per-hop re-validation; fopen pins the initial request and disables redirects (both pin the validated IP) |
| M-7 | iframe BBCode | exclude quotes/angle-brackets from the captured `src` |
| M-9, A2-M-2, A2-M-3 | template-set editor | confine save / generate / restore under `themes/` |
| M-11 | admin comment list | allowlist the `com_url` scheme |
| M-14, L-1 | image transformer | cap output dimensions/total pixels; allowlist filter names + arity |
| M-15 | CAPTCHA | CSPRNG for the challenge value |
| L-5 | request-origin (referer) check | exact scheme/host/port comparison |
| L-14 | Protector `gtickets` | constant-time ticket comparison |

## Tests

- `XoopsHttpGetSsrfTest` — outbound-request guard rejects non-public targets
- `IframeBreakoutTest` — iframe `src` capture (benign vs. breakout payloads)
- `XoopsSecurityTest` — referer origin (sibling-host / scheme / port) cases

## Not in this PR (tracked follow-ups)

- **H-7** installer lock — a naive guard breaks the mid-install bootstrap write; needs an install-complete signal + a real install test.
- **M-8 / A2-M-7** form-renderer value escaping — escaping the common Bootstrap renderer would double-encode the many `getVar('s')` callers; needs a caller audit first.
- **M-5** Snoopy, **M-14** source pre-decode cap, **M-15** text-mode entropy — residuals noted in `docs/SECURITY.md` Addendum 4.
- **M-6** profile search wildcards — already mitigated by the `Criteria` class's inner-wildcard escaping (no change needed).

Reviewed across two rounds; all actionable feedback addressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security controls for URL handling and image processing
  * Improved input validation for iframe content, file paths, and theme management
  * Strengthened authentication token generation and verification mechanisms
  * Updated CAPTCHA and password generation with improved randomization
  * Refined referer and query parameter validation

* **Tests**
  * Added security regression tests for URL validation and iframe processing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

