### PR TITLE
fix(moduleadmin): render safe-subset HTML in About changelog

### DIFF
--- a/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
@@ -507,6 +507,36 @@ class ModuleAdmin
     }
 
     /**
+     * Render a single changelog line as a safe subset of presentational HTML.
+     *
+     * Changelog files ship inside the module and are authored by the module
+     * developer, but they are still sanitized defensively. The whole line is
+     * HTML-escaped first, so every literal "<", ">" and "&" survives as visible
+     * text with no content loss (e.g. "requires PHP <= 8.0" or "<table>" stay
+     * readable). Only an explicit allowlist of attribute-free presentational
+     * tags is then re-enabled; any tag carrying attributes, or any tag not on
+     * the list, stays inert escaped text and can never inject <script>, event
+     * handlers, or href="javascript:" vectors. The allowlist is enforced in the
+     * pattern below, not delegated to strip_tags().
+     *
+     * @param string $line raw changelog line
+     *
+     * @return string sanitized HTML fragment
+     */
+    public static function sanitizeChangelogLine($line)
+    {
+        static $allowed = 'h1|h2|h3|h4|h5|h6|p|br|hr|ul|ol|li|strong|b|em|i|u|code|pre|blockquote|span';
+
+        $escaped = htmlspecialchars((string) $line, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+        return preg_replace_callback(
+            '#&lt;(/?)\s*(' . $allowed . ')\s*(/?)&gt;#i',
+            static fn($m) => '<' . $m[1] . strtolower($m[2]) . $m[3] . '>',
+            $escaped
+        );
+    }
+
+    /**
      * Create HTML text to display on Admin About page.
      *
      * The standard footer text is always appended via _AM_MODULEADMIN_ADMIN_FOOTER.
@@ -597,16 +627,10 @@ class ModuleAdmin
         // basename() the language segment so a poisoned config value cannot
         // traverse out of the module language directory.
         $language = empty( $GLOBALS['xoopsConfig']['language'] ) ? 'english' : basename( (string) $GLOBALS['xoopsConfig']['language'] );
-        // Changelog files ship inside the module and are authored by the module
-        // developer (trusted). Render a safe subset of presentational HTML so the
-        // intended formatting (headings, emphasis, rules) displays, while a poisoned
-        // changelog still cannot inject <script>, event handlers, or href=javascript:.
-        $allowedTags   = '<h1><h2><h3><h4><h5><h6><p><br><hr><ul><ol><li><strong><b><em><i><u><code><pre><blockquote><span>';
-        $changelogLine = static function ($line) use ($allowedTags) {
-            $line = strip_tags((string) $line, $allowedTags);
-            // Strip any attributes (onclick=, style=, href=, …) from the surviving tags.
-            return preg_replace('/<\s*(\/?)\s*([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>/', '<$1$2>', $line);
-        };
+        // Changelog files are rendered as a safe subset of presentational HTML
+        // (see sanitizeChangelogLine()) so intended formatting displays while any
+        // script/event-handler/attribute injection stays inert escaped text.
+        $changelogLine = static fn($line) => self::sanitizeChangelogLine($line);
         $file          = XOOPS_ROOT_PATH . "/modules/{$module_dir}/language/{$language}/changelog.txt";
         if ( !is_file( $file ) && ( 'english' !== $language ) ) {
             $file = XOOPS_ROOT_PATH . "/modules/{$module_dir}/language/english/changelog.txt";

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
@@ -597,16 +597,26 @@ class ModuleAdmin
         // basename() the language segment so a poisoned config value cannot
         // traverse out of the module language directory.
         $language = empty( $GLOBALS['xoopsConfig']['language'] ) ? 'english' : basename( (string) $GLOBALS['xoopsConfig']['language'] );
-        $file     = XOOPS_ROOT_PATH . "/modules/{$module_dir}/language/{$language}/changelog.txt";
+        // Changelog files ship inside the module and are authored by the module
+        // developer (trusted). Render a safe subset of presentational HTML so the
+        // intended formatting (headings, emphasis, rules) displays, while a poisoned
+        // changelog still cannot inject <script>, event handlers, or href=javascript:.
+        $allowedTags   = '<h1><h2><h3><h4><h5><h6><p><br><hr><ul><ol><li><strong><b><em><i><u><code><pre><blockquote><span>';
+        $changelogLine = static function ($line) use ($allowedTags) {
+            $line = strip_tags((string) $line, $allowedTags);
+            // Strip any attributes (onclick=, style=, href=, …) from the surviving tags.
+            return preg_replace('/<\s*(\/?)\s*([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>/', '<$1$2>', $line);
+        };
+        $file          = XOOPS_ROOT_PATH . "/modules/{$module_dir}/language/{$language}/changelog.txt";
         if ( !is_file( $file ) && ( 'english' !== $language ) ) {
             $file = XOOPS_ROOT_PATH . "/modules/{$module_dir}/language/english/changelog.txt";
         }
         if ( is_readable( $file ) ) {
-            $ret .= implode( '<br>', array_map( $esc, file( $file ) ) ) . "\n";
+            $ret .= implode( '<br>', array_map( $changelogLine, file( $file ) ) ) . "\n";
         } else {
             $file = XOOPS_ROOT_PATH . "/modules/{$module_dir}/docs/changelog.txt";
             if ( is_readable( $file ) ) {
-                $ret .= implode( '<br>', array_map( $esc, file( $file ) ) ) . "\n";
+                $ret .= implode( '<br>', array_map( $changelogLine, file( $file ) ) ) . "\n";
             }
         }
         $ret .= "</div>\n"

--- a/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
+++ b/htdocs/Frameworks/moduleclasses/moduleadmin/moduleadmin.php
@@ -523,17 +523,19 @@ class ModuleAdmin
      *
      * @return string sanitized HTML fragment
      */
-    public static function sanitizeChangelogLine($line)
+    public static function sanitizeChangelogLine(string $line): string
     {
         static $allowed = 'h1|h2|h3|h4|h5|h6|p|br|hr|ul|ol|li|strong|b|em|i|u|code|pre|blockquote|span';
 
-        $escaped = htmlspecialchars((string) $line, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        $escaped = htmlspecialchars($line, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 
+        // preg_replace_callback() returns ?string; fall back to the fully-escaped
+        // line if the PCRE engine ever fails, so output is never unsanitized.
         return preg_replace_callback(
             '#&lt;(/?)\s*(' . $allowed . ')\s*(/?)&gt;#i',
-            static fn($m) => '<' . $m[1] . strtolower($m[2]) . $m[3] . '>',
+            static fn($matches) => '<' . $matches[1] . strtolower($matches[2]) . $matches[3] . '>',
             $escaped
-        );
+        ) ?? $escaped;
     }
 
     /**

--- a/tests/unit/htdocs/Frameworks/moduleclasses/ModuleAdminTest.php
+++ b/tests/unit/htdocs/Frameworks/moduleclasses/ModuleAdminTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace frameworksmoduleclasses;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use ModuleAdmin;
@@ -435,6 +436,45 @@ class ModuleAdminTest extends TestCase
 
         $this->assertStringNotContainsString('xoopsmicrobutton.gif', $html, 'About page should not include XOOPS logo');
         $this->assertStringContainsString(_AM_MODULEADMIN_ADMIN_FOOTER, $html, 'About page should still include footer text');
+    }
+
+    // ---------------------------------------------------------------
+    // Changelog sanitizer tests
+    // ---------------------------------------------------------------
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function changelogSanitizerProvider(): array
+    {
+        return [
+            'allowed heading survives'      => ['<h5>1.1.0 RC 1</h5>', '<h5>1.1.0 RC 1</h5>'],
+            'allowed strong survives'       => ['<strong>Added</strong>', '<strong>Added</strong>'],
+            'allowed void hr survives'      => ['<hr>', '<hr>'],
+            'self-closing br survives'      => ['line<br/>break', 'line<br/>break'],
+            'uppercase tag normalized'      => ['<H5>Head</H5>', '<h5>Head</h5>'],
+            'disallowed tag kept as text'   => ['Added support for <table> tags', 'Added support for &lt;table&gt; tags'],
+            'literal comparison preserved'  => ['requires PHP <= 8.0 & up', 'requires PHP &lt;= 8.0 &amp; up'],
+            'bare ampersand escaped'        => ['AT&T', 'AT&amp;T'],
+            'attribute on allowed tag inert'=> ['<strong onclick="x()">y</strong>', '&lt;strong onclick=&quot;x()&quot;&gt;y</strong>'],
+            'script tag inert'              => ['<script>alert(1)</script>', '&lt;script&gt;alert(1)&lt;/script&gt;'],
+            'javascript href inert'         => ['<a href="javascript:alert(1)">x</a>', '&lt;a href=&quot;javascript:alert(1)&quot;&gt;x&lt;/a&gt;'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('changelogSanitizerProvider')]
+    public function testSanitizeChangelogLine(string $input, string $expected): void
+    {
+        $this->assertSame($expected, ModuleAdmin::sanitizeChangelogLine($input));
+    }
+
+    #[Test]
+    public function testSanitizeChangelogLineNeverEmitsScriptTag(): void
+    {
+        $output = ModuleAdmin::sanitizeChangelogLine('<script>alert(document.cookie)</script>');
+
+        $this->assertStringNotContainsString('<script>', $output, 'A poisoned changelog must never emit an executable <script> tag');
     }
 
     // ---------------------------------------------------------------


### PR DESCRIPTION
The 2.7.1 hardening pass wrapped every changelog line in htmlspecialchars, so the intentional <h5>/<strong>/<hr> markup shipped in module changelog.txt files rendered as literal source text on the module About page.

Changelog files ship inside the module and are authored by the module developer, so full escaping broke legitimate formatting for no real gain. Render an allowlist of presentational tags instead, and strip all attributes from the surviving tags, so headings/emphasis/rules display again while a poisoned changelog still cannot inject <script>, event handlers, or href=javascript: vectors.

Module metadata fields keep their existing htmlspecialchars escaping.

## Summary by Sourcery

Render module changelog content on the About page using a restricted set of safe HTML tags instead of fully escaping all markup.

Enhancements:
- Introduce a sanitization helper for changelog lines that strips all attributes while allowing a whitelist of presentational HTML tags for formatting.
- Update changelog rendering to use the new sanitization helper for both language-specific and docs-based changelog files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Changelog entries are now displayed more safely while preserving a small set of basic formatting like bold or italics.
  * Unsupported or potentially harmful HTML is shown as plain text instead of being rendered.

* **Tests**
  * Added coverage for changelog sanitization to verify safe output across multiple formatting cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->