### PR TITLE
chore(coderabbit): align test review instruction with PHPUnit ^11.2

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -45,7 +45,10 @@ reviews:
     - path: "tests/**/*.php"
       instructions: >-
         Review test code for proper assertions, test isolation, and edge
-        case coverage. Tests must work across PHPUnit 9.6, 10, and 11.
+        case coverage. The project pins PHPUnit ^11.2 (see composer/CLAUDE.md)
+        and uses its attribute API throughout (#[Test], #[DataProvider],
+        #[CoversClass]). Do NOT flag those attributes or the absence of a
+        test* method-name prefix as PHPUnit 9.6/10 incompatibilities.
   tools:
     phpcs:
       enabled: true


### PR DESCRIPTION
## What

Update the `tests/**/*.php` `path_instruction` in `.coderabbit.yaml` from
"Tests must work across PHPUnit 9.6, 10, and 11" to point at **PHPUnit `^11.2`**
(the project's pinned version) and explicitly tell CodeRabbit not to flag the
attribute API.

## Why

The old instruction made CodeRabbit repeatedly flag the project's PHPUnit
**attribute API** — `#[Test]`, `#[DataProvider]`, `#[CoversClass]` — and the
absence of a `test*` method-name prefix as "PHPUnit 9.6 incompatibilities".
This is a **false positive**: the project pins PHPUnit `^11.2` (composer /
`CLAUDE.md`) and uses those attributes throughout (`CriteriaTest`,
`XoopsSecurityTest`, the upgrade suite, etc.). The bogus finding has appeared on
three separate PRs, where it had to be dismissed each time.

Aligning the instruction with the real test baseline stops the recurring noise
without weakening any actual test-quality review.

## Summary by Sourcery

CI:
- Adjust CodeRabbit test-review instructions to reflect PHPUnit ^11.2 and prevent false positives related to attribute-based tests and method naming.