### PR TITLE
chore(release): XOOPS 2.7.1-RC1

### DIFF
--- a/docs/changelog.270.txt
+++ b/docs/changelog.270.txt
@@ -1,16 +1,24 @@
 XOOPS 2.7.x Changelog (Language changes: see: /docs/lang_diff.txt)
 
 ===================================
-2.7.1 Beta 2                  2026-06
+2.7.1 RC1                     2026-07
 ===================================
 Version and platform:
-- start the 2.7.1 Beta 2 cycle; set XOOPS_VERSION to "XOOPS 2.7.1-Beta2" (mamba)
+- promote the 2.7.1 cycle to RC1; set XOOPS_VERSION to "XOOPS 2.7.1-RC1" (mamba)
+
+Security:
+- harden SQL identifier and ORDER BY channels across Criteria, kernel/block and system admin (mamba) in #114
+- require a security token on the upgrade apply-patch path; move SQL dumps out of the web root and gate the download (mamba) in #114
+- inspect queryF() in the Protector dblayertrap wrapper; escape ModuleAdmin index menu output; basename language file loads (mamba) in #114
+- add CAPTCHA and a persistent per-IP rate limit to the tell-a-friend form (mamba) in #114
+- require admin-group membership for the upgrade wizard login (mamba) in #116
 
 Dependencies:
 - add xoops/helpers ^1.0 and tecnickcom/tcpdf ^6.10 to the bundled libraries (mamba)
 - bump xoops/smartyextensions from ^1.0 to ^1.3 (brings chillerlan/php-qrcode for QR support) (mamba)
-- bump xoops/xmf from ^1.3.0 to ^1.3.1 (mamba)
+- bump xoops/xmf to ^1.3.1 (v1.3.1-RC1; includes the queryF() -> exec() migration) (mamba) in #115
 - update webmozart/assert from 2.4.0 to 2.4.1 (mamba)
+- composer update sweep: php-debugbar 3.8.0, smarty 4.5.7, symfony/var-dumper and symfony/yaml 7.4.14 (mamba) in #115
 
 ===================================
 2.7.1 Beta 1                  2026-05

--- a/htdocs/include/version.php
+++ b/htdocs/include/version.php
@@ -32,4 +32,4 @@ if (file_exists($licenseFile)) {
 /**
  *  Define XOOPS version
  */
-define('XOOPS_VERSION', 'XOOPS 2.7.1-Beta2');
+define('XOOPS_VERSION', 'XOOPS 2.7.1-RC1');


### PR DESCRIPTION
## Summary

Promotes the 2.7.1 cycle from Beta2 to **RC1**. Version bump and changelog
only — no functional code changes.

- `htdocs/include/version.php`: `XOOPS_VERSION` → `XOOPS 2.7.1-RC1`
- `docs/changelog.270.txt`: new RC1 section, with the never-released Beta2
  cycle notes folded in

## Motivation

The 2.7.1 tree is feature-complete: 0 open issues / PRs and green CI across
PHP 8.2–8.5 after the hardening (#114), dependency refresh (#115), and
upgrade-login (#116) work. RC1 signals release-candidate confidence; only
blocker fixes are expected from here to final.

## Notes

- `CHANGELOG.md` is intentionally not edited here — it is regenerated by the
  git-cliff `changelog.yml` workflow.
- Tag `v2.7.1-RC1` and the GitHub pre-release are cut after this merges.

## Checklist

- [x] Version constant bumped (only core version marker)
- [x] Manual changelog updated (`docs/changelog.270.txt`)
- [x] No functional code changes
- [x] Pre-release — not final

## Summary by Sourcery

Promote the 2.7.1 release line from Beta2 to RC1 by updating the core version marker and the 2.7.0 changelog.

Enhancements:
- Update the XOOPS core version constant to 2.7.1-RC1 for the upcoming release candidate.
- Refresh the 2.7.0 series changelog to include the 2.7.1-RC1 notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release notes to reflect **XOOPS 2.7.1-RC1**.
  * Added highlighted security-related improvements, including stronger input handling, safer upgrade flow, CAPTCHA/rate limiting for contact features, and stricter admin checks during upgrades.
  * Refreshed the bundled dependency list for the RC1 release.
* **Chores**
  * Updated the displayed product version to **XOOPS 2.7.1-RC1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->