### PR TITLE
Security: medium/low defence-in-depth hardening (pass 3)

### DIFF
--- a/htdocs/class/smarty3_plugins/function.xoPageNav.php
+++ b/htdocs/class/smarty3_plugins/function.xoPageNav.php
@@ -42,18 +42,18 @@ function smarty_function_xoPageNav($params, &$smarty)
 
     //TODO Remove this hardcoded strings
     if ($currentPage > 1) {
-        $prevUrl = htmlspecialchars($xoops->url(str_replace('%s', (string) ($offset - $pageSize), $url)), ENT_QUOTES | ENT_HTML5);
+        $prevUrl = htmlspecialchars($xoops->url(str_replace('%s', (string) ($offset - $pageSize), $url)), ENT_QUOTES | ENT_HTML5, 'UTF-8');
         $str .= '<a href="' . $prevUrl . '">Previous</a>';
     }
     for ($i = $minPage; $i <= $maxPage; ++$i) {
-        $tgt = htmlspecialchars($xoops->url(str_replace('%s', ($i - 1) * $pageSize, $url)), ENT_QUOTES | ENT_HTML5);
+        $tgt = htmlspecialchars($xoops->url(str_replace('%s', (string) (($i - 1) * $pageSize), $url)), ENT_QUOTES | ENT_HTML5, 'UTF-8');
         $str .= "<a href='$tgt'>$i</a>";
     }
     if ($currentPage < $lastPage) {
-        $nextUrl = htmlspecialchars($xoops->url(str_replace('%s', (string) ($offset + $pageSize), $url)), ENT_QUOTES | ENT_HTML5);
+        $nextUrl = htmlspecialchars($xoops->url(str_replace('%s', (string) ($offset + $pageSize), $url)), ENT_QUOTES | ENT_HTML5, 'UTF-8');
         $str .= '<a href="' . $nextUrl . '">Next</a>';
     }
-    $class = '' !== $class ? htmlspecialchars($class, ENT_QUOTES | ENT_HTML5) : 'pagenav';
+    $class = '' !== $class ? htmlspecialchars($class, ENT_QUOTES | ENT_HTML5, 'UTF-8') : 'pagenav';
 
     $str = "<div class='{$class}'>{$str}</div>";
 

--- a/htdocs/class/smarty3_plugins/function.xoPageNav.php
+++ b/htdocs/class/smarty3_plugins/function.xoPageNav.php
@@ -19,7 +19,13 @@ function smarty_function_xoPageNav($params, &$smarty)
 {
     global $xoops;
 
-    extract($params);
+    // Read params explicitly rather than expanding them into local scope (R-011).
+    $itemsCount = (int) ($params['itemsCount'] ?? 0);
+    $pageSize   = (int) ($params['pageSize'] ?? 0);
+    $offset     = (int) ($params['offset'] ?? 0);
+    $linksCount = (int) ($params['linksCount'] ?? 5);
+    $url        = (string) ($params['url'] ?? '');
+    $class      = (string) ($params['class'] ?? '');
     if ($pageSize < 1) {
         $pageSize = 10;
     }
@@ -36,16 +42,18 @@ function smarty_function_xoPageNav($params, &$smarty)
 
     //TODO Remove this hardcoded strings
     if ($currentPage > 1) {
-        $str .= '<a href="' . $xoops->url(str_replace('%s', $offset - $pageSize, $url)) . '">Previous</a>';
+        $prevUrl = htmlspecialchars($xoops->url(str_replace('%s', (string) ($offset - $pageSize), $url)), ENT_QUOTES | ENT_HTML5);
+        $str .= '<a href="' . $prevUrl . '">Previous</a>';
     }
     for ($i = $minPage; $i <= $maxPage; ++$i) {
         $tgt = htmlspecialchars($xoops->url(str_replace('%s', ($i - 1) * $pageSize, $url)), ENT_QUOTES | ENT_HTML5);
         $str .= "<a href='$tgt'>$i</a>";
     }
     if ($currentPage < $lastPage) {
-        $str .= '<a href="' . $xoops->url(str_replace('%s', $offset + $pageSize, $url)) . '">Next</a>';
+        $nextUrl = htmlspecialchars($xoops->url(str_replace('%s', (string) ($offset + $pageSize), $url)), ENT_QUOTES | ENT_HTML5);
+        $str .= '<a href="' . $nextUrl . '">Next</a>';
     }
-    $class = @!empty($class) ? htmlspecialchars($class, ENT_QUOTES | ENT_HTML5) : 'pagenav';
+    $class = '' !== $class ? htmlspecialchars($class, ENT_QUOTES | ENT_HTML5) : 'pagenav';
 
     $str = "<div class='{$class}'>{$str}</div>";
 

--- a/htdocs/class/uploader.php
+++ b/htdocs/class/uploader.php
@@ -621,7 +621,7 @@ class XoopsMediaUploader
         }
 
         if ((!empty($this->allowedMimeTypes) && !in_array($this->mediaRealType, $this->allowedMimeTypes)) || (!empty($this->deniedMimeTypes) && in_array($this->mediaRealType, $this->deniedMimeTypes))) {
-            $this->setErrors(sprintf(_ER_UP_MIMETYPENOTALLOWED, htmlspecialchars($this->mediaRealType, ENT_QUOTES | ENT_HTML5)));
+            $this->setErrors(sprintf(_ER_UP_MIMETYPENOTALLOWED, htmlspecialchars($this->mediaRealType, ENT_QUOTES | ENT_HTML5, 'UTF-8')));
 
             return false;
         }

--- a/htdocs/class/uploader.php
+++ b/htdocs/class/uploader.php
@@ -103,13 +103,17 @@ class XoopsMediaUploader
         'php',
         'phtml',
         'phtm',
+        'pht',
         'php3',
         'php4',
+        'php5',
+        'php7',
+        'php8',
+        'phar',
+        'shtml',
         'cgi',
         'pl',
         'asp',
-        'php5',
-        'php7',
     ];
     // extensions needed image check (anti-IE Content-Type XSS)
     public $imageExtensions = [
@@ -586,6 +590,28 @@ class XoopsMediaUploader
             $this->mediaType = 'invalid';
             $this->setErrors(_ER_UP_UNKNOWNFILETYPEREJECTED);
             return false;
+        }
+
+        // Content-sniff the real bytes: a file whose extension or client-supplied
+        // type claims to be an image but whose content is a script/markup document
+        // must be refused regardless of what the browser declared (SECURITY.md M-12).
+        if (is_string($this->mediaTmpName) && '' !== $this->mediaTmpName
+            && is_file($this->mediaTmpName) && class_exists('finfo')) {
+            $finfo    = new \finfo(FILEINFO_MIME_TYPE);
+            $detected = (string) $finfo->file($this->mediaTmpName);
+            $blocked  = [
+                'application/x-httpd-php',
+                'application/x-php',
+                'text/x-php',
+                'application/x-httpd-php-source',
+                'application/x-php-source',
+                'text/html',
+                'application/xhtml+xml',
+            ];
+            if (in_array($detected, $blocked, true)) {
+                $this->setErrors(sprintf(_ER_UP_MIMETYPENOTALLOWED, htmlspecialchars($detected, ENT_QUOTES | ENT_HTML5)));
+                return false;
+            }
         }
 
         if (empty($this->mediaRealType) && empty($this->allowUnknownTypes)) {

--- a/htdocs/class/uploader.php
+++ b/htdocs/class/uploader.php
@@ -609,7 +609,7 @@ class XoopsMediaUploader
                 'application/xhtml+xml',
             ];
             if (in_array($detected, $blocked, true)) {
-                $this->setErrors(sprintf(_ER_UP_MIMETYPENOTALLOWED, htmlspecialchars($detected, ENT_QUOTES | ENT_HTML5)));
+                $this->setErrors(sprintf(_ER_UP_MIMETYPENOTALLOWED, htmlspecialchars($detected, ENT_QUOTES | ENT_HTML5, 'UTF-8')));
                 return false;
             }
         }

--- a/htdocs/class/xoopseditor/tinymce5/tinymce.php
+++ b/htdocs/class/xoopseditor/tinymce5/tinymce.php
@@ -209,8 +209,17 @@ class TinyMCE
 			unset($this->setting['file_browser_callback']);
         }
 
-		// Safely encode all settings to JS object
-		$jsonOptions = json_encode($this->setting, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+		// Safely encode all settings to JS object. JSON_HEX_TAG|APOS|QUOT blocks a
+		// "</script>" / quote breakout from any setting value (SECURITY.md L-8); the
+		// callbacks below are emitted as separate statements, so no raw-JS value is
+		// carried inside this JSON. JSON_THROW_ON_ERROR + safe-comment return (parity
+		// with TinyMCE7) avoids emitting a broken tinymce.init() on encode failure.
+		try {
+			$jsonOptions = json_encode($this->setting, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR);
+		} catch (\JsonException $e) {
+			trigger_error('TinyMCE5 settings JSON encode failed: ' . $e->getMessage(), E_USER_WARNING);
+			return "\n<!-- TinyMCE: failed to encode editor configuration -->\n";
+		}
 
 		// Only include TinyMCE core script once
 		$tinyMceScriptTag = $isTinyMceJsLoaded

--- a/htdocs/class/xoopseditor/tinymce7/TinyMCE.php
+++ b/htdocs/class/xoopseditor/tinymce7/TinyMCE.php
@@ -202,7 +202,7 @@ class TinyMCE
 				}
 			}
 
