### PR TITLE
security(upgrade): require admin group for the upgrade wizard login

### DIFF
--- a/upgrade/login.php
+++ b/upgrade/login.php
@@ -76,16 +76,16 @@ if ('' === $uname || '' === $pass) {
         }
     }
 
+    // The upgrade wizard is an administrative tool: it must never establish a
+    // session for a non-admin, regardless of closesite. Require webmaster-group
+    // (XOOPS_GROUP_ADMIN) membership and do NOT honour closesite_okgrp here.
+    // Group ids are normalised to int so the strict compare holds whether
+    // getGroups() yields string or int ids (XOOPS_GROUP_ADMIN is the string '1').
     $isAllowed = false;
-    if (is_object($user) && $user->getVar('level') > 0) {
-        $isAllowed = true;
-        if ($xoopsConfig['closesite'] == 1) {
-            $groups = $user->getGroups();
-            if (in_array(XOOPS_GROUP_ADMIN, $groups) || array_intersect($groups, $xoopsConfig['closesite_okgrp'])) {
-                $isAllowed = true;
-            } else {
-                $isAllowed = false;
-            }
+    if (is_object($user) && (int) $user->getVar('level') > 0) {
+        $groups = $user->getGroups();
+        if (is_array($groups) && in_array((int) XOOPS_GROUP_ADMIN, array_map('intval', $groups), true)) {
+            $isAllowed = true;
         }
     }
     if ($isAllowed) {


### PR DESCRIPTION
## Summary

Tightens the authorization gate in the upgrade wizard login handler
(`upgrade/login.php`) so it only establishes a session for a site
administrator.

## Motivation

The previous logic admitted any active user (`level > 0`) and only consulted
group membership when the site was closed, additionally honouring
`closesite_okgrp`. The upgrade wizard is an administrative tool, so its login
handler should require webmaster-group membership in all cases.

Defence in depth: `upgrade/index.php` already gates every upgrade action
behind `$xoopsUser->isAdmin()`, so a non-admin whose session was primed here
is bounced before any migration runs. This change closes the weaker
session-priming path in `login.php` rather than relying on a single check.

## Approach

Require `XOOPS_GROUP_ADMIN` membership regardless of `closesite`, and stop
honouring `closesite_okgrp` here.

```php
$isAllowed = false;
if (is_object($user) && (int) $user->getVar('level') > 0) {
    $groups = $user->getGroups();
    if (is_array($groups) && in_array((int) XOOPS_GROUP_ADMIN, array_map('intval', $groups), true)) {
        $isAllowed = true;
    }
}
```

Group ids are normalised with `intval` before a strict `in_array`. This
matters: `XOOPS_GROUP_ADMIN` is defined as the string `'1'`, so a naive
strict compare against int group ids (`'1' === 1`) would reject legitimate
admins. Normalising both sides to int keeps the check correct regardless of
id type.

## Testing

- `php -l` clean.
- Manual trace: non-admin credentials no longer set `$_SESSION['xoopsUserId']`
  in the upgrade context; admin (webmaster-group) login unaffected.

## Checklist

- [x] Admin-only tool now requires admin group membership
- [x] Type-safe group comparison (no admin lockout)
- [x] No BC break for legitimate admins

## Summary by Sourcery

Bug Fixes:
- Prevent upgrade wizard sessions from being created for non-admin users when the site is open or closed.