### PR TITLE
chore(phpstan): mark gitignored vendor excludePaths as optional

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,7 +20,9 @@ parameters:
             - htdocs/install/
             - htdocs/xoops_lib/vendor/ (?)
     scanFiles:
-        - htdocs/xoops_lib/vendor/kint-php/kint/src/Kint.php
+        # Same vendor tree as above — optional so PHPStan does not error when the
+        # kint dependency is absent (checkouts without `composer install`).
+        - htdocs/xoops_lib/vendor/kint-php/kint/src/Kint.php (?)
     stubFiles:
         - phpstan-constants.stub.php
     treatPhpDocTypesAsCertain: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,12 +10,15 @@ parameters:
     excludePaths:
         analyseAndScan:
             - htdocs/xoops_data/caches
-            - htdocs/class/libraries/vendor/
+            # vendor trees are gitignored / composer-installed, so they are absent in
+            # checkouts that skip `composer install` (e.g. CodeRabbit's PHPStan run).
+            # `(?)` marks the path optional so PHPStan does not error when it is missing.
+            - htdocs/class/libraries/vendor/ (?)
             - tests/
         analyse:
             - htdocs/class/auth/
             - htdocs/install/
-            - htdocs/xoops_lib/vendor/
+            - htdocs/xoops_lib/vendor/ (?)
     scanFiles:
         - htdocs/xoops_lib/vendor/kint-php/kint/src/Kint.php
     stubFiles:


### PR DESCRIPTION
## What

Append ` (?)` to the two **vendor** `excludePaths` entries in `phpstan.neon`:

```neon
- htdocs/class/libraries/vendor/ (?)
- htdocs/xoops_lib/vendor/ (?)
```

## Why

PHPStan 2.x validates `excludePaths` and **errors when an excluded path does not
exist** in the checkout. Both vendor trees are gitignored / composer-installed, so
they are absent wherever PHPStan runs without `composer install` — e.g. CodeRabbit's
PHPStan tool, which then reports:

> Path "/htdocs/class/libraries/vendor" is neither a directory, nor a file path, nor a fnmatch pattern.

`(?)` marks the path **optional** (PHPStan's own recommended fix), so the exclusions
still apply locally and in any composer-installed run, but no longer error when the
dirs are missing.

CI itself does not run PHPStan (only PHPUnit), so this was only visible via external
analysis tools. No behavior change to the analysis when vendor *is* present.

## Summary by Sourcery

Build:
- Update PHPStan configuration to treat vendor directory excludePaths as optional so static analysis does not fail when the directories are missing.