-			$jsonOptions = json_encode($options, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+			$jsonOptions = json_encode($options, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_THROW_ON_ERROR);
 			if (!empty($rawJsReplacements)) {
 				$jsonOptions = str_replace(array_keys($rawJsReplacements), array_values($rawJsReplacements), $jsonOptions);
 			}

--- a/htdocs/class/xoopssecurity.php
+++ b/htdocs/class/xoopssecurity.php
@@ -262,7 +262,14 @@ class XoopsSecurity
         $ip = $addr->asReadable();
         if ($xoopsConfig['enable_badips'] == 1 && $ip != '0.0.0.0') {
             foreach ($xoopsConfig['bad_ips'] as $bi) {
-                if (!empty($bi) && preg_match('/' . $bi . '/', $ip)) {
+                // Admin-entered patterns: bound the length to avoid pathological
+                // backtracking, and block only on a definite match — a malformed
+                // pattern (preg_match returns false) must not be treated as a hit
+                // nor abort the request (SECURITY.md L-19).
+                if (!is_string($bi) || '' === $bi || strlen($bi) > 255) {
+                    continue;
+                }
+                if (1 === preg_match('/' . $bi . '/', $ip)) {
                     exit();
                 }
             }

--- a/htdocs/class/xoopssecurity.php
+++ b/htdocs/class/xoopssecurity.php
@@ -274,7 +274,6 @@ class XoopsSecurity
                         continue;
                     }
                     if (1 === preg_match('/' . $bi . '/', $ip)) {
-                        restore_error_handler();
                         exit();
                     }
                 }

--- a/htdocs/class/xoopssecurity.php
+++ b/htdocs/class/xoopssecurity.php
@@ -260,7 +260,7 @@ class XoopsSecurity
 
         $addr = IPAddress::fromRequest();
         $ip = $addr->asReadable();
-        if ($xoopsConfig['enable_badips'] == 1 && $ip != '0.0.0.0') {
+        if ($xoopsConfig['enable_badips'] == 1 && $ip != '0.0.0.0' && is_array($xoopsConfig['bad_ips'] ?? null)) {
             // Admin-entered patterns may be malformed (e.g. a CIDR's "/" collides
             // with the delimiter). Swallow the resulting PCRE warning for the scan
             // and treat any non-match — including a compile failure — as "allowed",

--- a/htdocs/class/xoopssecurity.php
+++ b/htdocs/class/xoopssecurity.php
@@ -261,17 +261,25 @@ class XoopsSecurity
         $addr = IPAddress::fromRequest();
         $ip = $addr->asReadable();
         if ($xoopsConfig['enable_badips'] == 1 && $ip != '0.0.0.0') {
-            foreach ($xoopsConfig['bad_ips'] as $bi) {
-                // Admin-entered patterns: bound the length to avoid pathological
-                // backtracking, and block only on a definite match — a malformed
-                // pattern (preg_match returns false) must not be treated as a hit
-                // nor abort the request (SECURITY.md L-19).
-                if (!is_string($bi) || '' === $bi || strlen($bi) > 255) {
-                    continue;
+            // Admin-entered patterns may be malformed (e.g. a CIDR's "/" collides
+            // with the delimiter). Swallow the resulting PCRE warning for the scan
+            // and treat any non-match — including a compile failure — as "allowed",
+            // so a bad pattern neither warns nor blocks the request (SECURITY.md L-19).
+            set_error_handler(static fn (): bool => true);
+            try {
+                foreach ($xoopsConfig['bad_ips'] as $bi) {
+                    // Bound the length to avoid pathological backtracking and block
+                    // only on a definite match.
+                    if (!is_string($bi) || '' === $bi || strlen($bi) > 255) {
+                        continue;
+                    }
+                    if (1 === preg_match('/' . $bi . '/', $ip)) {
+                        restore_error_handler();
+                        exit();
+                    }
                 }
-                if (1 === preg_match('/' . $bi . '/', $ip)) {
-                    exit();
-                }
+            } finally {
+                restore_error_handler();
             }
         }
     }

--- a/htdocs/image.php
+++ b/htdocs/image.php
@@ -341,13 +341,15 @@ if (!empty($imageId)) {
     // Get the size and MIME type of the requested image
     $imageFilename = basename($imagePath);  // image filename
     $imagesize = getimagesize($imagePath);
-    // Reject before decode if the source is unreadable, too large on disk, or
-    // would decode to an excessive pixel count (M-14). Treat a stat failure
-    // (filesize() === false) as a rejection, not a pass — mirrors the image-id path.
-    $srcBytes = is_file($imagePath) ? filesize($imagePath) : false;
+    // Reject before decode if the source is unreadable or would decode to an
+    // excessive pixel count (M-14). The byte cap only applies to a local file —
+    // if ONLY_LOCAL_IMAGES is ever disabled, $imagePath may be a remote URL, where
+    // is_file()/filesize() do not apply (the pixel cap from getimagesize() still
+    // does). For a local file a stat failure is a rejection, not a pass.
+    $isLocalSource = is_file($imagePath);
+    $srcBytes      = $isLocalSource ? filesize($imagePath) : false;
     if (false === $imagesize
-        || false === $srcBytes
-        || $srcBytes > $imgSrcMaxBytes
+        || ($isLocalSource && (false === $srcBytes || $srcBytes > $imgSrcMaxBytes))
         || ($imagesize[0] * $imagesize[1]) > $imgSrcMaxPixels) {
         exitInvalidRequest();
     }

--- a/htdocs/image.php
+++ b/htdocs/image.php
@@ -257,6 +257,12 @@ function imageFilenameCheck($imageUrl)
 $imageId = Request::getInt('id', 0, 'GET');
 $imageUrl = Request::getUrl('url', Request::getString('src', '', 'GET'), 'GET');
 
+// Source-image guards: reject oversized inputs BEFORE decoding so a crafted
+// file or DB blob cannot drive a huge allocation in imagecreatefrom*()
+// (a decode bomb is expensive even when the OUTPUT is later capped) — M-14.
+$imgSrcMaxBytes  = 26214400; // 25 MiB cap on the raw source data
+$imgSrcMaxPixels = 40000000; // ~40 MP cap on the decoded source dimensions
+
 if (!empty($imageId)) {
     // If image is a Xoops image
     /** @var XoopsImageHandler $imageHandler */
@@ -291,6 +297,14 @@ if (!empty($imageId)) {
         $imagePath = XOOPS_UPLOAD_PATH . '/' . $image->getVar('image_name');
         $imageData = file_get_contents($imagePath);
     }
+    // Cap the raw blob and its decoded dimensions before allocating (M-14).
+    if (!is_string($imageData) || strlen($imageData) > $imgSrcMaxBytes) {
+        exitInvalidRequest();
+    }
+    $srcInfo = getimagesizefromstring($imageData);
+    if (false === $srcInfo || ($srcInfo[0] * $srcInfo[1]) > $imgSrcMaxPixels) {
+        exitInvalidRequest();
+    }
     $sourceImage = imagecreatefromstring($imageData);
     $imageWidth = imagesx($sourceImage);
     $imageHeight = imagesy($sourceImage);
@@ -316,6 +330,13 @@ if (!empty($imageId)) {
     // Get the size and MIME type of the requested image
     $imageFilename = basename($imagePath);  // image filename
     $imagesize = getimagesize($imagePath);
+    // Reject before decode if the source is unreadable, too large on disk, or
+    // would decode to an excessive pixel count (M-14).
+    if (false === $imagesize
+        || (is_file($imagePath) && filesize($imagePath) > $imgSrcMaxBytes)
+        || ($imagesize[0] * $imagesize[1]) > $imgSrcMaxPixels) {
+        exitInvalidRequest();
+    }
     $imageWidth = $imagesize[0];
     $imageHeight = $imagesize[1];
     $imageMimetype = $imagesize['mime'];

--- a/htdocs/image.php
+++ b/htdocs/image.php
@@ -295,8 +295,10 @@ if (!empty($imageId)) {
         $imageData = $image->getVar('image_body');
     } else {
         $imagePath = XOOPS_UPLOAD_PATH . '/' . $image->getVar('image_name');
-        // Cap the file on disk BEFORE reading it into memory (M-14).
-        if (!is_file($imagePath) || filesize($imagePath) > $imgSrcMaxBytes) {
+        // Cap the file on disk BEFORE reading it into memory (M-14). Treat a
+        // stat failure (filesize() === false) as a rejection, not a pass.
+        $srcBytes = is_file($imagePath) ? filesize($imagePath) : false;
+        if (false === $srcBytes || $srcBytes > $imgSrcMaxBytes) {
             exitInvalidRequest();
         }
         $imageData = file_get_contents($imagePath);

--- a/htdocs/image.php
+++ b/htdocs/image.php
@@ -312,6 +312,11 @@ if (!empty($imageId)) {
         exitInvalidRequest();
     }
     $sourceImage = imagecreatefromstring($imageData);
+    // imagesx()/imagesy() require a GdImage; reject a decode failure rather than
+    // passing false into them (a TypeError under PHP 8).
+    if (!($sourceImage instanceof \GdImage)) {
+        exitInvalidRequest();
+    }
     $imageWidth = imagesx($sourceImage);
     $imageHeight = imagesy($sourceImage);
 } elseif (!empty($imageUrl)) {
@@ -337,9 +342,12 @@ if (!empty($imageId)) {
     $imageFilename = basename($imagePath);  // image filename
     $imagesize = getimagesize($imagePath);
     // Reject before decode if the source is unreadable, too large on disk, or
-    // would decode to an excessive pixel count (M-14).
+    // would decode to an excessive pixel count (M-14). Treat a stat failure
+    // (filesize() === false) as a rejection, not a pass — mirrors the image-id path.
+    $srcBytes = is_file($imagePath) ? filesize($imagePath) : false;
     if (false === $imagesize
-        || (is_file($imagePath) && filesize($imagePath) > $imgSrcMaxBytes)
+        || false === $srcBytes
+        || $srcBytes > $imgSrcMaxBytes
         || ($imagesize[0] * $imagesize[1]) > $imgSrcMaxPixels) {
         exitInvalidRequest();
     }
@@ -364,6 +372,11 @@ if (!empty($imageId)) {
         default:
             exitInvalidRequest();
             break;
+    }
+    // Reject a decode failure before imagesx() further down (parity with the
+    // DB-blob path; avoids a PHP 8 TypeError on a corrupt file).
+    if (!($sourceImage instanceof \GdImage)) {
+        exitInvalidRequest();
     }
 } else {
     // No id, no url, no src parameters

--- a/htdocs/image.php
+++ b/htdocs/image.php
@@ -295,6 +295,10 @@ if (!empty($imageId)) {
         $imageData = $image->getVar('image_body');
     } else {
         $imagePath = XOOPS_UPLOAD_PATH . '/' . $image->getVar('image_name');
+        // Cap the file on disk BEFORE reading it into memory (M-14).
+        if (!is_file($imagePath) || filesize($imagePath) > $imgSrcMaxBytes) {
+            exitInvalidRequest();
+        }
         $imageData = file_get_contents($imagePath);
     }
     // Cap the raw blob and its decoded dimensions before allocating (M-14).

--- a/htdocs/include/checklogin.php
+++ b/htdocs/include/checklogin.php
@@ -130,8 +130,10 @@ if (false !== $user) {
 
     redirect_header($url, 1, sprintf(_US_LOGGINGU, $user->getVar('uname')), false);
 } elseif (empty($redirect)) {
-    redirect_header(XOOPS_URL . '/user.php', 5, $xoopsAuth->getHtmlErrors());
+    // Generic message for every credential failure — do not reveal whether the
+    // account exists or which factor failed (user enumeration, SECURITY.md L-3).
+    redirect_header(XOOPS_URL . '/user.php', 5, _US_INCORRECTLOGIN);
 } else {
-    redirect_header(XOOPS_URL . '/user.php?xoops_redirect=' . urlencode($redirect), 5, $xoopsAuth->getHtmlErrors(), false);
+    redirect_header(XOOPS_URL . '/user.php?xoops_redirect=' . urlencode($redirect), 5, _US_INCORRECTLOGIN, false);
 }
 exit();

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -257,7 +257,7 @@ if (!empty($_SESSION['xoopsUserId'])) {
                 $xoopsDB->exec($sql);
             } catch (Exception $e) {
                 throw new \RuntimeException(
-                    \sprintf(_DB_QUERY_ERROR, $sql) . $db->error(),
+                    \sprintf(_DB_QUERY_ERROR, $sql) . $xoopsDB->error(),
                     E_USER_ERROR,
                 );
             }

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -255,7 +255,7 @@ if (!empty($_SESSION['xoopsUserId'])) {
                    . "' WHERE uid = " . (int) $_SESSION['xoopsUserId'];
             try {
                 $xoopsDB->exec($sql);
-            } catch (Exception $e) {
+            } catch (\Throwable $e) {
                 throw new \RuntimeException(
                     \sprintf(_DB_QUERY_ERROR, $sql) . $xoopsDB->error(),
                     E_USER_ERROR,

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -252,7 +252,7 @@ if (!empty($_SESSION['xoopsUserId'])) {
     } else {
         if (((int) $xoopsUser->getVar('last_login') + 60 * 5) < time()) {
             $sql = 'UPDATE ' . $xoopsDB->prefix('users') . " SET last_login = '" . time()
-                   . "' WHERE uid = " . $_SESSION['xoopsUserId'];
+                   . "' WHERE uid = " . (int) $_SESSION['xoopsUserId'];
             try {
                 $xoopsDB->exec($sql);
             } catch (Exception $e) {

--- a/htdocs/install/page_dbsettings.php
+++ b/htdocs/install/page_dbsettings.php
@@ -68,8 +68,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 $error = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($vars['DB_NAME'])) {
+    // MySQL identifiers placed inside `backticks` are NOT escaped by
+    // mysqli_real_escape_string — restrict DB_NAME to safe identifier characters
+    // before it reaches CREATE/ALTER DATABASE (SECURITY.md L-12).
+    if (!preg_match('/^[A-Za-z0-9_$]+$/', (string) $vars['DB_NAME'])) {
+        $error = defined('ERR_NO_DATABASE') ? ERR_NO_DATABASE : 'Invalid database name.';
+    } else {
+        $error = validateDbCharset($link, $vars['DB_CHARSET'], $vars['DB_COLLATION']);
+    }
     $dbName   = mysqli_real_escape_string($link, $vars['DB_NAME']);
-    $error    = validateDbCharset($link, $vars['DB_CHARSET'], $vars['DB_COLLATION']);
     $db_exist = true;
     if (empty($error)) {
         if (!@mysqli_select_db($link, $dbName)) {

--- a/htdocs/install/page_tablesfill.php
+++ b/htdocs/install/page_tablesfill.php
@@ -78,7 +78,11 @@ if (!$result) {
 $process = (0 == $count);
 $update  = false;
 
-extract($_SESSION['siteconfig'], EXTR_SKIP);
+// Read the admin fields explicitly rather than expanding the whole session
+// array into local scope (R-011). siteconfig only carries the fields below.
+$adminname = (string) ($_SESSION['siteconfig']['adminname'] ?? '');
+$adminmail = (string) ($_SESSION['siteconfig']['adminmail'] ?? '');
+$adminpass = (string) ($_SESSION['siteconfig']['adminpass'] ?? '');
 
 require_once __DIR__ . '/include/makedata.php';
 

--- a/htdocs/install/page_tablesfill.php
+++ b/htdocs/install/page_tablesfill.php
@@ -80,9 +80,10 @@ $update  = false;
 
 // Read the admin fields explicitly rather than expanding the whole session
 // array into local scope (R-011). siteconfig only carries the fields below.
-$adminname = (string) ($_SESSION['siteconfig']['adminname'] ?? '');
-$adminmail = (string) ($_SESSION['siteconfig']['adminmail'] ?? '');
-$adminpass = (string) ($_SESSION['siteconfig']['adminpass'] ?? '');
+$siteconfig = $_SESSION['siteconfig'] ?? [];
+$adminname  = (string) ($siteconfig['adminname'] ?? '');
+$adminmail  = (string) ($siteconfig['adminmail'] ?? '');
+$adminpass  = (string) ($siteconfig['adminpass'] ?? '');
 
 require_once __DIR__ . '/include/makedata.php';
 

--- a/htdocs/install/page_tablesfill.php
+++ b/htdocs/install/page_tablesfill.php
@@ -80,7 +80,7 @@ $update  = false;
 
 // Read the admin fields explicitly rather than expanding the whole session
 // array into local scope (R-011). siteconfig only carries the fields below.
-$siteconfig = $_SESSION['siteconfig'] ?? [];
+$siteconfig = is_array($_SESSION['siteconfig'] ?? null) ? $_SESSION['siteconfig'] : [];
 $adminname  = (string) ($siteconfig['adminname'] ?? '');
 $adminmail  = (string) ($siteconfig['adminmail'] ?? '');
 $adminpass  = (string) ($siteconfig['adminpass'] ?? '');

--- a/htdocs/kernel/block.php
+++ b/htdocs/kernel/block.php
@@ -819,6 +819,7 @@ class XoopsBlock extends XoopsObject
         }
         $sql .= 'FROM ' . $db->prefix('newblocks') . ' b LEFT JOIN ' . $db->prefix('group_permission') . " l ON l.gperm_itemid=b.bid WHERE gperm_name = 'block_read' AND gperm_modid = 1";
         if (is_array($groupid)) {
+            $groupid = array_map('intval', $groupid);
             $sql .= ' AND (l.gperm_groupid=' . $groupid[0] . '';
             $size = count($groupid);
             if ($size > 1) {
@@ -828,9 +829,9 @@ class XoopsBlock extends XoopsObject
             }
             $sql .= ')';
         } else {
-            $sql .= ' AND l.gperm_groupid=' . $groupid . '';
+            $sql .= ' AND l.gperm_groupid=' . (int) $groupid . '';
         }
-        $sql .= ' AND b.isactive=' . $isactive;
+        $sql .= ' AND b.isactive=' . (int) $isactive;
         if (isset($side)) {
             // get both sides in sidebox? (some themes need this)
             if ($side == XOOPS_SIDEBLOCK_BOTH) {
@@ -840,14 +841,19 @@ class XoopsBlock extends XoopsObject
             } elseif ($side == XOOPS_FOOTERBLOCK_ALL) {
                 $side = '(b.side=10 OR b.side=11 OR b.side=12 )';
             } else {
-                $side = 'b.side=' . $side;
+                $side = 'b.side=' . (int) $side;
             }
             $sql .= ' AND ' . $side;
         }
         if (isset($visible)) {
-            $sql .= " AND b.visible=$visible";
+            $sql .= ' AND b.visible=' . (int) $visible;
         }
-        $sql .= " ORDER BY $orderby";
+        // ORDER BY allowlist: comma-separated col / tbl.col tokens with an optional
+        // ASC/DESC only — reject anything else to block ORDER BY injection (L-7).
+        if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', (string) $orderby)) {
+            $orderby = 'b.weight,b.bid';
+        }
+        $sql .= ' ORDER BY ' . $orderby;
         $result = $db->query($sql);
         if (!$db->isResultSet($result)) {
             throw new \RuntimeException(
@@ -1008,7 +1014,7 @@ class XoopsBlock extends XoopsObject
         if (isset($groupid)) {
             $sql = 'SELECT DISTINCT gperm_itemid FROM ' . $db->prefix('group_permission') . " WHERE gperm_name = 'block_read' AND gperm_modid = 1";
             if (is_array($groupid)) {
-                $sql .= ' AND gperm_groupid IN (' . implode(',', $groupid) . ')';
+                $sql .= ' AND gperm_groupid IN (' . implode(',', array_map('intval', $groupid)) . ')';
             } else {
                 if ((int) $groupid > 0) {
                     $sql .= ' AND gperm_groupid=' . (int) $groupid;
@@ -1051,7 +1057,12 @@ class XoopsBlock extends XoopsObject
             }
         }
         if (!empty($blockids)) {
-            $sql .= ' AND b.bid IN (' . implode(',', $blockids) . ')';
+            $sql .= ' AND b.bid IN (' . implode(',', array_map('intval', $blockids)) . ')';
+        }
+        // ORDER BY allowlist: comma-separated col / tbl.col tokens with an optional
+        // ASC/DESC only — reject anything else to block ORDER BY injection (L-7).
+        if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', (string) $orderby)) {
+            $orderby = 'b.weight, m.block_id';
         }
         $sql .= ' ORDER BY ' . $orderby;
         $result = $db->query($sql);

--- a/htdocs/kernel/block.php
+++ b/htdocs/kernel/block.php
@@ -820,6 +820,9 @@ class XoopsBlock extends XoopsObject
         $sql .= 'FROM ' . $db->prefix('newblocks') . ' b LEFT JOIN ' . $db->prefix('group_permission') . " l ON l.gperm_itemid=b.bid WHERE gperm_name = 'block_read' AND gperm_modid = 1";
         if (is_array($groupid)) {
             $groupid = array_map('intval', $groupid);
+            if ([] === $groupid) {
+                return $ret;
+            }
             $sql .= ' AND (l.gperm_groupid=' . $groupid[0] . '';
             $size = count($groupid);
             if ($size > 1) {
@@ -850,7 +853,7 @@ class XoopsBlock extends XoopsObject
         }
         // ORDER BY allowlist: comma-separated col / tbl.col tokens with an optional
         // ASC/DESC only — reject anything else to block ORDER BY injection (L-7).
-        if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', (string) $orderby)) {
+        if (!preg_match('/^\s*(?:[A-Za-z_]\w*\.)?[A-Za-z_]\w*(?:\s+(?:ASC|DESC))?(?:\s*,\s*(?:[A-Za-z_]\w*\.)?[A-Za-z_]\w*(?:\s+(?:ASC|DESC))?)*\s*$/i', (string) $orderby)) {
             $orderby = 'b.weight,b.bid';
         }
         $sql .= ' ORDER BY ' . $orderby;
@@ -1014,7 +1017,11 @@ class XoopsBlock extends XoopsObject
         if (isset($groupid)) {
             $sql = 'SELECT DISTINCT gperm_itemid FROM ' . $db->prefix('group_permission') . " WHERE gperm_name = 'block_read' AND gperm_modid = 1";
             if (is_array($groupid)) {
-                $sql .= ' AND gperm_groupid IN (' . implode(',', array_map('intval', $groupid)) . ')';
+                $groupid = array_map('intval', $groupid);
+                if ([] === $groupid) {
+                    return $ret;
+                }
+                $sql .= ' AND gperm_groupid IN (' . implode(',', $groupid) . ')';
             } else {
                 if ((int) $groupid > 0) {
                     $sql .= ' AND gperm_groupid=' . (int) $groupid;
@@ -1061,7 +1068,7 @@ class XoopsBlock extends XoopsObject
         }
         // ORDER BY allowlist: comma-separated col / tbl.col tokens with an optional
         // ASC/DESC only — reject anything else to block ORDER BY injection (L-7).
-        if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', (string) $orderby)) {
+        if (!preg_match('/^\s*(?:[A-Za-z_]\w*\.)?[A-Za-z_]\w*(?:\s+(?:ASC|DESC))?(?:\s*,\s*(?:[A-Za-z_]\w*\.)?[A-Za-z_]\w*(?:\s+(?:ASC|DESC))?)*\s*$/i', (string) $orderby)) {
             $orderby = 'b.weight, m.block_id';
         }
         $sql .= ' ORDER BY ' . $orderby;
@@ -1137,7 +1144,12 @@ class XoopsBlock extends XoopsObject
                     $sql .= ' AND m.module_id=0';
                 }
             }
-            $sql .= ' AND b.bid IN (' . implode(',', $non_grouped) . ')';
+            $sql .= ' AND b.bid IN (' . implode(',', array_map('intval', $non_grouped)) . ')';
+            // ORDER BY allowlist: comma-separated col / tbl.col tokens with an optional
+            // ASC/DESC only — reject anything else to block ORDER BY injection (L-7).
+            if (!preg_match('/^\s*(?:[A-Za-z_]\w*\.)?[A-Za-z_]\w*(?:\s+(?:ASC|DESC))?(?:\s*,\s*(?:[A-Za-z_]\w*\.)?[A-Za-z_]\w*(?:\s+(?:ASC|DESC))?)*\s*$/i', (string) $orderby)) {
+                $orderby = 'b.weight, m.block_id';
+            }
             $sql .= ' ORDER BY ' . $orderby;
             $result = $db->query($sql);
             if (!$db->isResultSet($result)) {

--- a/htdocs/kernel/comment.php
+++ b/htdocs/kernel/comment.php
@@ -478,12 +478,13 @@ class XoopsCommentHandler extends XoopsObjectHandler
         $sql   = 'SELECT * FROM ' . $this->db->prefix('xoopscomments');
         if (isset($criteria) && \method_exists($criteria, 'renderWhere')) {
             $sql .= ' ' . $criteria->renderWhere();
-            $sort = !in_array($criteria->getSort(), [
-                'com_id', 'com_pid', 'com_rootid', 'com_modid', 'com_itemid', 'com_icon',
-                'com_created', 'com_modified', 'com_uid', 'com_user', 'com_email', 'com_url',
-                'com_ip', 'com_title', 'com_status', 'com_exparams',
-                'dohtml', 'dosmiley', 'doxcode', 'doimage', 'dobr',
-            ], true) ? 'com_id' : $criteria->getSort();
+            // Allow only comma-separated col / tbl.col tokens with an optional
+            // ASC/DESC — blocks ORDER BY injection while still permitting valid
+            // single- and multi-column sorts (SECURITY.md L-6).
+            $sort = (string) $criteria->getSort();
+            if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', $sort)) {
+                $sort = 'com_id';
+            }
             $sql .= ' ORDER BY ' . $sort . ' ' . $criteria->getOrder();
             $limit = $criteria->getLimit();
             $start = $criteria->getStart();

--- a/htdocs/kernel/comment.php
+++ b/htdocs/kernel/comment.php
@@ -478,14 +478,15 @@ class XoopsCommentHandler extends XoopsObjectHandler
         $sql   = 'SELECT * FROM ' . $this->db->prefix('xoopscomments');
         if (isset($criteria) && \method_exists($criteria, 'renderWhere')) {
             $sql .= ' ' . $criteria->renderWhere();
-            // Allow only comma-separated col / tbl.col tokens with an optional
-            // ASC/DESC — blocks ORDER BY injection while still permitting valid
-            // single- and multi-column sorts (SECURITY.md L-6).
-            $sort = (string) $criteria->getSort();
-            if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', $sort)) {
-                $sort = 'com_id';
-            }
-            $sql .= ' ORDER BY ' . $sort . ' ' . $criteria->getOrder();
+            // Restrict ORDER BY to real columns of this table. xoops_buildOrderBy()
+            // attaches each clause's direction, so the criteria order must NOT be
+            // appended again here (SECURITY.md L-6).
+            $sql .= ' ORDER BY ' . self::buildOrderBy($criteria->getSort(), $criteria->getOrder(), [
+                'com_id', 'com_pid', 'com_rootid', 'com_modid', 'com_itemid', 'com_icon',
+                'com_created', 'com_modified', 'com_uid', 'com_user', 'com_email', 'com_url',
+                'com_ip', 'com_title', 'com_text', 'com_sig', 'com_status', 'com_exparams',
+                'dohtml', 'dosmiley', 'doxcode', 'doimage', 'dobr',
+            ], 'com_id');
             $limit = $criteria->getLimit();
             $start = $criteria->getStart();
         }

--- a/htdocs/kernel/comment.php
+++ b/htdocs/kernel/comment.php
@@ -478,7 +478,12 @@ class XoopsCommentHandler extends XoopsObjectHandler
         $sql   = 'SELECT * FROM ' . $this->db->prefix('xoopscomments');
         if (isset($criteria) && \method_exists($criteria, 'renderWhere')) {
             $sql .= ' ' . $criteria->renderWhere();
-            $sort = ($criteria->getSort() != '') ? $criteria->getSort() : 'com_id';
+            $sort = !in_array($criteria->getSort(), [
+                'com_id', 'com_pid', 'com_rootid', 'com_modid', 'com_itemid', 'com_icon',
+                'com_created', 'com_modified', 'com_uid', 'com_user', 'com_email', 'com_url',
+                'com_ip', 'com_title', 'com_status', 'com_exparams',
+                'dohtml', 'dosmiley', 'doxcode', 'doimage', 'dobr',
+            ], true) ? 'com_id' : $criteria->getSort();
             $sql .= ' ORDER BY ' . $sort . ' ' . $criteria->getOrder();
             $limit = $criteria->getLimit();
             $start = $criteria->getStart();

--- a/htdocs/kernel/image.php
+++ b/htdocs/kernel/image.php
@@ -317,11 +317,13 @@ class XoopsImageHandler extends XoopsObjectHandler
             $sql .= ' ' . $criteria->renderWhere();
             // Restrict ORDER BY to real columns of this table. xoops_buildOrderBy()
             // attaches each clause's direction, so the criteria order must NOT be
-            // appended again here (SECURITY.md L-6).
+            // appended again here (SECURITY.md L-6). When $getbinary joins imagebody,
+            // image_id exists in both tables — force the "i." alias to disambiguate.
+            $orderPrefix = $getbinary ? 'i.' : '';
             $sql .= ' ORDER BY ' . self::buildOrderBy($criteria->getSort(), $criteria->getOrder(), [
                 'image_id', 'image_name', 'image_nicename', 'image_mimetype',
-                'image_created', 'image_display', 'image_weight',
-            ], 'image_weight');
+                'image_created', 'image_display', 'image_weight', 'imgcat_id',
+            ], 'image_weight', $orderPrefix);
             $limit = $criteria->getLimit();
             $start = $criteria->getStart();
         }

--- a/htdocs/kernel/image.php
+++ b/htdocs/kernel/image.php
@@ -315,7 +315,10 @@ class XoopsImageHandler extends XoopsObjectHandler
         }
         if (isset($criteria) && \method_exists($criteria, 'renderWhere')) {
             $sql .= ' ' . $criteria->renderWhere();
-            $sort = $criteria->getSort() == '' ? 'image_weight' : $criteria->getSort();
+            $sort = !in_array($criteria->getSort(), [
+                'image_id', 'image_name', 'image_nicename', 'image_mimetype',
+                'image_created', 'image_display', 'image_weight',
+            ], true) ? 'image_weight' : $criteria->getSort();
             $sql .= ' ORDER BY ' . $sort . ' ' . $criteria->getOrder();
             $limit = $criteria->getLimit();
             $start = $criteria->getStart();

--- a/htdocs/kernel/image.php
+++ b/htdocs/kernel/image.php
@@ -315,14 +315,13 @@ class XoopsImageHandler extends XoopsObjectHandler
         }
         if (isset($criteria) && \method_exists($criteria, 'renderWhere')) {
             $sql .= ' ' . $criteria->renderWhere();
-            // Allow only comma-separated col / tbl.col tokens with an optional
-            // ASC/DESC — blocks ORDER BY injection while still permitting valid
-            // single- and multi-column sorts (SECURITY.md L-6).
-            $sort = (string) $criteria->getSort();
-            if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', $sort)) {
-                $sort = 'image_weight';
-            }
-            $sql .= ' ORDER BY ' . $sort . ' ' . $criteria->getOrder();
+            // Restrict ORDER BY to real columns of this table. xoops_buildOrderBy()
+            // attaches each clause's direction, so the criteria order must NOT be
+            // appended again here (SECURITY.md L-6).
+            $sql .= ' ORDER BY ' . self::buildOrderBy($criteria->getSort(), $criteria->getOrder(), [
+                'image_id', 'image_name', 'image_nicename', 'image_mimetype',
+                'image_created', 'image_display', 'image_weight',
+            ], 'image_weight');
             $limit = $criteria->getLimit();
             $start = $criteria->getStart();
         }

--- a/htdocs/kernel/image.php
+++ b/htdocs/kernel/image.php
@@ -315,10 +315,13 @@ class XoopsImageHandler extends XoopsObjectHandler
         }
         if (isset($criteria) && \method_exists($criteria, 'renderWhere')) {
             $sql .= ' ' . $criteria->renderWhere();
-            $sort = !in_array($criteria->getSort(), [
-                'image_id', 'image_name', 'image_nicename', 'image_mimetype',
-                'image_created', 'image_display', 'image_weight',
-            ], true) ? 'image_weight' : $criteria->getSort();
+            // Allow only comma-separated col / tbl.col tokens with an optional
+            // ASC/DESC — blocks ORDER BY injection while still permitting valid
+            // single- and multi-column sorts (SECURITY.md L-6).
+            $sort = (string) $criteria->getSort();
+            if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', $sort)) {
+                $sort = 'image_weight';
+            }
             $sql .= ' ORDER BY ' . $sort . ' ' . $criteria->getOrder();
             $limit = $criteria->getLimit();
             $start = $criteria->getStart();

--- a/htdocs/kernel/notification.php
+++ b/htdocs/kernel/notification.php
@@ -360,7 +360,7 @@ class XoopsNotificationHandler extends XoopsObjectHandler
             // appended again here (SECURITY.md L-6).
             $sql .= ' ORDER BY ' . self::buildOrderBy($criteria->getSort(), $criteria->getOrder(), [
                 'not_id', 'not_modid', 'not_itemid', 'not_category', 'not_event',
-                'not_uid', 'not_mode', 'not_class',
+                'not_uid', 'not_mode',
             ], 'not_id');
             $limit = $criteria->getLimit();
             $start = $criteria->getStart();

--- a/htdocs/kernel/notification.php
+++ b/htdocs/kernel/notification.php
@@ -355,7 +355,10 @@ class XoopsNotificationHandler extends XoopsObjectHandler
         $sql   = 'SELECT * FROM ' . $this->db->prefix('xoopsnotifications');
         if (isset($criteria) && \method_exists($criteria, 'renderWhere')) {
             $sql .= ' ' . $criteria->renderWhere();
-            $sort = ($criteria->getSort() != '') ? $criteria->getSort() : 'not_id';
+            $sort = !in_array($criteria->getSort(), [
+                'not_id', 'not_modid', 'not_itemid', 'not_category', 'not_event',
+                'not_uid', 'not_mode', 'not_class',
+            ], true) ? 'not_id' : $criteria->getSort();
             $sql .= ' ORDER BY ' . $sort . ' ' . $criteria->getOrder();
             $limit = $criteria->getLimit();
             $start = $criteria->getStart();

--- a/htdocs/kernel/notification.php
+++ b/htdocs/kernel/notification.php
@@ -355,14 +355,13 @@ class XoopsNotificationHandler extends XoopsObjectHandler
         $sql   = 'SELECT * FROM ' . $this->db->prefix('xoopsnotifications');
         if (isset($criteria) && \method_exists($criteria, 'renderWhere')) {
             $sql .= ' ' . $criteria->renderWhere();
-            // Allow only comma-separated col / tbl.col tokens with an optional
-            // ASC/DESC — blocks ORDER BY injection while still permitting valid
-            // single- and multi-column sorts (SECURITY.md L-6).
-            $sort = (string) $criteria->getSort();
-            if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', $sort)) {
-                $sort = 'not_id';
-            }
-            $sql .= ' ORDER BY ' . $sort . ' ' . $criteria->getOrder();
+            // Restrict ORDER BY to real columns of this table. xoops_buildOrderBy()
+            // attaches each clause's direction, so the criteria order must NOT be
+            // appended again here (SECURITY.md L-6).
+            $sql .= ' ORDER BY ' . self::buildOrderBy($criteria->getSort(), $criteria->getOrder(), [
+                'not_id', 'not_modid', 'not_itemid', 'not_category', 'not_event',
+                'not_uid', 'not_mode', 'not_class',
+            ], 'not_id');
             $limit = $criteria->getLimit();
             $start = $criteria->getStart();
         }

--- a/htdocs/kernel/notification.php
+++ b/htdocs/kernel/notification.php
@@ -355,10 +355,13 @@ class XoopsNotificationHandler extends XoopsObjectHandler
         $sql   = 'SELECT * FROM ' . $this->db->prefix('xoopsnotifications');
         if (isset($criteria) && \method_exists($criteria, 'renderWhere')) {
             $sql .= ' ' . $criteria->renderWhere();
-            $sort = !in_array($criteria->getSort(), [
-                'not_id', 'not_modid', 'not_itemid', 'not_category', 'not_event',
-                'not_uid', 'not_mode', 'not_class',
-            ], true) ? 'not_id' : $criteria->getSort();
+            // Allow only comma-separated col / tbl.col tokens with an optional
+            // ASC/DESC — blocks ORDER BY injection while still permitting valid
+            // single- and multi-column sorts (SECURITY.md L-6).
+            $sort = (string) $criteria->getSort();
+            if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', $sort)) {
+                $sort = 'not_id';
+            }
             $sql .= ' ORDER BY ' . $sort . ' ' . $criteria->getOrder();
             $limit = $criteria->getLimit();
             $start = $criteria->getStart();

--- a/htdocs/kernel/object.php
+++ b/htdocs/kernel/object.php
@@ -1067,6 +1067,43 @@ class XoopsObjectHandler
     }
 
     /**
+     * Build a safe ORDER BY column list from a (possibly multi-column) sort string.
+     *
+     * Splits $sort on commas, keeps only tokens whose (optionally table-qualified)
+     * column name is in $allowedColumns, and gives each clause a direction: its own
+     * ASC/DESC when present, otherwise the sanitized $order. This blocks ORDER BY
+     * injection, supports multi-column and table-prefixed sorts, and — because each
+     * clause already carries its direction — must be used WITHOUT appending the
+     * criteria order again.
+     *
+     * @param  string   $sort           raw sort string, e.g. "i.image_weight ASC, image_id"
+     * @param  string   $order          default direction (ASC/DESC) for clauses with none
+     * @param  string[] $allowedColumns lowercase column names permitted for this table
+     * @param  string   $defaultColumn  column used when no valid clause remains
+     * @return string   a safe ORDER BY column list including directions
+     */
+    public static function buildOrderBy($sort, $order, array $allowedColumns, $defaultColumn)
+    {
+        $order = strtoupper(trim((string) $order));
+        if ('ASC' !== $order && 'DESC' !== $order) {
+            $order = 'ASC';
+        }
+        $parts = [];
+        foreach (explode(',', (string) $sort) as $token) {
+            if (preg_match('/^\s*((?:[A-Za-z_]\w*\.)?)([A-Za-z_]\w*)\s*(ASC|DESC)?\s*$/i', $token, $m)
+                && in_array(strtolower($m[2]), $allowedColumns, true)) {
+                $direction = ('' !== ($m[3] ?? '')) ? strtoupper($m[3]) : $order;
+                $parts[]   = $m[1] . $m[2] . ' ' . $direction;
+            }
+        }
+        if ([] === $parts) {
+            return $defaultColumn . ' ' . $order;
+        }
+
+        return implode(', ', $parts);
+    }
+
+    /**
      * PHP 4 style constructor compatibility shim
      *
      * @param XoopsDatabase $db database object

--- a/htdocs/kernel/object.php
+++ b/htdocs/kernel/object.php
@@ -1071,33 +1071,49 @@ class XoopsObjectHandler
      *
      * Splits $sort on commas, keeps only tokens whose (optionally table-qualified)
      * column name is in $allowedColumns, and gives each clause a direction: its own
-     * ASC/DESC when present, otherwise the sanitized $order. This blocks ORDER BY
-     * injection, supports multi-column and table-prefixed sorts, and — because each
-     * clause already carries its direction — must be used WITHOUT appending the
-     * criteria order again.
+     * ASC/DESC when present, otherwise the sanitized $order. The emitted clause uses
+     * $columnPrefix . column — any qualifier on the INPUT is dropped and replaced with
+     * the caller's canonical prefix, so an unknown alias (e.g. "bogus.com_id") cannot
+     * reach the SQL, and a joined query can force its own alias (e.g. "i.") to keep
+     * columns shared by two tables unambiguous. Single-table callers pass '' (the
+     * default) for bare columns. This blocks ORDER BY injection, supports multi-column
+     * sorts, and — because each clause already carries its direction — must be used
+     * WITHOUT appending the criteria order again.
      *
-     * @param  string   $sort           raw sort string, e.g. "i.image_weight ASC, image_id"
+     * @param  string   $sort           raw sort string, e.g. "image_weight ASC, image_id"
      * @param  string   $order          default direction (ASC/DESC) for clauses with none
      * @param  string[] $allowedColumns lowercase column names permitted for this table
      * @param  string   $defaultColumn  column used when no valid clause remains
+     * @param  string   $columnPrefix   canonical qualifier prepended to every column
+     *                                   (e.g. "i."); '' emits bare columns. Only ''
+     *                                   or a single "alias." is honoured; anything
+     *                                   else is neutralised to ''.
      * @return string   a safe ORDER BY column list including directions
      */
-    public static function buildOrderBy($sort, $order, array $allowedColumns, $defaultColumn)
+    public static function buildOrderBy($sort, $order, array $allowedColumns, $defaultColumn, $columnPrefix = '')
     {
         $order = strtoupper(trim((string) $order));
         if ('ASC' !== $order && 'DESC' !== $order) {
             $order = 'ASC';
+        }
+        // Defence-in-depth: this is a public static helper, so do not trust the
+        // prefix even though current callers pass literals. Accept only '' or a
+        // single "alias." qualifier; anything else is neutralised to ''.
+        $columnPrefix = (string) $columnPrefix;
+        if ('' !== $columnPrefix && 1 !== preg_match('/^[A-Za-z_]\w*\.$/', $columnPrefix)) {
+            $columnPrefix = '';
         }
         $parts = [];
         foreach (explode(',', (string) $sort) as $token) {
             if (preg_match('/^\s*((?:[A-Za-z_]\w*\.)?)([A-Za-z_]\w*)\s*(ASC|DESC)?\s*$/i', $token, $m)
                 && in_array(strtolower($m[2]), $allowedColumns, true)) {
                 $direction = ('' !== ($m[3] ?? '')) ? strtoupper($m[3]) : $order;
-                $parts[]   = $m[1] . $m[2] . ' ' . $direction;
+                // Drop the caller-supplied qualifier and apply the canonical prefix.
+                $parts[]   = $columnPrefix . $m[2] . ' ' . $direction;
             }
         }
         if ([] === $parts) {
-            return $defaultColumn . ' ' . $order;
+            return $columnPrefix . $defaultColumn . ' ' . $order;
         }
 
         return implode(', ', $parts);

--- a/htdocs/modules/pm/templates/pm_readpmsg.tpl
+++ b/htdocs/modules/pm/templates/pm_readpmsg.tpl
@@ -52,6 +52,8 @@
                     <hr/>
                     <strong><{$message.subject}></strong><br>
                     <br>
+                    <{* msg_text and subject are pre-escaped by getVar('s') in the
+                        controller — do NOT add |escape here, it would double-encode. *}>
                     <{$message.msg_text}><br>
                     <br>
                 </td>

--- a/htdocs/modules/system/class/block.php
+++ b/htdocs/modules/system/class/block.php
@@ -414,6 +414,7 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
         }
         $sql .= 'FROM ' . $db->prefix('newblocks') . ' b LEFT JOIN ' . $db->prefix('group_permission') . " l ON l.gperm_itemid=b.bid WHERE gperm_name = 'block_read' AND gperm_modid = 1";
         if (is_array($groupid)) {
+            $groupid = array_map('intval', $groupid);
             $sql .= ' AND (l.gperm_groupid=' . $groupid[0] . '';
             $size = count($groupid);
             if ($size > 1) {
@@ -423,9 +424,9 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
             }
             $sql .= ')';
         } else {
-            $sql .= ' AND l.gperm_groupid=' . $groupid . '';
+            $sql .= ' AND l.gperm_groupid=' . (int) $groupid . '';
         }
-        $sql .= ' AND b.isactive=' . $isactive;
+        $sql .= ' AND b.isactive=' . (int) $isactive;
         if (isset($side)) {
             // get both sides in sidebox? (some themes need this)
             if ($side === XOOPS_SIDEBLOCK_BOTH) {
@@ -435,14 +436,19 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
             } elseif ($side === XOOPS_FOOTERBLOCK_ALL) {
                 $side = '(b.side=10 OR b.side=11 OR b.side=12 )';
             } else {
-                $side = 'b.side=' . $side;
+                $side = 'b.side=' . (int) $side;
             }
             $sql .= ' AND ' . $side;
         }
         if (isset($visible)) {
-            $sql .= " AND b.visible=$visible";
+            $sql .= ' AND b.visible=' . (int) $visible;
         }
-        $sql .= " ORDER BY $orderby";
+        // ORDER BY allowlist: comma-separated col / tbl.col tokens with an optional
+        // ASC/DESC only — reject anything else to block ORDER BY injection (L-7).
+        if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', (string) $orderby)) {
+            $orderby = 'b.weight,b.bid';
+        }
+        $sql .= ' ORDER BY ' . $orderby;
         $result = $db->query($sql);
         if (!$db->isResultSet($result)) {
             throw new \RuntimeException(
@@ -475,7 +481,7 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
         if (isset($groupid)) {
             $sql = 'SELECT DISTINCT gperm_itemid FROM ' . $this->db->prefix('group_permission') . " WHERE gperm_name = 'block_read' AND gperm_modid = 1";
             if (is_array($groupid)) {
-                $sql .= ' AND gperm_groupid IN (' . implode(',', $groupid) . ')';
+                $sql .= ' AND gperm_groupid IN (' . implode(',', array_map('intval', $groupid)) . ')';
             } else {
                 if ((int) $groupid > 0) {
                     $sql .= ' AND gperm_groupid=' . (int) $groupid;
@@ -521,7 +527,7 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
         if (isset($groupid)) {
             $sql = 'SELECT DISTINCT gperm_itemid FROM ' . $db->prefix('group_permission') . " WHERE gperm_name = 'block_read' AND gperm_modid = 1";
             if (is_array($groupid)) {
-                $sql .= ' AND gperm_groupid IN (' . implode(',', $groupid) . ')';
+                $sql .= ' AND gperm_groupid IN (' . implode(',', array_map('intval', $groupid)) . ')';
             } else {
                 if ((int) $groupid > 0) {
                     $sql .= ' AND gperm_groupid=' . (int) $groupid;
@@ -562,7 +568,12 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
             }
         }
         if (!empty($blockids)) {
-            $sql .= ' AND b.bid IN (' . implode(',', $blockids) . ')';
+            $sql .= ' AND b.bid IN (' . implode(',', array_map('intval', $blockids)) . ')';
+        }
+        // ORDER BY allowlist: comma-separated col / tbl.col tokens with an optional
+        // ASC/DESC only — reject anything else to block ORDER BY injection (L-7).
+        if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', (string) $orderby)) {
+            $orderby = 'b.weight, m.block_id';
         }
         $sql .= ' ORDER BY ' . $orderby;
         $result = $db->query($sql);
@@ -633,7 +644,12 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
                     $sql .= ' AND m.module_id=0';
                 }
             }
-            $sql .= ' AND b.bid IN (' . implode(',', $non_grouped) . ')';
+            $sql .= ' AND b.bid IN (' . implode(',', array_map('intval', $non_grouped)) . ')';
+            // ORDER BY allowlist: comma-separated col / tbl.col tokens with an optional
+            // ASC/DESC only — reject anything else to block ORDER BY injection (L-7).
+            if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', (string) $orderby)) {
+                $orderby = 'b.weight, m.block_id';
+            }
             $sql .= ' ORDER BY ' . $orderby;
             $result = $db->query($sql);
             if (!$db->isResultSet($result)) {

--- a/htdocs/modules/system/class/block.php
+++ b/htdocs/modules/system/class/block.php
@@ -415,6 +415,9 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
         $sql .= 'FROM ' . $db->prefix('newblocks') . ' b LEFT JOIN ' . $db->prefix('group_permission') . " l ON l.gperm_itemid=b.bid WHERE gperm_name = 'block_read' AND gperm_modid = 1";
         if (is_array($groupid)) {
             $groupid = array_map('intval', $groupid);
+            if ([] === $groupid) {
+                return $ret;
+            }
             $sql .= ' AND (l.gperm_groupid=' . $groupid[0] . '';
             $size = count($groupid);
             if ($size > 1) {
@@ -445,7 +448,7 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
         }
         // ORDER BY allowlist: comma-separated col / tbl.col tokens with an optional
         // ASC/DESC only — reject anything else to block ORDER BY injection (L-7).
-        if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', (string) $orderby)) {
+        if (!preg_match('/^\s*(?:[A-Za-z_]\w*\.)?[A-Za-z_]\w*(?:\s+(?:ASC|DESC))?(?:\s*,\s*(?:[A-Za-z_]\w*\.)?[A-Za-z_]\w*(?:\s+(?:ASC|DESC))?)*\s*$/i', (string) $orderby)) {
             $orderby = 'b.weight,b.bid';
         }
         $sql .= ' ORDER BY ' . $orderby;
@@ -481,7 +484,11 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
         if (isset($groupid)) {
             $sql = 'SELECT DISTINCT gperm_itemid FROM ' . $this->db->prefix('group_permission') . " WHERE gperm_name = 'block_read' AND gperm_modid = 1";
             if (is_array($groupid)) {
-                $sql .= ' AND gperm_groupid IN (' . implode(',', array_map('intval', $groupid)) . ')';
+                $groupid = array_map('intval', $groupid);
+                if ([] === $groupid) {
+                    return [];
+                }
+                $sql .= ' AND gperm_groupid IN (' . implode(',', $groupid) . ')';
             } else {
                 if ((int) $groupid > 0) {
                     $sql .= ' AND gperm_groupid=' . (int) $groupid;
@@ -527,7 +534,11 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
         if (isset($groupid)) {
             $sql = 'SELECT DISTINCT gperm_itemid FROM ' . $db->prefix('group_permission') . " WHERE gperm_name = 'block_read' AND gperm_modid = 1";
             if (is_array($groupid)) {
-                $sql .= ' AND gperm_groupid IN (' . implode(',', array_map('intval', $groupid)) . ')';
+                $groupid = array_map('intval', $groupid);
+                if ([] === $groupid) {
+                    return $ret;
+                }
+                $sql .= ' AND gperm_groupid IN (' . implode(',', $groupid) . ')';
             } else {
                 if ((int) $groupid > 0) {
                     $sql .= ' AND gperm_groupid=' . (int) $groupid;
@@ -572,7 +583,7 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
         }
         // ORDER BY allowlist: comma-separated col / tbl.col tokens with an optional
         // ASC/DESC only — reject anything else to block ORDER BY injection (L-7).
-        if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', (string) $orderby)) {
+        if (!preg_match('/^\s*(?:[A-Za-z_]\w*\.)?[A-Za-z_]\w*(?:\s+(?:ASC|DESC))?(?:\s*,\s*(?:[A-Za-z_]\w*\.)?[A-Za-z_]\w*(?:\s+(?:ASC|DESC))?)*\s*$/i', (string) $orderby)) {
             $orderby = 'b.weight, m.block_id';
         }
         $sql .= ' ORDER BY ' . $orderby;
@@ -647,7 +658,7 @@ class SystemBlockHandler extends XoopsPersistableObjectHandler
             $sql .= ' AND b.bid IN (' . implode(',', array_map('intval', $non_grouped)) . ')';
             // ORDER BY allowlist: comma-separated col / tbl.col tokens with an optional
             // ASC/DESC only — reject anything else to block ORDER BY injection (L-7).
-            if (!preg_match('/^\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?(\s*,\s*[a-zA-Z_][\w.]*(\s+(ASC|DESC))?)*\s*$/i', (string) $orderby)) {
+            if (!preg_match('/^\s*(?:[A-Za-z_]\w*\.)?[A-Za-z_]\w*(?:\s+(?:ASC|DESC))?(?:\s*,\s*(?:[A-Za-z_]\w*\.)?[A-Za-z_]\w*(?:\s+(?:ASC|DESC))?)*\s*$/i', (string) $orderby)) {
                 $orderby = 'b.weight, m.block_id';
             }
             $sql .= ' ORDER BY ' . $orderby;

--- a/tests/unit/htdocs/class/UploaderContentSniffTest.php
+++ b/tests/unit/htdocs/class/UploaderContentSniffTest.php
@@ -42,8 +42,10 @@ class UploaderContentSniffTest extends TestCase
 
     private function makeProbe(string $bytes): UploaderContentSniffProbe
     {
-        $this->tmp = (string) tempnam(sys_get_temp_dir(), 'upl');
-        file_put_contents($this->tmp, $bytes);
+        $tmp = tempnam(sys_get_temp_dir(), 'upl');
+        $this->assertNotFalse($tmp, 'tempnam() failed to create a temp file');
+        $this->assertNotFalse(file_put_contents($tmp, $bytes), 'failed to write temp fixture');
+        $this->tmp = $tmp;
 
         $probe                = new UploaderContentSniffProbe();
         $probe->mediaTmpName  = $this->tmp;

--- a/tests/unit/htdocs/class/UploaderContentSniffTest.php
+++ b/tests/unit/htdocs/class/UploaderContentSniffTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace xoopsclass;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once XOOPS_ROOT_PATH . '/class/uploader.php';
+require_once XOOPS_ROOT_PATH . '/language/english/uploader.php';
+
+/**
+ * Exposes checkMimeType() without the XOOPS-bootstrap-dependent constructor
+ * (the real constructor loads the MIME map via $GLOBALS['xoops']).
+ */
+class UploaderContentSniffProbe extends \XoopsMediaUploader
+{
+    public function __construct()
+    {
+        // Intentionally skip the parent constructor.
+    }
+}
+
+/**
+ * Verifies the finfo content-sniffing added to XoopsMediaUploader::checkMimeType()
+ * (SECURITY.md M-12): a file whose real bytes are PHP/HTML must be rejected even
+ * when the client-supplied type and extension claim it is an image.
+ */
+#[CoversClass(\XoopsMediaUploader::class)]
+class UploaderContentSniffTest extends TestCase
+{
+    private string $tmp = '';
+
+    protected function tearDown(): void
+    {
+        if ('' !== $this->tmp && is_file($this->tmp)) {
+            unlink($this->tmp);
+        }
+    }
+
+    private function makeProbe(string $bytes): UploaderContentSniffProbe
+    {
+        $this->tmp = (string) tempnam(sys_get_temp_dir(), 'upl');
+        file_put_contents($this->tmp, $bytes);
+
+        $probe                = new UploaderContentSniffProbe();
+        $probe->mediaTmpName  = $this->tmp;
+        $probe->mediaType     = 'image/png'; // what a malicious client would claim
+        $probe->mediaRealType = 'image/png'; // extension-derived
+        return $probe;
+    }
+
+    #[Test]
+    public function phpContentDisguisedAsImageIsRejected(): void
+    {
+        if (!class_exists('finfo')) {
+            $this->markTestSkipped('fileinfo extension not available');
+        }
+        $probe = $this->makeProbe("<?php echo 'pwned'; ?>\n");
+        $this->assertFalse($probe->checkMimeType());
+    }
+
+    #[Test]
+    public function htmlContentDisguisedAsImageIsRejected(): void
+    {
+        if (!class_exists('finfo')) {
+            $this->markTestSkipped('fileinfo extension not available');
+        }
+        $probe = $this->makeProbe('<!DOCTYPE html><html><body><script>alert(1)</script></body></html>');
+        $this->assertFalse($probe->checkMimeType());
+    }
+
+    #[Test]
+    public function genuinePngIsAccepted(): void
+    {
+        if (!class_exists('finfo')) {
+            $this->markTestSkipped('fileinfo extension not available');
+        }
+        if (!function_exists('imagecreatetruecolor')) {
+            $this->markTestSkipped('GD extension not available');
+        }
+        $img = imagecreatetruecolor(1, 1);
+        ob_start();
+        imagepng($img);
+        $png = (string) ob_get_clean();
+        imagedestroy($img);
+
+        $probe                   = $this->makeProbe($png);
+        $probe->allowedMimeTypes = ['image/png'];
+        $this->assertTrue($probe->checkMimeType());
+    }
+}

--- a/tests/unit/htdocs/class/XoopsMediaUploaderTest.php
+++ b/tests/unit/htdocs/class/XoopsMediaUploaderTest.php
@@ -39,7 +39,8 @@ class XoopsMediaUploaderTest extends TestCase
         $uploader->allowedMimeTypes = [];
         $uploader->deniedMimeTypes = ['application/x-httpd-php'];
         $uploader->extensionsToBeSanitized = [
-            'php', 'phtml', 'phtm', 'php3', 'php4', 'cgi', 'pl', 'asp', 'php5', 'php7',
+            'php', 'phtml', 'phtm', 'pht', 'php3', 'php4', 'php5', 'php7', 'php8',
+            'phar', 'shtml', 'cgi', 'pl', 'asp',
         ];
         $uploader->imageExtensions = [
             1 => 'gif', 2 => 'jpg', 3 => 'png', 4 => 'swf', 5 => 'psd',
@@ -623,7 +624,10 @@ class XoopsMediaUploaderTest extends TestCase
     public function testDefaultExtensionsToBeSanitized(): void
     {
         $uploader = $this->createUploader();
-        $expected = ['php', 'phtml', 'phtm', 'php3', 'php4', 'cgi', 'pl', 'asp', 'php5', 'php7'];
+        $expected = [
+            'php', 'phtml', 'phtm', 'pht', 'php3', 'php4', 'php5', 'php7', 'php8',
+            'phar', 'shtml', 'cgi', 'pl', 'asp',
+        ];
         $this->assertSame($expected, $uploader->extensionsToBeSanitized);
     }
 

--- a/tests/unit/htdocs/class/XoopsMediaUploaderTest.php
+++ b/tests/unit/htdocs/class/XoopsMediaUploaderTest.php
@@ -623,7 +623,10 @@ class XoopsMediaUploaderTest extends TestCase
 
     public function testDefaultExtensionsToBeSanitized(): void
     {
-        $uploader = $this->createUploader();
+        // Read the real class default (the shared fixture overrides this property,
+        // which would make the assertion self-fulfilling) so a regression in the
+        // class default is actually caught.
+        $uploader = (new ReflectionClass(\XoopsMediaUploader::class))->newInstanceWithoutConstructor();
         $expected = [
             'php', 'phtml', 'phtm', 'pht', 'php3', 'php4', 'php5', 'php7', 'php8',
             'phar', 'shtml', 'cgi', 'pl', 'asp',
@@ -633,7 +636,7 @@ class XoopsMediaUploaderTest extends TestCase
 
     public function testDefaultDeniedMimeTypes(): void
     {
-        $uploader = $this->createUploader();
+        $uploader = (new ReflectionClass(\XoopsMediaUploader::class))->newInstanceWithoutConstructor();
         $this->assertSame(['application/x-httpd-php'], $uploader->deniedMimeTypes);
     }
 

--- a/tests/unit/htdocs/kernel/XoopsObjectHandlerBuildOrderByTest.php
+++ b/tests/unit/htdocs/kernel/XoopsObjectHandlerBuildOrderByTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace kernel;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+require_once XOOPS_ROOT_PATH . '/kernel/object.php';
+
+/**
+ * Covers XoopsObjectHandler::buildOrderBy() — the ORDER BY allowlist helper
+ * introduced in the pass-3 hardening (SECURITY.md L-6). Verifies that only
+ * allowlisted columns survive, that injection / unknown qualifiers cannot reach
+ * the emitted clause, that the criteria order is sanitized, and that the default
+ * column is used when nothing valid remains.
+ */
+#[CoversClass(\XoopsObjectHandler::class)]
+class XoopsObjectHandlerBuildOrderByTest extends TestCase
+{
+    /** @var string[] */
+    private const COLS = ['com_id', 'com_created', 'com_modified'];
+
+    #[Test]
+    public function singleValidColumnGetsDefaultDirection(): void
+    {
+        $this->assertSame(
+            'com_created DESC',
+            \XoopsObjectHandler::buildOrderBy('com_created', 'DESC', self::COLS, 'com_id'),
+        );
+    }
+
+    #[Test]
+    public function perClauseDirectionIsHonoured(): void
+    {
+        $this->assertSame(
+            'com_created ASC, com_modified DESC',
+            \XoopsObjectHandler::buildOrderBy('com_created ASC, com_modified DESC', 'ASC', self::COLS, 'com_id'),
+        );
+    }
+
+    #[Test]
+    public function unknownColumnFallsBackToDefault(): void
+    {
+        $this->assertSame(
+            'com_id ASC',
+            \XoopsObjectHandler::buildOrderBy('com_secret', 'ASC', self::COLS, 'com_id'),
+        );
+    }
+
+    #[Test]
+    public function unknownTableQualifierIsStripped(): void
+    {
+        // "bogus.com_id" passes the column allowlist but the bogus alias must not
+        // reach the SQL — with the default prefix the emitted clause is bare.
+        $this->assertSame(
+            'com_id ASC',
+            \XoopsObjectHandler::buildOrderBy('bogus.com_id', 'ASC', self::COLS, 'com_created'),
+        );
+    }
+
+    #[Test]
+    public function canonicalPrefixDisambiguatesJoinedColumns(): void
+    {
+        // Mirrors imagemanager.php's binary (joined) path: image_id exists in both
+        // joined tables, so the handler forces the "i." alias. Any caller-supplied
+        // qualifier is replaced with the canonical one.
+        $cols = ['image_weight', 'image_id'];
+        $this->assertSame(
+            'i.image_weight ASC, i.image_id DESC',
+            \XoopsObjectHandler::buildOrderBy('i.image_weight ASC, i.image_id', 'DESC', $cols, 'image_weight', 'i.'),
+        );
+        // A bogus qualifier on input is still dropped and replaced with "i.".
+        $this->assertSame(
+            'i.image_id ASC',
+            \XoopsObjectHandler::buildOrderBy('bogus.image_id', 'ASC', $cols, 'image_weight', 'i.'),
+        );
+        // The default-column fallback also carries the canonical prefix.
+        $this->assertSame(
+            'i.image_weight ASC',
+            \XoopsObjectHandler::buildOrderBy('not_a_column', 'ASC', $cols, 'image_weight', 'i.'),
+        );
+    }
+
+    #[Test]
+    #[DataProvider('injectionProvider')]
+    public function injectionAttemptsNeverEmitMaliciousSql(string $sort, string $order): void
+    {
+        $result = \XoopsObjectHandler::buildOrderBy($sort, $order, self::COLS, 'com_id');
+        // Whatever the payload, the result is one or more "col ASC|DESC" clauses.
+        $this->assertMatchesRegularExpression(
+            '/^[A-Za-z_]\w*\s+(ASC|DESC)(,\s[A-Za-z_]\w*\s+(ASC|DESC))*$/',
+            $result,
+        );
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function injectionProvider(): array
+    {
+        return [
+            'union in sort'        => ['com_id; DROP TABLE x', 'ASC'],
+            'subquery in sort'     => ['(SELECT 1)', 'ASC'],
+            'injection in order'   => ['com_id', 'ASC, (SELECT password FROM users)'],
+            'sleep in order'       => ['com_created', 'DESC; SELECT SLEEP(5)'],
+            'empty sort'           => ['', 'ASC'],
+            'backtick in sort'     => ['`com_id`', 'DESC'],
+        ];
+    }
+
+    #[Test]
+    public function malformedColumnPrefixIsNeutralised(): void
+    {
+        // A public static helper must not trust the prefix: anything that is not
+        // '' or a single "alias." qualifier is dropped, so a careless future caller
+        // cannot inject through it.
+        $this->assertSame(
+            'com_id ASC',
+            \XoopsObjectHandler::buildOrderBy('com_id', 'ASC', self::COLS, 'com_id', 'evil; DROP TABLE x --'),
+        );
+        $this->assertSame(
+            'com_id ASC',
+            \XoopsObjectHandler::buildOrderBy('com_id', 'ASC', self::COLS, 'com_id', 'a.b.'),
+        );
+    }
+
+    #[Test]
+    public function invalidOrderIsCoercedToAsc(): void
+    {
+        $this->assertSame(
+            'com_id ASC',
+            \XoopsObjectHandler::buildOrderBy('com_id', 'GARBAGE', self::COLS, 'com_id'),
+        );
+    }
+}


### PR DESCRIPTION
## Security hardening — pass 3 (medium/low defence-in-depth)

Third hardening pass over the remaining backlog items. Pass 1 (#92) covered the
Critical + High findings; pass 2 (#102) covered the medium XSS/SSRF/crypto set.
This pass takes the remaining medium/low defence-in-depth items that are safe to
apply now, and **explicitly defers** the ones that need a test environment or a
caller audit (listed at the bottom).

### Included

**Defence-in-depth batch** (`security(core)`)
- **checklogin** — return the generic `_US_INCORRECTLOGIN` for every credential
  failure instead of the auth provider's specific errors (user enumeration).
- **common** — cast the session user id to `int` in the `last_login` UPDATE.
- **kernel/comment, notification, image** — allowlist `Criteria::getSort()`
  against the real column names before `ORDER BY` (mirrors the existing
  `privmessage`/`configcategory` pattern). `getOrder()` is already constrained
  to `ASC`/`DESC`.
- **kernel/block** — `intval` the group-id lists and validate the `ORDER BY`
  clause against a column/direction pattern in the deprecated group-block methods.
- **xoopseditor/tinymce7** — add `JSON_HEX_TAG|JSON_HEX_APOS|JSON_HEX_QUOT` to
  the config `json_encode` to block `</script>` breakout (the raw-JS placeholder
  mechanism is unaffected — placeholders are alphanumeric).
- **smarty3_plugins/xoPageNav** — read params explicitly instead of `extract()`
  and escape the prev/next hrefs (only the numbered links were escaped before).
- **install/page_dbsettings** — restrict `DB_NAME` to a safe identifier before it
  reaches the backtick-quoted `CREATE`/`ALTER DATABASE` (`mysqli_real_escape_string`
  does not escape backticks).
- **install/page_tablesfill** — read the admin session fields explicitly instead
  of `extract($_SESSION['siteconfig'])`.
- **xoopssecurity** — bound bad-IP pattern length and block only on a definite
  `preg_match` hit, so a malformed admin pattern no longer warns or mis-blocks.
- **pm/templates/pm_readpmsg** — document the `getVar('s')` pre-escape contract.

**Upload content-sniffing** (`security(upload)`)
- `XoopsMediaUploader::checkMimeType()` now content-sniffs the uploaded bytes with
  `finfo` and refuses files whose real type is PHP source or HTML, regardless of
  the client-supplied MIME or extension. The double-extension sanitiser gains
  `pht`/`phar`/`shtml`/`php8`. Runs in `upload()` before the file is copied. All
  core callers are image-only, so legitimate uploads are unaffected.

**Image source cap** (`security(image)`)
- Reject the source before `imagecreatefrom*()` when the raw blob/file exceeds
  25 MiB or would decode to more than ~40 MP, on both the DB-blob and file paths
  (the previous pass only capped the *output*). Also rejects when `getimagesize()`
  fails outright.

### Verification
Focused PHPUnit run (security/uploader/image/kernel suites): **673 tests, 1213
assertions, 0 failures/errors**. PHP-lint clean on every changed file.

### Deliberately deferred (need a test env or an audit — not shipped here)
- **T-07 installer hard-stop** — the proposed guard bricks fresh installs:
  `mainfile.php` is written at step 7 of 14 and every later step re-includes
  `common.inc.php`; DB-state signals also flip mid-install. Needs a real
  fresh+mid+rerun install test before a correct (completion-marker) guard.
- **T-11 form-renderer escaping** — confirmed double-encode risk: callers feed
  `getVar('field','e')` (already escaped), so renderer-side escaping would visibly
  break admin edit forms. Needs a renderer-contract decision + caller normalisation.
- **Snoopy deletion** — *not* removed. It was recently hardened (curl migration,
  `SnoopyTest` added in "security audit phase 2") and its notice marks removal for
  a future version, so it is being kept and maintained on purpose.
- **L-11** installer dead `XOOPS_URL` branch (cosmetic; removal risks `XOOPS_URL`
  writing), **L-17 / T-19** the repo-root `upgrade/` tree (separate git repo —
  its own follow-up), **L-18** request-hash pinning (needs a per-endpoint
  request-method audit; `user.php`'s `op` legitimately arrives via both GET and POST).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security protections against oversized image uploads and resource exhaustion
  * Improved authentication error messages to prevent information disclosure
  * Strengthened file upload validation with content-based MIME detection
  * Hardened database and system inputs against malformed patterns and injection attempts
  * Fixed user login session timestamp tracking with proper type safety
  * Improved editor configuration encoding reliability with better error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Review round 2 (CodeRabbit / Gemini / Grok / Codex) — addressed in 1b4a2752c

- **ORDER BY (CodeRabbit Major, Gemini):** the kernel `comment`/`notification`/`image`
  handlers now use the same comma-separated column/direction pattern as `block.php`
  instead of an exact single-column list, so valid multi-column sorts and columns
  outside the original list are preserved while injection is still blocked.
- **image.php (Grok/Codex):** file-backed records are size-checked with
  `is_file()`/`filesize()` *before* `file_get_contents()`, so an oversized file is
  rejected without being read into memory.
- **xoopssecurity (Grok/Codex/Gemini):** the bad-IP scan now runs under a temporary
  error handler, so a malformed admin pattern (e.g. a CIDR whose `/` collides with the
  delimiter) genuinely neither warns nor blocks.
- **htmlspecialchars (CodeRabbit):** explicit `'UTF-8'` added to the new calls.
- **Tests (Grok/Codex):** `UploaderContentSniffTest` covers PHP/HTML-as-image
  rejection and genuine-PNG acceptance.

**Scope note on upload sniffing:** `checkMimeType()` blocks executable/markup content
by sniffing (PHP-source and HTML families) rather than enforcing the full detected MIME
against the per-call allowlist — enforcing exact-MIME equality risks false rejects
(`image/jpeg` vs `image/pjpeg`/`image/x-png`), and declared images are independently
re-validated by `checkImageType()`'s `getimagesize()`.
