### PR TITLE
compat: PHP 8.5 hardening and who-is-online tracking for 2.7.3-Beta1

### DIFF
--- a/htdocs/class/cache/file.php
+++ b/htdocs/class/cache/file.php
@@ -211,9 +211,25 @@ class XoopsCacheFile extends XoopsCacheEngine
         $data = $this->file->read(true);
         if (!empty($data) && !empty($this->settings['serialize'])) {
             $data = stripslashes($data);
-            // $data = preg_replace('!s:(\d+):"(.*?)";!se', "'s:'.strlen('$2').':\"$2\";'", $data);
-            $data = preg_replace_callback('!s:(\d+):"(.*?)";!s', function ($m) { return 's:' . strlen($m[2]) . ':"' . $m[2] . '";'; }, $data);
-            $data = unserialize($data, ['allowed_classes' => false]);
+
+            // Try the payload as-is first. The length-repair pass below exists for
+            // magic_quotes-era data, but its pattern is non-greedy: a stored string
+            // containing '";' terminates the match early, so the rewritten length is
+            // too short and unserialize() then fails at an offset. That silently
+            // turned every affected cache entry into a permanent miss.
+            $unserialized = unserialize($data, ['allowed_classes' => false]);
+
+            if (false === $unserialized && 'b:0;' !== $data) {
+                // Genuinely malformed: fall back to the legacy length repair.
+                $repaired = preg_replace_callback(
+                    '!s:(\d+):"(.*?)";!s',
+                    static function ($m) { return 's:' . strlen($m[2]) . ':"' . $m[2] . '";'; },
+                    $data
+                );
+                $unserialized = unserialize($repaired, ['allowed_classes' => false]);
+            }
+
+            $data = $unserialized;
             if (is_array($data)) {
                 XoopsLoad::load('XoopsUtility');
                 $data = XoopsUtility::recursive('stripslashes', $data);

--- a/htdocs/class/cache/file.php
+++ b/htdocs/class/cache/file.php
@@ -217,7 +217,19 @@ class XoopsCacheFile extends XoopsCacheEngine
             // containing '";' terminates the match early, so the rewritten length is
             // too short and unserialize() then fails at an offset. That silently
             // turned every affected cache entry into a permanent miss.
-            $unserialized = unserialize($data, ['allowed_classes' => false]);
+            //
+            // This first parse is SPECULATIVE, so its failure is expected for genuine
+            // legacy payloads and must not reach the error log. unserialize() emits an
+            // E_WARNING on malformed input, so swallow it for the duration of the probe
+            // only — the fallback below runs unguarded and still reports real problems.
+            set_error_handler(static function () {
+                return true;
+            }, E_WARNING | E_NOTICE);
+            try {
+                $unserialized = unserialize($data, ['allowed_classes' => false]);
+            } finally {
+                restore_error_handler();
+            }
 
             if (false === $unserialized && 'b:0;' !== $data) {
                 // Genuinely malformed: fall back to the legacy length repair.

--- a/htdocs/class/logger/xoopslogger.php
+++ b/htdocs/class/logger/xoopslogger.php
@@ -361,6 +361,9 @@ class XoopsLogger
             echo sprintf($fatalMessage, htmlspecialchars((string) $errstr, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
             if ($includeTrace) {
                 $backtraceLabel = defined('_XOOPS_FATAL_BACKTRACE') ? _XOOPS_FATAL_BACKTRACE : 'Backtrace';
+                // Escaped like every other value echoed here. It is a language constant
+                // today, but translations are user-editable files.
+                $backtraceLabel = htmlspecialchars((string) $backtraceLabel, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
                 echo "<div style='color:#f0f0f0;background-color:#f0f0f0;'>" . $backtraceLabel . ':<br>';
                 if ($trace === null && function_exists('debug_backtrace')) {
                     $trace = \debug_backtrace();

--- a/htdocs/class/logger/xoopslogger.php
+++ b/htdocs/class/logger/xoopslogger.php
@@ -372,7 +372,10 @@ class XoopsLogger
                 foreach ($trace as $step) {
                     if (isset($step['file'])) {
                         echo htmlspecialchars($this->sanitizePath($step['file']), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
-                        echo ' (' . $step['line'] . ")\n<br>";
+                        // The line number is escaped too. Engine-generated traces give an
+                        // int, but handleError() is public and $trace is untyped, so a
+                        // caller can supply any string here.
+                        echo ' (' . htmlspecialchars((string) ($step['line'] ?? '?'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . ")\n<br>";
                     }
                 }
                 echo '</div>';

--- a/htdocs/class/logger/xoopslogger.php
+++ b/htdocs/class/logger/xoopslogger.php
@@ -291,8 +291,17 @@ class XoopsLogger
                 $line = $trace['line'] ?? '(unknown line)';
                 $miniTrace .= $file . ':' . $line . "<br>";
             }
-            // Replace paths to keep the output clean
-            $miniTrace = str_replace([XOOPS_VAR_PATH, XOOPS_PATH, XOOPS_ROOT_PATH], '', $miniTrace);
+            // Replace paths to keep the output clean. Guarded so a deprecation raised before
+            // mainfile.php finishes cannot turn into an "Undefined constant" fatal of its own.
+            $paths = [];
+            foreach (['XOOPS_VAR_PATH', 'XOOPS_PATH', 'XOOPS_ROOT_PATH'] as $pathConstant) {
+                if (defined($pathConstant)) {
+                    $paths[] = constant($pathConstant);
+                }
+            }
+            if ([] !== $paths) {
+                $miniTrace = str_replace($paths, '', $miniTrace);
+            }
 
             $this->deprecated[] = $msg . $miniTrace;
 
@@ -345,9 +354,14 @@ class XoopsLogger
                 $includeTrace  = false;
                 $errstr = substr($errstr, 8);
             }
-            echo sprintf(_XOOPS_FATAL_MESSAGE, htmlspecialchars((string) $errstr, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
+            // Guarded: an E_USER_ERROR can be raised before the language files are loaded,
+            // and an "Undefined constant" here would replace the real fatal with a useless
+            // one. Fall back to the constant name's plain-English intent.
+            $fatalMessage = defined('_XOOPS_FATAL_MESSAGE') ? _XOOPS_FATAL_MESSAGE : '%s';
+            echo sprintf($fatalMessage, htmlspecialchars((string) $errstr, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
             if ($includeTrace) {
-                echo "<div style='color:#f0f0f0;background-color:#f0f0f0;'>" . _XOOPS_FATAL_BACKTRACE . ':<br>';
+                $backtraceLabel = defined('_XOOPS_FATAL_BACKTRACE') ? _XOOPS_FATAL_BACKTRACE : 'Backtrace';
+                echo "<div style='color:#f0f0f0;background-color:#f0f0f0;'>" . $backtraceLabel . ':<br>';
                 if ($trace === null && function_exists('debug_backtrace')) {
                     $trace = \debug_backtrace();
                     array_shift($trace);  // Remove the first element, which is this function itself
@@ -417,9 +431,15 @@ class XoopsLogger
      */
     protected function sanitizeDbMessage($message)
     {
-        // XOOPS_DB_PREFIX  XOOPS_DB_NAME
-        $message = str_replace(XOOPS_DB_PREFIX . '_', '', $message);
-        $message = str_replace(XOOPS_DB_NAME . '.', '', $message);
+        // Guarded: this runs from the exception handler, which must survive an error raised
+        // BEFORE mainfile.php has defined the database constants. Unguarded, the handler
+        // itself fataled on "Undefined constant XOOPS_DB_PREFIX" and masked the real error.
+        if (defined('XOOPS_DB_PREFIX')) {
+            $message = str_replace(XOOPS_DB_PREFIX . '_', '', $message);
+        }
+        if (defined('XOOPS_DB_NAME')) {
+            $message = str_replace(XOOPS_DB_NAME . '.', '', $message);
+        }
 
         return $message;
     }

--- a/htdocs/class/model/joint.php
+++ b/htdocs/class/model/joint.php
@@ -69,6 +69,7 @@ class XoopsModelJoint extends XoopsModelAbstract
      */
     public function getByLink(?CriteriaElement $criteria = null, $fields = null, $asObject = true, $field_link = null, $field_object = null)
     {
+        $this->assertTableConfigured();
         $ret = [];
         if (!empty($field_link)) {
             $this->handler->field_link = $field_link;
@@ -139,6 +140,7 @@ class XoopsModelJoint extends XoopsModelAbstract
      */
     public function getCountByLink(?CriteriaElement $criteria = null)
     {
+        $this->assertTableConfigured();
         if (!$this->validateLinks()) {
             return null;
         }
@@ -164,6 +166,7 @@ class XoopsModelJoint extends XoopsModelAbstract
      */
     public function getCountsByLink(?CriteriaElement $criteria = null)
     {
+        $this->assertTableConfigured();
         if (!$this->validateLinks()) {
             return null;
         }
@@ -194,6 +197,7 @@ class XoopsModelJoint extends XoopsModelAbstract
      */
     public function updateByLink($data, ?CriteriaElement $criteria = null)
     {
+        $this->assertTableConfigured();
         if (!$this->validateLinks()) {
             return null;
         }
@@ -217,6 +221,7 @@ class XoopsModelJoint extends XoopsModelAbstract
      */
     public function deleteByLink(?CriteriaElement $criteria = null)
     {
+        $this->assertTableConfigured();
         if (!$this->validateLinks()) {
             return null;
         }

--- a/htdocs/class/model/read.php
+++ b/htdocs/class/model/read.php
@@ -38,6 +38,7 @@ class XoopsModelRead extends XoopsModelAbstract
      */
     public function &getAll(?CriteriaElement $criteria = null, $fields = null, $asObject = true, $id_as_key = true)
     {
+        $this->assertTableConfigured();
         if (!empty($fields) && \is_array($fields)) {
             if (!in_array($this->handler->keyName, $fields)) {
                 $fields[] = $this->handler->keyName;
@@ -63,7 +64,8 @@ class XoopsModelRead extends XoopsModelAbstract
         $result = $this->handler->db->query($sql, $limit, $start);
         if (!$this->handler->db->isResultSet($result)) {
             throw new \RuntimeException(
-                \sprintf(_DB_QUERY_ERROR, $sql) . $this->handler->db->error(),
+                \sprintf(_DB_QUERY_ERROR, $sql) . $this->handler->db->error()
+                . \sprintf(' [handler: %s, table: %s]', get_class($this->handler), $this->handler->table),
                 E_USER_ERROR,
             );
         }
@@ -123,6 +125,7 @@ class XoopsModelRead extends XoopsModelAbstract
      */
     public function getList(?CriteriaElement $criteria = null, $limit = 0, $start = 0)
     {
+        $this->assertTableConfigured();
         $ret = [];
         if ($criteria == null) {
             $criteria = new CriteriaCompo();
@@ -167,6 +170,7 @@ class XoopsModelRead extends XoopsModelAbstract
      */
     public function &getIds(?CriteriaElement $criteria = null)
     {
+        $this->assertTableConfigured();
         $ret   = [];
         $sql   = "SELECT `{$this->handler->keyName}` FROM `{$this->handler->table}`";
         $limit = $start = null;

--- a/htdocs/class/model/stats.php
+++ b/htdocs/class/model/stats.php
@@ -35,6 +35,7 @@ class XoopsModelStats extends XoopsModelAbstract
      */
     public function getCount(?CriteriaElement $criteria = null)
     {
+        $this->assertTableConfigured();
         $field   = '';
         $groupby = false;
         if (isset($criteria) && is_subclass_of($criteria, 'CriteriaElement')) {
@@ -75,6 +76,7 @@ class XoopsModelStats extends XoopsModelAbstract
      */
     public function getCounts(?CriteriaElement $criteria = null)
     {
+        $this->assertTableConfigured();
         $ret         = [];
         $sql_where   = '';
         $limit       = null;

--- a/htdocs/class/model/xoopsmodel.php
+++ b/htdocs/class/model/xoopsmodel.php
@@ -143,6 +143,36 @@ class XoopsModelAbstract
     }
 
     /**
+     * Fail fast when the handler was never given a table name.
+     *
+     * XoopsPersistableObjectHandler::__construct() defaults $table to '' and
+     * XoopsDatabase::prefix('') returns the bare prefix, so a handler that never ran
+     * its constructor silently points every query at a table literally named after the
+     * DB prefix. The resulting "Table 'xyz' doesn't exist" gives no hint which handler
+     * is at fault. The usual cause is a PHP4-style constructor (a method named after
+     * the class), which PHP 8 no longer treats as a constructor.
+     *
+     * Checked here rather than in the handler constructor on purpose: some legitimate
+     * subclasses call parent::__construct($db) and assign $this->table themselves, and
+     * a constructor-time check would report those as broken.
+     *
+     * @throws RuntimeException
+     * @return void
+     */
+    protected function assertTableConfigured()
+    {
+        $table = (string) $this->handler->table;
+        if ('' === $table || $table === $this->handler->db->prefix()) {
+            throw new \RuntimeException(sprintf(
+                '%s has no table configured: its constructor never supplied a table name. '
+                . 'A PHP4-style constructor (a method named after the class) is ignored by '
+                . 'PHP 8 — rename it to __construct().',
+                get_class($this->handler)
+            ));
+        }
+    }
+
+    /**
      * XoopsModelAbstract::setVars()
      *
      * @param  mixed $args

--- a/htdocs/class/module.textsanitizer.php
+++ b/htdocs/class/module.textsanitizer.php
@@ -536,13 +536,26 @@ class MyTextSanitizer
     /**
      * Convert special characters to HTML entities
      *
-     * @param  string $text    string being converted
+     * $text accepts any scalar, not just string. Callers legitimately pass ints and floats --
+     * ids, counts, years, timestamps -- and the body has always cast to string on the first
+     * line, so the value was never used as anything but a string. A bare "string" declaration
+     * made that cast unreachable for such callers: strict_types is decided by the CALLING
+     * file, so any module with declare(strict_types=1) got an uncaught
+     *   TypeError: Argument #1 ($text) must be of type string, int given
+     * instead of the intended coercion. That took the xoops.org front page down from
+     * wgtimelines/blocks/timelines.php, and this was the only method in this class carrying
+     * such a declaration -- every sibling sanitizer is untyped.
+     *
+     * Arrays and objects are still rejected, which is the check actually worth keeping.
+     *
+     * @param  string|int|float|null $text string being converted
      * @param  int|null    $quote_style
      * @param  string|null $charset character set used in conversion
      * @param  bool   $double_encode
      * @return string
+     * @since  2.7.3 widened from string
      */
-    public function htmlSpecialChars(string $text, ?int $quote_style = null, ?string $charset = null, $double_encode = true)
+    public function htmlSpecialChars(string|int|float|null $text, ?int $quote_style = null, ?string $charset = null, $double_encode = true)
     {
         if ($quote_style === null) {
             $quote_style = ENT_QUOTES;

--- a/htdocs/class/module.textsanitizer.php
+++ b/htdocs/class/module.textsanitizer.php
@@ -536,26 +536,28 @@ class MyTextSanitizer
     /**
      * Convert special characters to HTML entities
      *
-     * $text accepts any scalar, not just string. Callers legitimately pass ints and floats --
-     * ids, counts, years, timestamps -- and the body has always cast to string on the first
-     * line, so the value was never used as anything but a string. A bare "string" declaration
-     * made that cast unreachable for such callers: strict_types is decided by the CALLING
-     * file, so any module with declare(strict_types=1) got an uncaught
+     * $text accepts any scalar, not just string. Callers legitimately pass ints, floats and
+     * bools -- ids, counts, years, timestamps, flags -- and the body has always cast to string
+     * on the first line, so the value was never used as anything but a string. A bare "string"
+     * declaration made that cast unreachable for such callers: strict_types is decided by the
+     * CALLING file, so any module with declare(strict_types=1) got an uncaught
      *   TypeError: Argument #1 ($text) must be of type string, int given
      * instead of the intended coercion. That took the xoops.org front page down from
      * wgtimelines/blocks/timelines.php, and this was the only method in this class carrying
      * such a declaration -- every sibling sanitizer is untyped.
      *
-     * Arrays and objects are still rejected, which is the check actually worth keeping.
+     * The union covers exactly what (string) handles predictably: bool casts to '1'/'',
+     * null to ''. Arrays and objects are still rejected, which is the check actually worth
+     * keeping.
      *
-     * @param  string|int|float|null $text string being converted
+     * @param  string|int|float|bool|null $text string being converted
      * @param  int|null    $quote_style
      * @param  string|null $charset character set used in conversion
      * @param  bool   $double_encode
      * @return string
      * @since  2.7.3 widened from string
      */
-    public function htmlSpecialChars(string|int|float|null $text, ?int $quote_style = null, ?string $charset = null, $double_encode = true)
+    public function htmlSpecialChars(string|int|float|bool|null $text, ?int $quote_style = null, ?string $charset = null, $double_encode = true)
     {
         if ($quote_style === null) {
             $quote_style = ENT_QUOTES;

--- a/htdocs/class/smarty3_plugins/function.xoStats.php
+++ b/htdocs/class/smarty3_plugins/function.xoStats.php
@@ -59,25 +59,13 @@ function xoStatsRegen()
     // Getting Total Online Users
     /** @var \XoopsOnlineHandler $onlineHandler */
     $onlineHandler = xoops_getHandler('online');
-    // set gc probability to 10% for now..
-    if (mt_rand(1, 100) < 11) {
-        $onlineHandler->gc(300);
-    }
-    if (is_object($xoopsUser)) {
-        $uid   = $xoopsUser->getVar('uid');
-        $uname = $xoopsUser->getVar('uname');
-    } else {
-        $uid   = 0;
-        $uname = '';
-    }
 
-    $requestIp = IPAddress::fromRequest()->asReadable();
-    $requestIp = (false === $requestIp) ? '0.0.0.0' : $requestIp;
-    if (is_object($xoopsModule)) {
-        $onlineHandler->write($uid, $uname, time(), $xoopsModule->getVar('mid'), $requestIp);
-    } else {
-        $onlineHandler->write($uid, $uname, time(), 0, $requestIp);
-    }
+    // READ-ONLY, like the Who is Online block. Recording the visitor is done once per
+    // request by SystemCorePreload::eventCoreIncludeCommonEnd(). Writing here as well
+    // meant the online row was rewritten (and gc run) a second time on any theme that
+    // used this plugin, and it ran inside a 30 second cacheRead() callback, so it only
+    // fired on cache regeneration anyway.
+
     $onlines = $onlineHandler->getAll();
     if (empty($onlines)) {
         $stats['totalOnline'] = 0;

--- a/htdocs/include/comment_constants.php
+++ b/htdocs/include/comment_constants.php
@@ -22,12 +22,15 @@ defined('XOOPS_ROOT_PATH') || exit('Restricted access');
  * Comment Constants
  *
  */
-define('XOOPS_COMMENT_APPROVENONE', 0);
-define('XOOPS_COMMENT_APPROVEALL', 1);
-define('XOOPS_COMMENT_APPROVEUSER', 2);
-define('XOOPS_COMMENT_APPROVEADMIN', 3);
-define('XOOPS_COMMENT_PENDING', 1);
-define('XOOPS_COMMENT_ACTIVE', 2);
-define('XOOPS_COMMENT_HIDDEN', 3);
-define('XOOPS_COMMENT_OLD1ST', 0);
-define('XOOPS_COMMENT_NEW1ST', 1);
+// Guarded individually rather than behind one "already loaded" flag: a module that
+// defined a subset of these itself would otherwise leave the rest undefined.
+// Redefining a constant is an E_WARNING today and a fatal error in PHP 9.
+defined('XOOPS_COMMENT_APPROVENONE')  || define('XOOPS_COMMENT_APPROVENONE', 0);
+defined('XOOPS_COMMENT_APPROVEALL')   || define('XOOPS_COMMENT_APPROVEALL', 1);
+defined('XOOPS_COMMENT_APPROVEUSER')  || define('XOOPS_COMMENT_APPROVEUSER', 2);
+defined('XOOPS_COMMENT_APPROVEADMIN') || define('XOOPS_COMMENT_APPROVEADMIN', 3);
+defined('XOOPS_COMMENT_PENDING')      || define('XOOPS_COMMENT_PENDING', 1);
+defined('XOOPS_COMMENT_ACTIVE')       || define('XOOPS_COMMENT_ACTIVE', 2);
+defined('XOOPS_COMMENT_HIDDEN')       || define('XOOPS_COMMENT_HIDDEN', 3);
+defined('XOOPS_COMMENT_OLD1ST')       || define('XOOPS_COMMENT_OLD1ST', 0);
+defined('XOOPS_COMMENT_NEW1ST')       || define('XOOPS_COMMENT_NEW1ST', 1);

--- a/htdocs/include/comment_view.php
+++ b/htdocs/include/comment_view.php
@@ -177,6 +177,17 @@ if (XOOPS_COMMENT_APPROVENONE != $xoopsModuleConfig['com_rule']) {
         $commentTpl->assign('commentRefreshButton', $commentRefreshButton);
 
         unset($postcomment_link);
+
+        // Assigned unconditionally. system_comment.tpl:50 reads $anon_canpost for EVERY comment
+        // row, but this was only ever assigned when anonymous posting is enabled or the visitor
+        // is logged in. A guest on a site with anonymous posting off therefore produced, once
+        // per comment:
+        //   Undefined array key "anon_canpost"
+        //   Attempt to read property "value" on null
+        // 253 such pairs in nine minutes of xoops.org guest traffic -- the single largest
+        // source of noise in the log. false is exactly what the template's "== true" wants.
+        $xoopsTpl->assign('anon_canpost', false);
+
         if (!empty($xoopsModuleConfig['com_anonpost']) || is_object($xoopsUser)) {
             $postcomment_link = 'comment_new.php?com_itemid=' . $com_itemid . '&amp;com_order=' . $com_order . '&amp;com_mode=' . $com_mode;
 

--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -970,9 +970,13 @@ function xoops_getMailer()
 /**
  * xoops_getrank()
  *
- * @param integer $rank_id
- * @param mixed   $posts
- * @return
+ * Resolves a user's rank, either the one explicitly assigned to them or the special
+ * rank matching their post count. Always returns the full shape: when no row matches,
+ * the title and image are empty strings rather than the array being absent.
+ *
+ * @param  integer $rank_id
+ * @param  mixed   $posts
+ * @return array{title: string, image: string, id: int}
  */
 function xoops_getrank($rank_id = 0, $posts = 0)
 {

--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -992,8 +992,21 @@ function xoops_getrank($rank_id = 0, $posts = 0)
             E_USER_ERROR,
         );
     }
-    $rank          = $db->fetchArray($result);
-    $rank['title'] = $myts->htmlSpecialChars($rank['title']);
+    $rank = $db->fetchArray($result);
+
+    // No row matches when the user's rank_id no longer exists, or when their post count
+    // falls outside every non-special rank range (a gap between rank_min/rank_max, or no
+    // ranks defined at all). fetchArray() then returns false, and this went straight on to
+    // $rank['title'] — "Trying to access array offset on false" — passing the resulting
+    // null into htmlSpecialChars(), which is a TypeError and therefore fatal on PHP 8.
+    // That killed every page rendering such a user; on xoops.org it took down newbb topic
+    // pages through XoopsUser::rank().
+    if (!is_array($rank)) {
+        $rank = ['title' => '', 'image' => ''];
+    }
+
+    $rank['title'] = $myts->htmlSpecialChars((string) ($rank['title'] ?? ''));
+    $rank['image'] = (string) ($rank['image'] ?? '');
     $rank['id']    = $rank_id;
 
     return $rank;

--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -24,10 +24,20 @@ require_once XOOPS_ROOT_PATH . '/include/theme_config.php';
 /**
  * xoops_getHandler()
  *
- * @param string $name
- * @param bool   $optional
+ * Returns the kernel handler for $name, or false when it cannot be loaded and $optional
+ * is true. (With $optional false, failure raises E_USER_ERROR, which XoopsLogger turns
+ * into exit() — not a Throwable, so it cannot be caught.)
  *
- * @return XoopsObjectHandler|false
+ * NOT every handler extends XoopsObjectHandler. XoopsOnlineHandler, XoopsSessionHandler,
+ * XoopsMemberHandler and XoopsConfigHandler are plain classes with their own APIs, so the
+ * previous XoopsObjectHandler|false was inaccurate: static analysis concluded that
+ * "$handler instanceof XoopsOnlineHandler" could never be true, and that methods such as
+ * XoopsOnlineHandler::write() did not exist on the returned value. Callers that need a
+ * specific handler should assert it with instanceof and let that narrow the type.
+ *
+ * @param  string $name     handler name, e.g. 'member', 'online', 'module'
+ * @param  bool   $optional return false instead of raising a fatal when unavailable
+ * @return XoopsObjectHandler|object|false
  */
 function xoops_getHandler($name, $optional = false)
 {

--- a/htdocs/include/version.php
+++ b/htdocs/include/version.php
@@ -32,4 +32,4 @@ if (file_exists($licenseFile)) {
 /**
  *  Define XOOPS version
  */
-define('XOOPS_VERSION', 'XOOPS 2.7.2');
+define('XOOPS_VERSION', 'XOOPS 2.7.3-Beta1');

--- a/htdocs/install/include/makedata.php
+++ b/htdocs/install/include/makedata.php
@@ -478,6 +478,7 @@ function make_data($dbm, $adminname, $hashedAdminPass, $adminmail, $language, $g
     $dbm->insert('config', $cfgCols . " VALUES (136, 0, 1, 'session_cookie_samesite', '_MD_AM_SESSSAMESITE', 'Lax', '_MD_AM_SESSSAMESITE_DSC', 'select', 'text', 43)");
     $dbm->insert('config', $cfgCols . " VALUES (137, 0, 1, 'session_cookie_secure', '_MD_AM_SESSSECURE', '0', '_MD_AM_SESSSECURE_DSC', 'yesno', 'int', 44)");
     $dbm->insert('config', $cfgCols . " VALUES (138, 1, 0, 'active_menus', '_MI_SYSTEM_MENUS_ACTIVE', '1', '_MI_SYSTEM_MENUS_ACTIVE_DESC', 'yesno', 'int', 145)");
+    $dbm->insert('config', $cfgCols . " VALUES (139, 0, 1, 'enable_online_tracking', '_MD_AM_ONLINETRACKING', '1', '_MD_AM_ONLINETRACKINGDSC', 'yesno', 'int', 45)");
 
     require_once XOOPS_ROOT_PATH . '/class/xoopslists.php';
     $editors = XoopsLists::getDirListAsArray(XOOPS_ROOT_PATH . '/class/xoopseditor');

--- a/htdocs/install/sql/mysql.structure.sql
+++ b/htdocs/install/sql/mysql.structure.sql
@@ -125,9 +125,12 @@ CREATE TABLE xoopscomments (
   KEY `com_itemid` (`com_itemid`),
   KEY `com_uid` (`com_uid`),
   KEY `com_title` (`com_title`(40)),
-  KEY `com_status` (`com_status`),
   KEY `com_user` (`com_user`),
-  KEY `com_email` (`com_email`)
+  KEY `com_email` (`com_email`),
+  # Serves the "recent comments" block: equality on com_status then com_created in
+  # index order, so the LIMIT stops early instead of filesorting the whole table.
+  # Replaces the old single-column KEY `com_status`, which this index prefixes.
+  KEY `idx_status_created` (`com_status`, `com_created`)
 ) ENGINE=MyISAM;
 # --------------------------------------------------------
 

--- a/htdocs/kernel/member.php
+++ b/htdocs/kernel/member.php
@@ -61,6 +61,21 @@ class XoopsMemberHandler
     protected $membersWorkingList = [];
 
     /**
+     * Per-request memo for getGroupList() when called without criteria.
+     *
+     * The unfiltered list is requested repeatedly during a single render — the xoops2020
+     * theme drives publisher's ItemHandler once per section and each call asked again,
+     * producing ~50 identical "SELECT * FROM groups" per page. The set cannot change
+     * mid-request except through insertGroup()/deleteGroup(), which both clear this.
+     *
+     * Only the no-criteria case is memoised; filtered calls (3 sites in the tree) still
+     * query, so no criteria-keying subtleties are introduced.
+     *
+     * @var array<int,string>|null
+     */
+    protected $groupListCache;
+
+    /**
      * Constructor
      * @param XoopsDatabase $db Database connection object
      */
@@ -125,6 +140,7 @@ class XoopsMemberHandler
         $criteria = $this->createSafeInCriteria('groupid', $group->getVar('groupid'));
         $s1 = $this->membershipHandler->deleteAll($criteria);
         $s2 = $this->groupHandler->delete($group);
+        $this->groupListCache = null;   // the memoised list is now stale
         return ($s1 && $s2);
     }
 
@@ -148,6 +164,7 @@ class XoopsMemberHandler
      */
     public function insertGroup(XoopsGroup $group)
     {
+        $this->groupListCache = null;   // name may have changed, or this is a new group
         return $this->groupHandler->insert($group);
     }
 
@@ -191,11 +208,22 @@ class XoopsMemberHandler
      */
     public function getGroupList($criteria = null)
     {
+        // Unfiltered calls dominate (57 of 60 in this tree) and are the ones repeated
+        // dozens of times per page, so memoise just those for the life of the request.
+        if (null === $criteria && null !== $this->groupListCache) {
+            return $this->groupListCache;
+        }
+
         $groups = $this->groupHandler->getObjects($criteria, true);
         $ret = [];
         foreach (array_keys($groups) as $i) {
             $ret[$i] = $groups[$i]->getVar('name');
         }
+
+        if (null === $criteria) {
+            $this->groupListCache = $ret;
+        }
+
         return $ret;
     }
 

--- a/htdocs/kernel/user.php
+++ b/htdocs/kernel/user.php
@@ -40,7 +40,12 @@ class XoopsUser extends XoopsObject
      */
     public $_isAdmin;
     /**
-     * @var string user's rank
+     * User's rank as returned by xoops_getrank(): title, image and id.
+     *
+     * Documented as a string historically, but xoops_getrank() has always returned an
+     * array and rank() assigns its result directly.
+     *
+     * @var array{title: string, image: string, id: int}|null
      * @access private
      */
     public $_rank;

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -27,24 +27,15 @@ function b_system_online_show()
     global $xoopsUser, $xoopsModule;
     /** @var XoopsOnlineHandler $online_handler */
     $online_handler = xoops_getHandler('online');
-    // set gc probability to 10% for now..
-    if (mt_rand(1, 100) < 11) {
-        $online_handler->gc(300);
-    }
-    if (is_object($xoopsUser)) {
-        $uid   = $xoopsUser->getVar('uid');
-        $uname = $xoopsUser->getVar('uname');
-    } else {
-        $uid   = 0;
-        $uname = '';
-    }
-    $requestIp = \Xmf\IPAddress::fromRequest()->asReadable();
-    $requestIp = (false === $requestIp) ? '0.0.0.0' : $requestIp;
-    if (is_object($xoopsModule)) {
-        $online_handler->write($uid, $uname, time(), $xoopsModule->getVar('mid'), $requestIp);
-    } else {
-        $online_handler->write($uid, $uname, time(), 0, $requestIp);
-    }
+
+    // This block is READ-ONLY. Recording the visitor happens in
+    // SystemCorePreload::eventCoreIncludeCommonEnd() (modules/system/preloads/core.php).
+    //
+    // It used to write here, which made tracking depend on the block being rendered:
+    // the block's group permissions then decided who was counted, so with the block
+    // visible to admins only the table recorded admins only and the block reported
+    // "Guests: 0". Pages without the block recorded nobody at all.
+
     $onlines = $online_handler->getAll();
     if (!empty($onlines)) {
         $total   = count($onlines);
@@ -223,8 +214,10 @@ function b_system_user_show()
 
 
 function checkPendingContent($module, $table, $condition, $adminlink, $lang_linkname, &$block, $xoopsDB) {
-    $module_handler = xoops_getHandler('module');
-    if (xoops_isActiveModule($module) && $module_handler->getCount(new Criteria('dirname', $module))) {
+    // xoops_isActiveModule() already proves the module is installed AND active (it reads
+    // the cached active-module list), so the getCount() that used to follow it was a
+    // wasted query per module — and several callers repeat both checks before calling in.
+    if (xoops_isActiveModule($module)) {
         $sql = "SELECT COUNT(*) FROM " . $xoopsDB->prefix($table);
         if ('' !== $condition) {
             $sql .= " WHERE $condition";
@@ -467,6 +460,10 @@ function b_system_comments_show($options)
     }
     // Check modules permissions
 
+    // NOTE: XoopsCommentHandler is a legacy XoopsObjectHandler — it has no getAll() and
+    // no field-list support, so this is necessarily SELECT *. That is acceptable now that
+    // idx_status_created(com_status, com_created) lets the LIMIT stop after 5 rows instead
+    // of sorting the whole table.
     $comments       = $comment_handler->getObjects($criteria, true);
     /** @var XoopsMemberHandler $member_handler */
     $member_handler = xoops_getHandler('member');
@@ -476,10 +473,19 @@ function b_system_comments_show($options)
     $comment_config = [];
     foreach (array_keys($comments) as $i) {
         $mid           = $comments[$i]->getVar('com_modid');
-        $com['module'] = '<a href="' . XOOPS_URL . '/modules/' . $modules[$mid]->getVar('dirname') . '/">' . $modules[$mid]->getVar('name') . '</a>';
+        // $comments is filtered by module_read permission while $modules only holds
+        // modules with hascomments=1, so a comment can outlive its module (uninstalled,
+        // or comments turned off). Dereferencing it unguarded was a fatal.
+        if (!isset($modules[$mid])) {
+            continue;
+        }
         if (!isset($comment_config[$mid])) {
             $comment_config[$mid] = $modules[$mid]->getInfo('comments');
         }
+        if (empty($comment_config[$mid]['pageName']) || empty($comment_config[$mid]['itemName'])) {
+            continue;
+        }
+        $com['module'] = '<a href="' . XOOPS_URL . '/modules/' . $modules[$mid]->getVar('dirname') . '/">' . $modules[$mid]->getVar('name') . '</a>';
         $com['id']    = $i;
         $com['title'] = '<a href="' . XOOPS_URL . '/modules/' . $modules[$mid]->getVar('dirname') . '/' . $comment_config[$mid]['pageName'] . '?' . $comment_config[$mid]['itemName'] . '=' . $comments[$i]->getVar('com_itemid') . '&amp;com_id=' . $i . '&amp;com_rootid=' . $comments[$i]->getVar('com_rootid') . '&amp;' . htmlspecialchars((string) $comments[$i]->getVar('com_exparams'), ENT_QUOTES | ENT_HTML5) . '#comment' . $i . '">' . $comments[$i]->getVar('com_title') . '</a>';
         $com['icon']  = htmlspecialchars((string) $comments[$i]->getVar('com_icon'), ENT_QUOTES | ENT_HTML5);

--- a/htdocs/modules/system/language/english/admin/preferences.php
+++ b/htdocs/modules/system/language/english/admin/preferences.php
@@ -310,3 +310,7 @@ define('_AM_SYSTEM_PREFERENCES_SETTINGS', 'System Module Settings');
 //2.7.0
 define('_MD_AM_SENDMAIL_NOT_FOUND', 'Sendmail binary not found. Please check your server configuration.');
 define('_MD_AM_SENDMAIL_HELP_MISSING_BIN', 'No valid sendmail-compatible binary was detected. Install an MTA (e.g. Postfix, msmtp) or switch to SMTP in Preferences.');
+
+// 2.7.3
+define('_MD_AM_ONLINETRACKING', 'Track who is online?');
+define('_MD_AM_ONLINETRACKINGDSC', 'Records each visitor in the online table so the "Who is Online" block and the online list can report member and guest counts. Costs a couple of small queries per page view. Turn this off if you do not need those figures - the block will then show nothing rather than wrong numbers.');

--- a/htdocs/modules/system/preloads/core.php
+++ b/htdocs/modules/system/preloads/core.php
@@ -60,7 +60,12 @@ class SystemCorePreload extends XoopsPreloadItem
      *
      * Turn it off with the "Track who is online?" preference under General Settings.
      *
-     * @param $args
+     * Never throws. Every failure path — an unloadable handler, a failed write, a corrupt
+     * table — is caught and downgraded to E_USER_WARNING, because this runs on EVERY request
+     * and statistics must never be able to take down a page. Hence no @throws tag: propagating
+     * an exception from here would be a defect, not part of the contract.
+     *
+     * @param  mixed $args event arguments (unused)
      * @return void
      */
     public static function eventCoreIncludeCommonEnd($args)
@@ -119,19 +124,19 @@ class SystemCorePreload extends XoopsPreloadItem
             // write() returns false rather than throwing on a failed INSERT/UPDATE, so a
             // read-only account or a corrupt table would otherwise stop tracking silently.
             if (false === $onlineHandler->write($uid, $uname, time(), $mid, $requestIp)) {
-                $GLOBALS['xoopsLogger']->handleError(
-                    E_USER_WARNING,
-                    'Online tracking: write to the online table failed',
-                    __FILE__,
-                    __LINE__
-                );
+                trigger_error('Online tracking: write to the online table failed', E_USER_WARNING);
             }
         } catch (\Throwable $e) {
-            $GLOBALS['xoopsLogger']->handleError(
-                E_USER_WARNING,
-                'Online tracking failed: ' . $e->getMessage(),
-                $e->getFile(),
-                $e->getLine()
+            // basename() only: the logger output is visible wherever debug rendering is on,
+            // and absolute server paths do not belong there.
+            trigger_error(
+                sprintf(
+                    'Online tracking failed: %s (%s:%d)',
+                    $e->getMessage(),
+                    basename($e->getFile()),
+                    $e->getLine()
+                ),
+                E_USER_WARNING
             );
         }
     }

--- a/htdocs/modules/system/preloads/core.php
+++ b/htdocs/modules/system/preloads/core.php
@@ -44,6 +44,99 @@ class SystemCorePreload extends XoopsPreloadItem
     }
 
     /**
+     * Record the current visitor in the online table.
+     *
+     * This used to live inside b_system_online_show() in the system module's blocks.
+     * That made tracking a side effect of RENDERING a block, so it only ran when the
+     * "Who is Online" block happened to be displayed — which meant the block's group
+     * permissions silently decided who got counted, and any page without the block
+     * (including whole modules with page caching on) recorded nobody at all. A block
+     * permission is meant to control who can SEE a block, not who is measured.
+     *
+     * Fires on core.include.common.end, which is after authentication (so $xoopsUser
+     * is resolved) and after the module is resolved at include/common.php:343 (so the
+     * "browsing <module>" figure still works), and before any page cache short-circuit
+     * in header.php — so cached pages are counted too.
+     *
+     * Turn it off with the "Track who is online?" preference under General Settings.
+     *
+     * @param $args
+     * @return void
+     */
+    public static function eventCoreIncludeCommonEnd($args)
+    {
+        // Default to enabled so an install that predates the preference keeps working.
+        if (isset($GLOBALS['xoopsConfig']['enable_online_tracking'])
+            && !$GLOBALS['xoopsConfig']['enable_online_tracking']) {
+            return;
+        }
+
+        // Only track real HTTP visitors. A CLI or cron script that includes mainfile.php
+        // would otherwise be recorded as a guest at 0.0.0.0 (IPAddress::fromRequest()
+        // falls back to that when REMOTE_ADDR is absent) and, if it runs often enough,
+        // would sit in "Who is Online" permanently.
+        if ('cli' === PHP_SAPI || 'phpdbg' === PHP_SAPI || empty($_SERVER['REMOTE_ADDR'])) {
+            return;
+        }
+
+        // EVERYTHING below is inside the try. Statistics must never take down a page, and
+        // that includes acquiring the handler (xoops_getHandler raises E_USER_ERROR when
+        // the class cannot be loaded) and the garbage collection sweep — not just write().
+        try {
+            // The second argument is $optional. Without it a missing or broken
+            // XoopsOnlineHandler raises E_USER_ERROR, and XoopsLogger's handler calls
+            // exit() on that — exit() is not a Throwable, so the catch below would never
+            // run and the whole page would simply stop. With $optional = true the same
+            // condition is an E_USER_WARNING and the call returns false, which the
+            // is_object() check then absorbs.
+            /** @var XoopsOnlineHandler|false $onlineHandler */
+            $onlineHandler = xoops_getHandler('online', true);
+            if (!is_object($onlineHandler)) {
+                return;
+            }
+
+            // Probabilistic garbage collection: roughly one request in ten clears out
+            // anything older than five minutes.
+            if (mt_rand(1, 100) < 11) {
+                $onlineHandler->gc(300);
+            }
+
+            $xoopsUser = $GLOBALS['xoopsUser'] ?? null;
+            if ($xoopsUser instanceof XoopsUser) {
+                $uid   = $xoopsUser->getVar('uid');
+                $uname = $xoopsUser->getVar('uname');
+            } else {
+                $uid   = 0;
+                $uname = '';
+            }
+
+            $requestIp = \Xmf\IPAddress::fromRequest()->asReadable();
+            $requestIp = (false === $requestIp) ? '0.0.0.0' : $requestIp;
+
+            $xoopsModule = $GLOBALS['xoopsModule'] ?? null;
+            $mid         = is_object($xoopsModule) ? $xoopsModule->getVar('mid') : 0;
+
+            // write() returns false rather than throwing on a failed INSERT/UPDATE, so a
+            // read-only account or a corrupt table would otherwise stop tracking silently.
+            if (false === $onlineHandler->write($uid, $uname, time(), $mid, $requestIp)) {
+                $GLOBALS['xoopsLogger']->handleError(
+                    E_USER_WARNING,
+                    'Online tracking: write to the online table failed',
+                    __FILE__,
+                    __LINE__
+                );
+            }
+        } catch (\Throwable $e) {
+            $GLOBALS['xoopsLogger']->handleError(
+                E_USER_WARNING,
+                'Online tracking failed: ' . $e->getMessage(),
+                $e->getFile(),
+                $e->getLine()
+            );
+        }
+    }
+
+    /**
      * @param $args
      */
     public static function eventCoreHeaderCheckcache($args)

--- a/htdocs/modules/system/preloads/core.php
+++ b/htdocs/modules/system/preloads/core.php
@@ -94,12 +94,18 @@ class SystemCorePreload extends XoopsPreloadItem
             // run and the whole page would simply stop. With $optional = true the same
             // condition is an E_USER_WARNING and the call returns false, which the
             // is_object() check then absorbs.
-            // Annotated with the union xoops_getHandler() itself documents. Naming the
-            // concrete XoopsOnlineHandler here instead made static analysis collapse the
-            // union to false and report the is_object() check as always failing.
-            /** @var XoopsObjectHandler|false $onlineHandler */
             $onlineHandler = xoops_getHandler('online', true);
-            if (!is_object($onlineHandler)) {
+
+            // instanceof rather than is_object(): write() and gc() below are declared on
+            // XoopsOnlineHandler, not on the XoopsObjectHandler base that xoops_getHandler()
+            // is documented to return, so only the concrete type makes this call safe. It
+            // also removes the need for a @var annotation -- annotating the base type left
+            // the calls unresolvable, and annotating the concrete type made the false half
+            // of the union unresolvable instead.
+            //
+            // Safe even when the class was never loaded: instanceof against an undefined
+            // class is simply false, and false is what $optional = true returns.
+            if (!($onlineHandler instanceof XoopsOnlineHandler)) {
                 return;
             }
 
@@ -136,15 +142,25 @@ class SystemCorePreload extends XoopsPreloadItem
             // rendered whenever debug display is on. The class plus file:line is enough to
             // find the fault; online tracking is statistics, so losing the detail here
             // costs nothing that matters.
-            trigger_error(
-                sprintf(
-                    'Online tracking failed: %s at %s:%d',
-                    get_class($e),
-                    basename($e->getFile()),
-                    $e->getLine()
-                ),
-                E_USER_WARNING
-            );
+            //
+            // Nested try: a module or framework may install an error handler that converts
+            // E_USER_WARNING into an ErrorException. Without this, reporting the failure
+            // would itself throw -- from the catch block, where nothing else can contain it
+            // -- turning an optional statistics failure into an uncaught exception on every
+            // single request. That is precisely the outage this method exists to prevent.
+            try {
+                trigger_error(
+                    sprintf(
+                        'Online tracking failed: %s at %s:%d',
+                        get_class($e),
+                        basename($e->getFile()),
+                        $e->getLine()
+                    ),
+                    E_USER_WARNING
+                );
+            } catch (\Throwable $ignored) {
+                // Nothing left to do: reporting the failure has itself failed.
+            }
         }
     }
 

--- a/htdocs/modules/system/preloads/core.php
+++ b/htdocs/modules/system/preloads/core.php
@@ -94,7 +94,10 @@ class SystemCorePreload extends XoopsPreloadItem
             // run and the whole page would simply stop. With $optional = true the same
             // condition is an E_USER_WARNING and the call returns false, which the
             // is_object() check then absorbs.
-            /** @var XoopsOnlineHandler|false $onlineHandler */
+            // Annotated with the union xoops_getHandler() itself documents. Naming the
+            // concrete XoopsOnlineHandler here instead made static analysis collapse the
+            // union to false and report the is_object() check as always failing.
+            /** @var XoopsObjectHandler|false $onlineHandler */
             $onlineHandler = xoops_getHandler('online', true);
             if (!is_object($onlineHandler)) {
                 return;
@@ -127,12 +130,16 @@ class SystemCorePreload extends XoopsPreloadItem
                 trigger_error('Online tracking: write to the online table failed', E_USER_WARNING);
             }
         } catch (\Throwable $e) {
-            // basename() only: the logger output is visible wherever debug rendering is on,
-            // and absolute server paths do not belong there.
+            // Report the exception CLASS and location, never its message. A message can
+            // carry SQL fragments, credentials or absolute paths, and this runs on every
+            // request, so it is the worst possible place to leak one into output that is
+            // rendered whenever debug display is on. The class plus file:line is enough to
+            // find the fault; online tracking is statistics, so losing the detail here
+            // costs nothing that matters.
             trigger_error(
                 sprintf(
-                    'Online tracking failed: %s (%s:%d)',
-                    $e->getMessage(),
+                    'Online tracking failed: %s at %s:%d',
+                    get_class($e),
                     basename($e->getFile()),
                     $e->getLine()
                 ),

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -134,6 +134,46 @@ if ($action !== 'showallbyuser') {
         $queries = [$xoopsDB->escape($query)];
     }
 }
+/**
+ * Reduce whatever a module's search callback returned to rows this file can safely render.
+ *
+ * XoopsModule::search() is documented as returning mixed and simply hands back whatever the
+ * module supplies, so nothing about the shape is guaranteed. Validating the outer array, or
+ * even each element, was not enough: a row like ['link' => []] survives an is_array() check
+ * and then reaches preg_match() and string concatenation below, where an array argument is
+ * a TypeError on PHP 8 -- raised OUTSIDE the try/catch, which is exactly the failure the
+ * guard exists to prevent.
+ *
+ * 'link' and 'title' are required and must be scalar because they are concatenated and
+ * pattern-matched. 'image', 'uid' and 'time' are optional, so a non-scalar value is dropped
+ * rather than rejecting the whole row.
+ *
+ * @param  mixed $rows raw return value from a module search callback
+ * @return array<int, array> rows safe to render
+ */
+$xoopsNormaliseSearchRows = static function ($rows) {
+    if (!is_array($rows)) {
+        return [];
+    }
+    $clean = [];
+    foreach ($rows as $row) {
+        if (!is_array($row)
+            || !isset($row['link'], $row['title'])
+            || !is_scalar($row['link'])
+            || !is_scalar($row['title'])) {
+            continue;
+        }
+        foreach (['image', 'uid', 'time'] as $optional) {
+            if (isset($row[$optional]) && !is_scalar($row[$optional])) {
+                unset($row[$optional]);
+            }
+        }
+        $clean[] = $row;
+    }
+
+    return $clean;
+};
+
 switch ($action) {
     case 'results':
         /** @var XoopsModuleHandler $module_handler */
@@ -195,14 +235,10 @@ switch ($action) {
                     // string, an object) would reach count() below, which is a TypeError on
                     // PHP 8 raised OUTSIDE this try, defeating the whole guard. Normalise
                     // here, where a misbehaving module is still contained.
-                    if (!is_array($results)) {
-                        $results = [];
-                    }
-                    // Per ELEMENT too. Normalising only the outer array still let a
-                    // string or object element reach $results[$i]['link'] further
-                    // down -- outside this try -- which is a TypeError on PHP 8 and
-                    // defeated the guard just as completely.
-                    $results = array_values(array_filter($results, 'is_array'));
+                    // Rows are validated by FIELD, not merely by type -- see the
+                    // normaliser above. Anything unusable is dropped here, inside the
+                    // try, where a misbehaving module is still contained.
+                    $results = $xoopsNormaliseSearchRows($results);
                 } catch (\Throwable $e) {
                     // A broken module must not take down the whole search page.
                     $GLOBALS['xoopsLogger']->handleError(
@@ -289,30 +325,27 @@ switch ($action) {
         }
         // Resolve the label BEFORE the try: the catch must never dereference $module,
         // or a failure there throws a second, uncaught error.
+        //
+        // No blind cast either: getVar() can return an array, and converting that raises a
+        // notice HERE, before the try, which an ErrorException handler would turn into an
+        // escape from the very guard below.
         $moduleDirname = $module->getVar('dirname', 'n');
-                // No blind cast: getVar() can return an array, and converting that
-                // raises a notice here, BEFORE the try -- which an ErrorException
-                // handler would turn into an escape from the very guard below.
-                $moduleLabel = is_scalar($moduleDirname) ? (string) $moduleDirname : 'mid:' . $mid;
+        $moduleLabel   = is_scalar($moduleDirname) ? (string) $moduleDirname : 'mid:' . $mid;
         try {
             $next_results = [];
             $results      = $module->search($queries, $andor, 20, $start, $uid);
             // search() returns mixed. A truthy non-array would reach count() further down,
             // outside this try, and a TypeError there would bypass the guard entirely.
-            if (!is_array($results)) {
-                $results = [];
-            }
-            // Per element too -- see the results route above.
-            $results = array_values(array_filter($results, 'is_array'));
+            // Validated by FIELD -- see the normaliser above the switch.
+            $results = $xoopsNormaliseSearchRows($results);
             // The next-page probe exists only to decide whether to render a "next" link,
             // which is meaningless when this page is already empty. Running it
             // unconditionally doubled the module and database work on every no-match
             // search, and gave a failing module a second chance to throw.
             if ([] !== $results) {
-                $next_results = $module->search($queries, $andor, 1, $start + 20, $uid);
-                if (!is_array($next_results)) {
-                    $next_results = [];
-                }
+                $next_results = $xoopsNormaliseSearchRows(
+                    $module->search($queries, $andor, 1, $start + 20, $uid)
+                );
             }
         } catch (\Throwable $e) {
             // A broken module must not take down the whole search page.

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -183,7 +183,11 @@ switch ($action) {
                 $module = $modules[$mid];
                 // Resolve the label BEFORE the try: the catch must never dereference
                 // $module, or a failure there throws a second, uncaught error.
-                $moduleLabel = (string) $module->getVar('dirname', 'n');
+                $moduleDirname = $module->getVar('dirname', 'n');
+                // No blind cast: getVar() can return an array, and converting that
+                // raises a notice here, BEFORE the try -- which an ErrorException
+                // handler would turn into an escape from the very guard below.
+                $moduleLabel = is_scalar($moduleDirname) ? (string) $moduleDirname : 'mid:' . $mid;
                 try {
                     $results = $module->search($queries, $andor, 5, 0);
                     // XoopsModule::search() returns mixed -- it hands off to whatever the
@@ -194,6 +198,11 @@ switch ($action) {
                     if (!is_array($results)) {
                         $results = [];
                     }
+                    // Per ELEMENT too. Normalising only the outer array still let a
+                    // string or object element reach $results[$i]['link'] further
+                    // down -- outside this try -- which is a TypeError on PHP 8 and
+                    // defeated the guard just as completely.
+                    $results = array_values(array_filter($results, 'is_array'));
                 } catch (\Throwable $e) {
                     // A broken module must not take down the whole search page.
                     $GLOBALS['xoopsLogger']->handleError(
@@ -280,7 +289,11 @@ switch ($action) {
         }
         // Resolve the label BEFORE the try: the catch must never dereference $module,
         // or a failure there throws a second, uncaught error.
-        $moduleLabel = (string) $module->getVar('dirname', 'n');
+        $moduleDirname = $module->getVar('dirname', 'n');
+                // No blind cast: getVar() can return an array, and converting that
+                // raises a notice here, BEFORE the try -- which an ErrorException
+                // handler would turn into an escape from the very guard below.
+                $moduleLabel = is_scalar($moduleDirname) ? (string) $moduleDirname : 'mid:' . $mid;
         try {
             $next_results = [];
             $results      = $module->search($queries, $andor, 20, $start, $uid);
@@ -289,6 +302,8 @@ switch ($action) {
             if (!is_array($results)) {
                 $results = [];
             }
+            // Per element too -- see the results route above.
+            $results = array_values(array_filter($results, 'is_array'));
             // The next-page probe exists only to decide whether to render a "next" link,
             // which is meaningless when this page is already empty. Running it
             // unconditionally doubled the module and database work on every no-match

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -183,7 +183,7 @@ switch ($action) {
                 $module = $modules[$mid];
                 // Resolve the label BEFORE the try: the catch must never dereference
                 // $module, or a failure there throws a second, uncaught error.
-                $moduleLabel = $module->getVar('dirname', 'n');
+                $moduleLabel = (string) $module->getVar('dirname', 'n');
                 try {
                     $results = $module->search($queries, $andor, 5, 0);
                 } catch (\Throwable $e) {
@@ -272,7 +272,7 @@ switch ($action) {
         }
         // Resolve the label BEFORE the try: the catch must never dereference $module,
         // or a failure there throws a second, uncaught error.
-        $moduleLabel = $module->getVar('dirname', 'n');
+        $moduleLabel = (string) $module->getVar('dirname', 'n');
         try {
             $results      = $module->search($queries, $andor, 20, $start, $uid);
             $next_results = $module->search($queries, $andor, 1, $start + 20, $uid);

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -282,15 +282,22 @@ switch ($action) {
         // or a failure there throws a second, uncaught error.
         $moduleLabel = (string) $module->getVar('dirname', 'n');
         try {
+            $next_results = [];
             $results      = $module->search($queries, $andor, 20, $start, $uid);
-            $next_results = $module->search($queries, $andor, 1, $start + 20, $uid);
             // search() returns mixed. A truthy non-array would reach count() further down,
             // outside this try, and a TypeError there would bypass the guard entirely.
             if (!is_array($results)) {
                 $results = [];
             }
-            if (!is_array($next_results)) {
-                $next_results = [];
+            // The next-page probe exists only to decide whether to render a "next" link,
+            // which is meaningless when this page is already empty. Running it
+            // unconditionally doubled the module and database work on every no-match
+            // search, and gave a failing module a second chance to throw.
+            if ([] !== $results) {
+                $next_results = $module->search($queries, $andor, 1, $start + 20, $uid);
+                if (!is_array($next_results)) {
+                    $next_results = [];
+                }
             }
         } catch (\Throwable $e) {
             // A broken module must not take down the whole search page.

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -191,7 +191,7 @@ switch ($action) {
                     $GLOBALS['xoopsLogger']->handleError(
                         E_USER_WARNING,
                         sprintf('Search failed in module "%s": %s', $moduleLabel, $e->getMessage()),
-                        $e->getFile(),
+                        basename($e->getFile()),
                         $e->getLine()
                     );
                     unset($module);
@@ -259,8 +259,15 @@ switch ($action) {
         $module      = $module_handler->get($mid);
         // get() returns false for an unknown mid, and the mid arrives straight from the
         // query string, so /search.php?action=showall&mid=999999 is reachable by anyone.
-        // Also refuse a module the current user may not read.
-        if (!is_object($module) || !in_array((int) $mid, $available_modules, true)) {
+        //
+        // The checks must match the 'results' branch above, which selects modules with
+        // hassearch = 1 AND isactive = 1 AND module_read permission. Testing only the
+        // permission here would let this route run search() for a module the administrator
+        // has deactivated, or one that never declared search support at all.
+        if (!is_object($module)
+            || !in_array((int) $mid, $available_modules, true)
+            || 1 !== (int) $module->getVar('isactive')
+            || 1 !== (int) $module->getVar('hassearch')) {
             redirect_header(XOOPS_URL . '/search.php', 2, _SR_NOMATCH);
         }
         // Resolve the label BEFORE the try: the catch must never dereference $module,
@@ -274,7 +281,7 @@ switch ($action) {
             $GLOBALS['xoopsLogger']->handleError(
                 E_USER_WARNING,
                 sprintf('Search failed in module "%s": %s', $moduleLabel, $e->getMessage()),
-                $e->getFile(),
+                basename($e->getFile()),
                 $e->getLine()
             );
             $results      = [];

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -186,6 +186,14 @@ switch ($action) {
                 $moduleLabel = (string) $module->getVar('dirname', 'n');
                 try {
                     $results = $module->search($queries, $andor, 5, 0);
+                    // XoopsModule::search() returns mixed -- it hands off to whatever the
+                    // module's search callback returns. A truthy non-array (true, an error
+                    // string, an object) would reach count() below, which is a TypeError on
+                    // PHP 8 raised OUTSIDE this try, defeating the whole guard. Normalise
+                    // here, where a misbehaving module is still contained.
+                    if (!is_array($results)) {
+                        $results = [];
+                    }
                 } catch (\Throwable $e) {
                     // A broken module must not take down the whole search page.
                     $GLOBALS['xoopsLogger']->handleError(
@@ -276,6 +284,14 @@ switch ($action) {
         try {
             $results      = $module->search($queries, $andor, 20, $start, $uid);
             $next_results = $module->search($queries, $andor, 1, $start + 20, $uid);
+            // search() returns mixed. A truthy non-array would reach count() further down,
+            // outside this try, and a TypeError there would bypass the guard entirely.
+            if (!is_array($results)) {
+                $results = [];
+            }
+            if (!is_array($next_results)) {
+                $next_results = [];
+            }
         } catch (\Throwable $e) {
             // A broken module must not take down the whole search page.
             $GLOBALS['xoopsLogger']->handleError(

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -174,8 +174,29 @@ switch ($action) {
         foreach ($mids as $mid) {
             $mid = (int) $mid;
             if (in_array($mid, $available_modules)) {
-                $module  = $modules[$mid];
-                $results = $module->search($queries, $andor, 5, 0);
+                // $mids can come straight from the query string, and $modules only holds
+                // modules that are active AND searchable. A readable-but-not-searchable
+                // mid (e.g. mids[]=1) would otherwise index a missing key and yield null.
+                if (!isset($modules[$mid]) || !is_object($modules[$mid])) {
+                    continue;
+                }
+                $module = $modules[$mid];
+                // Resolve the label BEFORE the try: the catch must never dereference
+                // $module, or a failure there throws a second, uncaught error.
+                $moduleLabel = $module->getVar('dirname', 'n');
+                try {
+                    $results = $module->search($queries, $andor, 5, 0);
+                } catch (\Throwable $e) {
+                    // A broken module must not take down the whole search page.
+                    $GLOBALS['xoopsLogger']->handleError(
+                        E_USER_WARNING,
+                        sprintf('Search failed in module "%s": %s', $moduleLabel, $e->getMessage()),
+                        $e->getFile(),
+                        $e->getLine()
+                    );
+                    unset($module);
+                    continue;
+                }
                 if (empty($results)) {
                     $count = 0;
                 } else {
@@ -236,10 +257,39 @@ switch ($action) {
         $module_handler = xoops_getHandler('module');
         /** @var XoopsModule $module */
         $module      = $module_handler->get($mid);
-        $results = $module->search($queries, $andor, 20, $start, $uid);
+        // get() returns false for an unknown mid, and the mid arrives straight from the
+        // query string, so /search.php?action=showall&mid=999999 is reachable by anyone.
+        // Also refuse a module the current user may not read.
+        if (!is_object($module) || !in_array((int) $mid, $available_modules, true)) {
+            redirect_header(XOOPS_URL . '/search.php', 2, _SR_NOMATCH);
+        }
+        // Resolve the label BEFORE the try: the catch must never dereference $module,
+        // or a failure there throws a second, uncaught error.
+        $moduleLabel = $module->getVar('dirname', 'n');
+        try {
+            $results      = $module->search($queries, $andor, 20, $start, $uid);
+            $next_results = $module->search($queries, $andor, 1, $start + 20, $uid);
+        } catch (\Throwable $e) {
+            // A broken module must not take down the whole search page.
+            $GLOBALS['xoopsLogger']->handleError(
+                E_USER_WARNING,
+                sprintf('Search failed in module "%s": %s', $moduleLabel, $e->getMessage()),
+                $e->getFile(),
+                $e->getLine()
+            );
+            $results      = [];
+            $next_results = [];
+        }
+        // Assigned unconditionally. The showall block in system_search.tpl renders even when
+        // there are no results, so leaving these unset produced, on every empty showall page:
+        //   Undefined array key "showing" / "module_name"
+        //   Attempt to read property "value" on null   (Smarty's compiled tpl_vars access)
+        // The results branch below overwrites 'showing' with the real range.
+        $xoopsTpl->assign('module_name', $module->getVar('name'));
+        $xoopsTpl->assign('showing', '');
+
         $results ? $count = count($results) : $count = 0;
         if (is_array($results) && $count > 0) {
-            $next_results = $module->search($queries, $andor, 1, $start + 20, $uid);
             $next_count   = count($next_results);
             $has_next     = false;
             if (is_array($next_results) && $next_count == 1) {
@@ -258,7 +308,6 @@ switch ($action) {
                 $xoopsTpl->assign('keywords', $keywords);
             }
             $xoopsTpl->assign('showing', sprintf(_SR_SHOWING, $start + 1, $start + $count));
-            $xoopsTpl->assign('module_name', $module->getVar('name'));
             $results_arr = [];
             for ($i = 0; $i < $count; ++$i) {
                 if (isset($results[$i]['image']) && $results[$i]['image'] != '') {

--- a/upgrade/upd_2.7.1-to-2.7.3/index.php
+++ b/upgrade/upd_2.7.1-to-2.7.3/index.php
@@ -1,14 +1,29 @@
 <?php
 
+/*
+ * You may not change or alter any portion of this comment or credits
+ * of supporting developers from this source code or any supporting source code
+ * which is considered copyrighted (c) material of the original comment or credit authors.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
 use Xoops\Upgrade\UpgradeControl;
 use Xoops\Upgrade\XoopsUpgrade;
 
 /**
- * XOOPS Upgrade 2.7.1 -> 2.7.3
+ * Upgrade from 2.7.1 to 2.7.3
  *
  * Carries the schema and configuration changes that a fresh install already gets from
  * install/sql/mysql.structure.sql and install/include/makedata.php. Without this patch an
  * upgraded site silently diverges from a freshly installed one.
+ *
+ * Tasks (both idempotent, order irrelevant):
+ *  1. commentsindex  — add idx_status_created(com_status, com_created) to xoopscomments and
+ *                      drop the single-column com_status key it prefixes.
+ *  2. onlinetracking — insert the enable_online_tracking core preference.
  *
  * UpgradeControl scans every "*-to-*" directory and asks each patch's check_ methods
  * whether it applies (UpgradeControl.php:229-250) — applicability is NOT decided by
@@ -16,10 +31,13 @@ use Xoops\Upgrade\XoopsUpgrade;
  * 2.7.2 or later, which is exactly what is wanted: they are corrective, and both are
  * idempotent. 2.7.2 is already released, so sites sitting on it still pick these up.
  *
+ * @category     Upgrade
  * @copyright    (c) 2000-2026 XOOPS Project (https://xoops.org)
  * @license      GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
  * @package      XOOPS
+ * @link         https://xoops.org
  * @since        2.7.3
+ * @author       XOOPS Team
  */
 class Upgrade_273 extends XoopsUpgrade
 {
@@ -76,8 +94,23 @@ class Upgrade_273 extends XoopsUpgrade
         }
 
         if ($this->indexExists($table, 'com_status')) {
-            // Failure here is not fatal: the new index is what matters.
-            $this->db->exec('ALTER TABLE `' . $table . '` DROP INDEX `com_status`');
+            // Not fatal: the composite index is what this task exists to create, and the site
+            // is correct with the redundant key still present — it only costs writes. But the
+            // schema then differs from a fresh install, so say so loudly rather than silently.
+            if (false === $this->db->exec('ALTER TABLE `' . $table . '` DROP INDEX `com_status`')
+                || $this->indexExists($table, 'com_status')) {
+                trigger_error(
+                    sprintf(
+                        'Upgrade 2.7.3: could not drop the redundant `com_status` index on `%s`. '
+                        . 'The new idx_status_created index is in place and the site is correct, '
+                        . 'but this table now differs from a fresh install. Drop it by hand: '
+                        . 'ALTER TABLE `%s` DROP INDEX `com_status`;',
+                        $table,
+                        $table
+                    ),
+                    E_USER_WARNING
+                );
+            }
         }
 
         return $this->indexExists($table, 'idx_status_created');
@@ -158,15 +191,20 @@ class Upgrade_273 extends XoopsUpgrade
     }
 
     /**
-     * Does a core config row with this name exist?
+     * Does a CORE config row with this name exist?
+     *
+     * Scoped to conf_modid = 0 because that is what apply_onlinetracking() inserts. Matching
+     * on conf_name alone would let any module preference of the same name satisfy the check,
+     * so the core row would never be created and the preference would silently go missing.
      *
      * @param  string $name conf_name
-     * @return bool
+     * @return bool true when the core row exists
      */
     protected function configExists(string $name): bool
     {
         $sql = 'SELECT COUNT(*) FROM `' . $this->db->prefix('config') . '`'
-             . " WHERE conf_name = '" . $this->db->escape($name) . "'";
+             . ' WHERE conf_modid = 0'
+             . " AND conf_name = '" . $this->db->escape($name) . "'";
 
         $result = $this->db->query($sql);
         if (!$this->db->isResultSet($result)) {

--- a/upgrade/upd_2.7.1-to-2.7.3/index.php
+++ b/upgrade/upd_2.7.1-to-2.7.3/index.php
@@ -41,6 +41,12 @@ use Xoops\Upgrade\XoopsUpgrade;
  */
 class Upgrade_273 extends XoopsUpgrade
 {
+    /** Name of the composite index the recent-comments block needs. */
+    private const COMMENTS_INDEX = 'idx_status_created';
+
+    /** Its columns, in index order. Order matters: reversed, it does not serve the query. */
+    private const COMMENTS_INDEX_COLUMNS = ['com_status', 'com_created'];
+
     /**
      * @param XoopsMySQLDatabase $db      database connection
      * @param UpgradeControl     $control upgrade control instance
@@ -70,7 +76,8 @@ class Upgrade_273 extends XoopsUpgrade
      */
     public function check_commentsindex(): bool
     {
-        return $this->indexExists($this->db->prefix('xoopscomments'), 'idx_status_created');
+        return self::COMMENTS_INDEX_COLUMNS
+            === $this->indexColumns($this->db->prefix('xoopscomments'), self::COMMENTS_INDEX);
     }
 
     /**
@@ -84,10 +91,32 @@ class Upgrade_273 extends XoopsUpgrade
      */
     public function apply_commentsindex(): bool
     {
-        $table = $this->db->prefix('xoopscomments');
+        $table   = $this->db->prefix('xoopscomments');
+        $columns = $this->indexColumns($table, self::COMMENTS_INDEX);
 
-        if (!$this->indexExists($table, 'idx_status_created')) {
-            $sql = 'ALTER TABLE `' . $table . '` ADD INDEX `idx_status_created` (`com_status`, `com_created`)';
+        if (null === $columns) {
+            // Could not inspect the schema. Issuing DDL blindly here would either fail on a
+            // duplicate index or, worse, appear to succeed while the final verification
+            // still cannot confirm anything -- leaving the task pending on every rerun.
+            trigger_error(
+                'Upgrade 2.7.3: cannot read information_schema.STATISTICS, so the '
+                . '`' . self::COMMENTS_INDEX . '` index on `' . $table . '` cannot be verified '
+                . 'or safely created. Grant access, or add it by hand: ALTER TABLE `' . $table
+                . '` ADD INDEX `' . self::COMMENTS_INDEX . '` (`com_status`, `com_created`);',
+                E_USER_WARNING
+            );
+
+            return false;
+        }
+
+        if (self::COMMENTS_INDEX_COLUMNS !== $columns) {
+            // An index of the right NAME but the wrong shape does not serve the query, so
+            // drop it before recreating. [] means simply absent, and nothing to drop.
+            if ([] !== $columns
+                && false === $this->db->exec('ALTER TABLE `' . $table . '` DROP INDEX `' . self::COMMENTS_INDEX . '`')) {
+                return false;
+            }
+            $sql = 'ALTER TABLE `' . $table . '` ADD INDEX `' . self::COMMENTS_INDEX . '` (`com_status`, `com_created`)';
             if (false === $this->db->exec($sql)) {
                 return false;
             }
@@ -113,7 +142,10 @@ class Upgrade_273 extends XoopsUpgrade
             }
         }
 
-        return $this->indexExists($table, 'idx_status_created');
+        // Verified by SHAPE, not by name, and identical to check_commentsindex() -- a task
+        // that reports success on a weaker condition than its own check would re-queue for
+        // ever.
+        return self::COMMENTS_INDEX_COLUMNS === $this->indexColumns($table, self::COMMENTS_INDEX);
     }
 
     // =========================================================================
@@ -164,10 +196,51 @@ class Upgrade_273 extends XoopsUpgrade
     // =========================================================================
 
     /**
-     * Does $indexName exist on $table?
+     * Which columns does $indexName cover on $table, in index order?
      *
-     * Uses information_schema rather than SHOW INDEX so the answer is unambiguous, and
-     * returns false when the question cannot be answered — a check_ that cannot verify
+     * Three distinct answers, which the callers must not conflate:
+     *   null  the question could not be answered (information_schema restricted, proxy
+     *         rejected the query). NEVER treat this as "absent" and issue blind DDL.
+     *   []    the index does not exist.
+     *   [...] the column names, ordered by SEQ_IN_INDEX.
+     *
+     * Column order matters: an index named idx_status_created that happens to cover
+     * (com_created, com_status) does not serve "com_status = ? ORDER BY com_created" at
+     * all, so checking the name alone would report a performance fix that is not present.
+     *
+     * @param  string $table     fully prefixed table name
+     * @param  string $indexName index to inspect
+     * @return array<int, string>|null
+     */
+    protected function indexColumns(string $table, string $indexName): ?array
+    {
+        $sql = 'SELECT COLUMN_NAME FROM information_schema.STATISTICS'
+             . ' WHERE TABLE_SCHEMA = DATABASE()'
+             . " AND TABLE_NAME = '" . $this->db->escape($table) . "'"
+             . " AND INDEX_NAME = '" . $this->db->escape($indexName) . "'"
+             . ' ORDER BY SEQ_IN_INDEX';
+
+        $result = $this->db->query($sql);
+        if (!$this->db->isResultSet($result)) {
+            return null;
+        }
+        // isResultSet() above already proved this is a result set, but static analysis
+        // cannot narrow through a helper, so state it explicitly.
+        /** @var mysqli_result $result */
+        $columns = [];
+        while (false !== ($row = $this->db->fetchRow($result))) {
+            if (is_array($row) && isset($row[0])) {
+                $columns[] = (string) $row[0];
+            }
+        }
+
+        return $columns;
+    }
+
+    /**
+     * Does $indexName exist on $table, whatever its shape?
+     *
+     * Returns false when the question cannot be answered — a check_ that cannot verify
      * must not report success.
      *
      * @param  string $table     fully prefixed table name
@@ -176,21 +249,9 @@ class Upgrade_273 extends XoopsUpgrade
      */
     protected function indexExists(string $table, string $indexName): bool
     {
-        $sql = 'SELECT COUNT(*) FROM information_schema.STATISTICS'
-             . ' WHERE TABLE_SCHEMA = DATABASE()'
-             . " AND TABLE_NAME = '" . $this->db->escape($table) . "'"
-             . " AND INDEX_NAME = '" . $this->db->escape($indexName) . "'";
+        $columns = $this->indexColumns($table, $indexName);
 
-        $result = $this->db->query($sql);
-        if (!$this->db->isResultSet($result)) {
-            return false;
-        }
-        // isResultSet() above already proved this is a result set, but static analysis
-        // cannot narrow through a helper, so state it explicitly.
-        /** @var mysqli_result $result */
-        $row = $this->db->fetchRow($result);
-
-        return is_array($row) && (int)$row[0] > 0;
+        return is_array($columns) && [] !== $columns;
     }
 
     /**

--- a/upgrade/upd_2.7.1-to-2.7.3/index.php
+++ b/upgrade/upd_2.7.1-to-2.7.3/index.php
@@ -1,0 +1,181 @@
+<?php
+
+use Xoops\Upgrade\UpgradeControl;
+use Xoops\Upgrade\XoopsUpgrade;
+
+/**
+ * XOOPS Upgrade 2.7.1 -> 2.7.3
+ *
+ * Carries the schema and configuration changes that a fresh install already gets from
+ * install/sql/mysql.structure.sql and install/include/makedata.php. Without this patch an
+ * upgraded site silently diverges from a freshly installed one.
+ *
+ * UpgradeControl scans every "*-to-*" directory and asks each patch's check_ methods
+ * whether it applies (UpgradeControl.php:229-250) — applicability is NOT decided by
+ * comparing version numbers. So these tasks are evaluated even on a site already reporting
+ * 2.7.2 or later, which is exactly what is wanted: they are corrective, and both are
+ * idempotent. 2.7.2 is already released, so sites sitting on it still pick these up.
+ *
+ * @copyright    (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license      GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @package      XOOPS
+ * @since        2.7.3
+ */
+class Upgrade_273 extends XoopsUpgrade
+{
+    /**
+     * @param XoopsMySQLDatabase $db      database connection
+     * @param UpgradeControl     $control upgrade control instance
+     */
+    public function __construct(XoopsMySQLDatabase $db, UpgradeControl $control)
+    {
+        parent::__construct($db, $control, basename(__DIR__));
+        $this->tasks = [
+            'commentsindex',
+            'onlinetracking',
+        ];
+        $this->usedFiles = [];
+    }
+
+    // =========================================================================
+    // Task 1: commentsindex
+    // =========================================================================
+
+    /**
+     * Does xoopscomments carry the index the recent-comments block needs?
+     *
+     * The block filters on com_status then orders by com_created. With only the
+     * single-column com_status key, MySQL matched tens of thousands of rows and filesorted
+     * them to return five. Measured on a 46,403-row table: 541 ms before, 0.5 ms after.
+     *
+     * @return bool true when idx_status_created exists
+     */
+    public function check_commentsindex(): bool
+    {
+        return $this->indexExists($this->db->prefix('xoopscomments'), 'idx_status_created');
+    }
+
+    /**
+     * Add idx_status_created(com_status, com_created) and drop the redundant com_status.
+     *
+     * com_status is a strict prefix of the new index, so keeping it would only cost writes.
+     * It is dropped in a separate statement, and its absence is not treated as failure —
+     * an install that never had it, or a re-run of this task, must still pass.
+     *
+     * @return bool true when the index is present afterwards
+     */
+    public function apply_commentsindex(): bool
+    {
+        $table = $this->db->prefix('xoopscomments');
+
+        if (!$this->indexExists($table, 'idx_status_created')) {
+            $sql = 'ALTER TABLE `' . $table . '` ADD INDEX `idx_status_created` (`com_status`, `com_created`)';
+            if (false === $this->db->exec($sql)) {
+                return false;
+            }
+        }
+
+        if ($this->indexExists($table, 'com_status')) {
+            // Failure here is not fatal: the new index is what matters.
+            $this->db->exec('ALTER TABLE `' . $table . '` DROP INDEX `com_status`');
+        }
+
+        return $this->indexExists($table, 'idx_status_created');
+    }
+
+    // =========================================================================
+    // Task 2: onlinetracking
+    // =========================================================================
+
+    /**
+     * Is the "Track who is online?" preference present?
+     *
+     * Visitor tracking moved out of the Who-is-Online block and into a system preload, so
+     * it now runs on every request. That needs a real off switch rather than relying on
+     * the block's group permissions, which only ever produced a partial sample.
+     *
+     * @return bool true when the config row exists
+     */
+    public function check_onlinetracking(): bool
+    {
+        return $this->configExists('enable_online_tracking');
+    }
+
+    /**
+     * Insert the preference, defaulting to enabled to preserve current behaviour.
+     *
+     * @return bool true when the row exists afterwards
+     */
+    public function apply_onlinetracking(): bool
+    {
+        if ($this->configExists('enable_online_tracking')) {
+            return true;
+        }
+
+        $table = $this->db->prefix('config');
+        $sql   = 'INSERT INTO `' . $table . '`'
+               . ' (conf_modid, conf_catid, conf_name, conf_title, conf_value, conf_desc,'
+               . '  conf_formtype, conf_valuetype, conf_order)'
+               . " VALUES (0, 1, 'enable_online_tracking', '_MD_AM_ONLINETRACKING', '1',"
+               . " '_MD_AM_ONLINETRACKINGDSC', 'yesno', 'int', 45)";
+
+        if (false === $this->db->exec($sql)) {
+            return false;
+        }
+
+        return $this->configExists('enable_online_tracking');
+    }
+
+    // =========================================================================
+    // helpers
+    // =========================================================================
+
+    /**
+     * Does $indexName exist on $table?
+     *
+     * Uses information_schema rather than SHOW INDEX so the answer is unambiguous, and
+     * returns false when the question cannot be answered — a check_ that cannot verify
+     * must not report success.
+     *
+     * @param  string $table     fully prefixed table name
+     * @param  string $indexName index to look for
+     * @return bool
+     */
+    protected function indexExists(string $table, string $indexName): bool
+    {
+        $sql = 'SELECT COUNT(*) FROM information_schema.STATISTICS'
+             . ' WHERE TABLE_SCHEMA = DATABASE()'
+             . " AND TABLE_NAME = '" . $this->db->escape($table) . "'"
+             . " AND INDEX_NAME = '" . $this->db->escape($indexName) . "'";
+
+        $result = $this->db->query($sql);
+        if (!$this->db->isResultSet($result)) {
+            return false;
+        }
+        $row = $this->db->fetchRow($result);
+
+        return is_array($row) && (int)$row[0] > 0;
+    }
+
+    /**
+     * Does a core config row with this name exist?
+     *
+     * @param  string $name conf_name
+     * @return bool
+     */
+    protected function configExists(string $name): bool
+    {
+        $sql = 'SELECT COUNT(*) FROM `' . $this->db->prefix('config') . '`'
+             . " WHERE conf_name = '" . $this->db->escape($name) . "'";
+
+        $result = $this->db->query($sql);
+        if (!$this->db->isResultSet($result)) {
+            return false;
+        }
+        $row = $this->db->fetchRow($result);
+
+        return is_array($row) && (int)$row[0] > 0;
+    }
+}
+
+return Upgrade_273::class;

--- a/upgrade/upd_2.7.1-to-2.7.3/index.php
+++ b/upgrade/upd_2.7.1-to-2.7.3/index.php
@@ -94,6 +94,12 @@ class Upgrade_273 extends XoopsUpgrade
         $table   = $this->db->prefix('xoopscomments');
         $columns = $this->indexColumns($table, self::COMMENTS_INDEX);
 
+        // Derived from the constant, never hand-written: a column list that drifts from
+        // COMMENTS_INDEX_COLUMNS would recreate the index in a shape check_ rejects, and
+        // the task would re-queue for ever while reintroducing the very bug it fixes.
+        $columnList = '`' . implode('`, `', self::COMMENTS_INDEX_COLUMNS) . '`';
+        $addIndex   = 'ALTER TABLE `' . $table . '` ADD INDEX `' . self::COMMENTS_INDEX . '` (' . $columnList . ')';
+
         if (null === $columns) {
             // Could not inspect the schema. Issuing DDL blindly here would either fail on a
             // duplicate index or, worse, appear to succeed while the final verification
@@ -102,7 +108,7 @@ class Upgrade_273 extends XoopsUpgrade
                 'Upgrade 2.7.3: cannot read information_schema.STATISTICS, so the '
                 . '`' . self::COMMENTS_INDEX . '` index on `' . $table . '` cannot be verified '
                 . 'or safely created. Grant access, or add it by hand: ALTER TABLE `' . $table
-                . '` ADD INDEX `' . self::COMMENTS_INDEX . '` (`com_status`, `com_created`);',
+                . '` ADD INDEX `' . self::COMMENTS_INDEX . '` (' . $columnList . ');',
                 E_USER_WARNING
             );
 
@@ -116,8 +122,7 @@ class Upgrade_273 extends XoopsUpgrade
                 && false === $this->db->exec('ALTER TABLE `' . $table . '` DROP INDEX `' . self::COMMENTS_INDEX . '`')) {
                 return false;
             }
-            $sql = 'ALTER TABLE `' . $table . '` ADD INDEX `' . self::COMMENTS_INDEX . '` (`com_status`, `com_created`)';
-            if (false === $this->db->exec($sql)) {
+            if (false === $this->db->exec($addIndex)) {
                 return false;
             }
         }

--- a/upgrade/upd_2.7.1-to-2.7.3/index.php
+++ b/upgrade/upd_2.7.1-to-2.7.3/index.php
@@ -104,26 +104,37 @@ class Upgrade_273 extends XoopsUpgrade
             // Could not inspect the schema. Issuing DDL blindly here would either fail on a
             // duplicate index or, worse, appear to succeed while the final verification
             // still cannot confirm anything -- leaving the task pending on every rerun.
-            trigger_error(
-                'Upgrade 2.7.3: cannot read information_schema.STATISTICS, so the '
-                . '`' . self::COMMENTS_INDEX . '` index on `' . $table . '` cannot be verified '
-                . 'or safely created. Grant access, or add it by hand: ALTER TABLE `' . $table
-                . '` ADD INDEX `' . self::COMMENTS_INDEX . '` (' . $columnList . ');',
-                E_USER_WARNING
-            );
+            // Contained: a handler that converts E_USER_WARNING into an ErrorException
+            // would otherwise throw out of a method whose contract is to return false,
+            // aborting the upgrade over a diagnostic message.
+            try {
+                trigger_error(
+                    'Upgrade 2.7.3: cannot read information_schema.STATISTICS, so the '
+                    . '`' . self::COMMENTS_INDEX . '` index on `' . $table . '` cannot be verified '
+                    . 'or safely created. Grant access, or add it by hand: ALTER TABLE `' . $table
+                    . '` ADD INDEX `' . self::COMMENTS_INDEX . '` (' . $columnList . ');',
+                    E_USER_WARNING
+                );
+            } catch (\Throwable $ignored) {
+            }
 
             return false;
         }
 
         if (self::COMMENTS_INDEX_COLUMNS !== $columns) {
             // An index of the right NAME but the wrong shape does not serve the query, so
-            // drop it before recreating. [] means simply absent, and nothing to drop.
-            if ([] !== $columns
+            // drop it before recreating. The name-only check matters here: indexColumns()
+            // filters by shape, so a UNIQUE or prefixed index reports as absent, and
+            // skipping the drop would make ADD INDEX fail on a duplicate name.
+            if ($this->indexExists($table, self::COMMENTS_INDEX)
                 && false === $this->db->exec('ALTER TABLE `' . $table . '` DROP INDEX `' . self::COMMENTS_INDEX . '`')) {
                 return false;
             }
             if (false === $this->db->exec($addIndex)) {
-                return false;
+                // A concurrent applier may have created it between the inspection above and
+                // this statement. Re-verify rather than reporting failure for a schema that
+                // is now correct.
+                return self::COMMENTS_INDEX_COLUMNS === $this->indexColumns($table, self::COMMENTS_INDEX);
             }
         }
 
@@ -133,17 +144,22 @@ class Upgrade_273 extends XoopsUpgrade
             // schema then differs from a fresh install, so say so loudly rather than silently.
             if (false === $this->db->exec('ALTER TABLE `' . $table . '` DROP INDEX `com_status`')
                 || $this->indexExists($table, 'com_status')) {
-                trigger_error(
-                    sprintf(
-                        'Upgrade 2.7.3: could not drop the redundant `com_status` index on `%s`. '
-                        . 'The new idx_status_created index is in place and the site is correct, '
-                        . 'but this table now differs from a fresh install. Drop it by hand: '
-                        . 'ALTER TABLE `%s` DROP INDEX `com_status`;',
-                        $table,
-                        $table
-                    ),
-                    E_USER_WARNING
-                );
+                // Contained for the same reason as above: this is a diagnostic, and the
+                // task has already succeeded at what it exists to do.
+                try {
+                    trigger_error(
+                        sprintf(
+                            'Upgrade 2.7.3: could not drop the redundant `com_status` index on `%s`. '
+                            . 'The new idx_status_created index is in place and the site is correct, '
+                            . 'but this table now differs from a fresh install. Drop it by hand: '
+                            . 'ALTER TABLE `%s` DROP INDEX `com_status`;',
+                            $table,
+                            $table
+                        ),
+                        E_USER_WARNING
+                    );
+                } catch (\Throwable $ignored) {
+                }
             }
         }
 
@@ -219,10 +235,20 @@ class Upgrade_273 extends XoopsUpgrade
      */
     protected function indexColumns(string $table, string $indexName): ?array
     {
+        // NON_UNIQUE = 1 and INDEX_TYPE = BTREE are part of the shape, not decoration.
+        // A UNIQUE index of the same name over exactly these columns would otherwise be
+        // accepted, silently imposing a constraint that REJECTS any two comments sharing
+        // (com_status, com_created) -- data loss dressed up as a performance fix. SUB_PART
+        // must be NULL too: a prefixed index like (com_status(4), com_created) does not
+        // serve the query. Anything not matching is reported as the wrong shape, so
+        // apply_ drops and recreates it.
         $sql = 'SELECT COLUMN_NAME FROM information_schema.STATISTICS'
              . ' WHERE TABLE_SCHEMA = DATABASE()'
              . " AND TABLE_NAME = '" . $this->db->escape($table) . "'"
              . " AND INDEX_NAME = '" . $this->db->escape($indexName) . "'"
+             . ' AND NON_UNIQUE = 1'
+             . " AND INDEX_TYPE = 'BTREE'"
+             . ' AND SUB_PART IS NULL'
              . ' ORDER BY SEQ_IN_INDEX';
 
         $result = $this->db->query($sql);
@@ -254,9 +280,23 @@ class Upgrade_273 extends XoopsUpgrade
      */
     protected function indexExists(string $table, string $indexName): bool
     {
-        $columns = $this->indexColumns($table, $indexName);
+        // Deliberately NOT built on indexColumns(): that one filters by shape, so a UNIQUE
+        // or prefixed index of the same name reports as absent. This answers the different
+        // question "is the NAME taken", which is what decides whether a DROP is needed
+        // before recreating -- without it, ADD INDEX would fail on a duplicate name.
+        $sql = 'SELECT COUNT(*) FROM information_schema.STATISTICS'
+             . ' WHERE TABLE_SCHEMA = DATABASE()'
+             . " AND TABLE_NAME = '" . $this->db->escape($table) . "'"
+             . " AND INDEX_NAME = '" . $this->db->escape($indexName) . "'";
 
-        return is_array($columns) && [] !== $columns;
+        $result = $this->db->query($sql);
+        if (!$this->db->isResultSet($result)) {
+            return false;
+        }
+        /** @var mysqli_result $result */
+        $row = $this->db->fetchRow($result);
+
+        return is_array($row) && (int) $row[0] > 0;
     }
 
     /**

--- a/upgrade/upd_2.7.1-to-2.7.3/index.php
+++ b/upgrade/upd_2.7.1-to-2.7.3/index.php
@@ -116,6 +116,9 @@ class Upgrade_273 extends XoopsUpgrade
                     E_USER_WARNING
                 );
             } catch (\Throwable $ignored) {
+                // Intentionally empty. Reporting the problem has itself failed, and
+                // there is nowhere left to report that to. The task result below is
+                // what actually matters.
             }
 
             return false;
@@ -159,6 +162,8 @@ class Upgrade_273 extends XoopsUpgrade
                         E_USER_WARNING
                     );
                 } catch (\Throwable $ignored) {
+                    // Intentionally empty, as above: the diagnostic is optional and
+                    // the task has already done what it exists to do.
                 }
             }
         }

--- a/upgrade/upd_2.7.1-to-2.7.3/index.php
+++ b/upgrade/upd_2.7.1-to-2.7.3/index.php
@@ -185,6 +185,9 @@ class Upgrade_273 extends XoopsUpgrade
         if (!$this->db->isResultSet($result)) {
             return false;
         }
+        // isResultSet() above already proved this is a result set, but static analysis
+        // cannot narrow through a helper, so state it explicitly.
+        /** @var mysqli_result $result */
         $row = $this->db->fetchRow($result);
 
         return is_array($row) && (int)$row[0] > 0;
@@ -210,6 +213,9 @@ class Upgrade_273 extends XoopsUpgrade
         if (!$this->db->isResultSet($result)) {
             return false;
         }
+        // isResultSet() above already proved this is a result set, but static analysis
+        // cannot narrow through a helper, so state it explicitly.
+        /** @var mysqli_result $result */
         $row = $this->db->fetchRow($result);
 
         return is_array($row) && (int)$row[0] > 0;


### PR DESCRIPTION
# PR: PHP 8.5 hardening and who-is-online tracking (2.7.3 Beta 1)

Branch: `fix/php85-hardening-2.7.3` in `L:\GitHub\MAMBAX7\CORE\XoopsCore27`
11 commits · 19 files · +514 / −64

## Summary

Fixes every core defect found while running XOOPS 2.7.2 on **www.xoops.org** under PHP 8.5.8, plus
the two performance problems that dominated its profile. 

## What is in this PR

### Fatals (all reproduced, then fixed)

| commit | problem |
|---|---|
| `compat(textsanitizer)` | `htmlSpecialChars(string $text)` cast to string on its own second line, but the declaration rejected scalars first. `strict_types` is decided by the **calling** file, so any module declaring it and passing an id or year got an uncaught `TypeError`. In a block that is fatal — it blanked the xoops.org front page. This was the only typed method in the class; every sibling sanitiser is untyped. |
| `fix(kernel)` | `xoops_getrank()` fed `false` from `fetchArray()` straight into `$rank['title']`, then passed `null` to `htmlSpecialChars()`. Fatal for any user whose rank_id is stale or whose post count falls in a gap between ranks. Killed newbb topic pages. |
| `fix(search)` | one throwing module aborted the whole results page. Also fixed a second fatal introduced by the first draft of that guard: the `catch` re-dereferenced `$module`, which was reachable from a crafted `mid`. |
| `fix(model)` | a handler whose constructor never ran points every query at the bare DB prefix. The error named neither handler nor table. Now both are reported, and `assertTableConfigured()` names the usual cause. |

### Correctness and noise

- `fix(comments)` — `anon_canpost` was assigned only when anonymous posting is on or a user is
  logged in, while the template reads it per comment row. **253 warning pairs in nine minutes** of
  guest traffic, the single largest source of log noise.
- `compat(comments)` — bare `define()` calls produced "already defined" warnings; a hard error in
  PHP 9. Guarded per constant, not with one wrapper flag, so a partial earlier definition cannot
  leave the rest undefined.
- `fix(cache)` — the magic_quotes-era length-repair pass ran on **every** read; its non-greedy
  pattern corrupted any payload containing `";`, turning those entries into permanent cache
  misses. Now only used as a fallback when `unserialize()` genuinely fails.
- `fix(search)` — empty `showall` pages warned on `showing` / `module_name`.

### Who-is-online

`feat(system)` — `write()` lived **inside** the block that displays the count, so visitors were
recorded only when that block rendered. Where the block was limited to one group, only that group
was ever counted; cached pages and pages without the block counted nobody. The count was not
wrong, the *sample* was.

Tracking moves to a system preload that runs after authentication and module resolution, and
before `header.php`'s cache short-circuit so cached pages still count. CLI/phpdbg are skipped so
cron does not create guest rows at `0.0.0.0`. `xoops_getHandler()` is called with the optional
flag because its failure path is `E_USER_ERROR` → `exit()`, which no `try/catch` can contain. A
new preference switches tracking off; absent, it defaults to enabled.

### Performance

- `perf(member)` — `getGroupList()` re-queried on every call: ~48 identical
  `SELECT * FROM groups` per front page. Memoised for the null-criteria case only, invalidated on
  insert/delete. **117 → 69 queries** on one page.
- `feat(upgrade)` — `idx_status_created(com_status, com_created)` on `xoopscomments`.
  **541 ms → 0.5 ms** on a 46,403-row table.

### Install / upgrade parity

Both schema changes ship on **both** paths so a fresh install and an upgraded site end up
identical. `upgrade/upd_2.7.1-to-2.7.3` targets **2.7.3** because 2.7.2 is already released — a
directory claiming to deliver a shipped version would be wrong. Applicability is unaffected:
`UpgradeControl` asks each task's `check_` method rather than comparing versions, so sites already
on released 2.7.2 still pick these up. Both tasks are idempotent.

### Release marker

`chore(release)` sets `XOOPS_VERSION` to **`XOOPS 2.7.3-Beta1`** in
`htdocs/include/version.php`. That is the single source of truth for the core version — no other
tracked file carries it. The remaining `2.7.2` strings in the tree belong to third-party libraries
(font-awesome, Smarty), a composer dependency pin, and prose in the `upd_2.7.1-to-2.7.3` patch,
which correctly names the released version it upgrades *from*.

## Approach notes for reviewers

- **`assertTableConfigured()` lives in the model, not the handler constructor.** Some legitimate
  subclasses call `parent::__construct($db)` and assign `$this->table` themselves; a
  constructor-time check would report those as broken.
- **`htmlSpecialChars()` still rejects arrays and objects.** Only scalars and null were widened —
  exactly what the existing cast already handled.
- **Comment constants are guarded individually**, not behind one flag.
- **The online preference defaults to enabled when the row is absent**, so upgraded sites that
  skip the DB step keep working.

## Testing

Every fix was reproduced before being fixed, and verified after.

- Reproduced locally against a copy of the xoops.org database (2.7.2, ~46k comments, 175 tables).
- Fatals confirmed by a real before/after on the same URL, not by reasoning — e.g. the archive
  fatal was 28,301 bytes with the error logged before, 34,738 bytes and no log entry after.
- Search regression suite: 7 cases (uid with/without results, OR/AND, matching and non-matching,
  no terms) — identical result counts before and after every change.
- **Deployed to www.xoops.org in slices and confirmed in production**: search works for every
  module; the front page, profile pages and newbb topic pages render; Who's Online reports real
  numbers (520 rows / 520 distinct IPs / zero duplicates / oldest 308 s against a 300 s expiry);
  the `anon_canpost` and `htmlSpecialChars` errors stopped at the moment of deploy and have not
  recurred.
- `php -l` clean on all 18 files. `queryF()` avoided per the project's pre-commit standard —
  `exec()` for writes and DDL, `query()` for SELECTs.

## Checklist

- [x] PSR-12 / project style respected
- [x] `php -l` passes on every changed file
- [x] Pre-commit hook passes without `--no-verify`
- [x] Language constants appended at the end of the file under a `// 2.7.3` marker, per the
      convention already in `preferences.php`
- [x] Smarty delimiters untouched
- [x] No BC break — signatures were only widened, never narrowed
- [x] Install and upgrade paths kept in parity

## Base

Verified, not assumed:

```
master           49cc2454ef33f36235d595773e93042866bc16fc
upstream/master  49cc2454ef33f36235d595773e93042866bc16fc   (identical)

fix/php85-hardening-2.7.3 -> 10 ahead, 0 behind upstream/master
```

No rebase required. Every touched file was additionally confirmed byte-identical to pristine
2.7.2 before being modified, so nothing in this branch can silently overwrite upstream work.

## Summary by Sourcery

Harden core behaviour for PHP 8.5, improve who-is-online tracking, and align install and upgrade paths for XOOPS 2.7.3-Beta1.

New Features:
- Add a configurable, preload-based who-is-online tracking mechanism that runs per request instead of only when the block renders.
- Introduce an upgrade step to add the who-is-online tracking preference and a performance index on comments for existing installations.

Bug Fixes:
- Prevent PHP 8+ fatals and warnings in text sanitization, rank lookup, search handling, comments display, and comment-related templates when data is missing or types differ from expectations.
- Stop cache corruption and permanent cache misses caused by always running the legacy magic_quotes length-repair logic on serialized payloads.
- Avoid search and comments pages breaking when modules are missing, misconfigured, or throw exceptions, and ensure templates receive required variables even for empty result sets.
- Guard comment-related constants against redefinition to avoid warnings and future PHP fatal errors.

Enhancements:
- Add handler table-configuration checks and richer error messages in model classes to surface misconfigured handlers under PHP 8.
- Memoize unfiltered group list retrieval per request to reduce redundant queries and improve page performance.
- Tighten who-is-online tracking to skip CLI/phpdbg contexts and turn write failures into logged warnings instead of hard errors.

Documentation:
- Document new who-is-online tracking preference text and behaviour in the English admin preferences language file.

Chores:
- Update the core version marker to XOOPS 2.7.3-Beta1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional online visitor tracking, configurable through system preferences.
  * Added an upgrade path to XOOPS 2.7.3-Beta1 with automatic database updates.
  * Improved support for varied values in HTML sanitization.

* **Bug Fixes**
  * Search results now continue loading when individual modules fail or return invalid data.
  * Prevented errors when comments reference unavailable modules or guest posting settings are unset.
  * Improved handling of missing user ranks and cache data.

* **Performance**
  * Improved recent-comment query performance and reduced repeated group lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->