### PR TITLE
chore(deps): patch nanoid/postcss advisory and track npm in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,42 @@ updates:
       - "dependencies"
       - "github-actions"
     open-pull-requests-limit: 5
+
+  # npm here builds the Tailwind theme CSS -- none of it is served at runtime.
+  #
+  # Dependabot SECURITY updates ignore this file entirely: they fire from vulnerability
+  # alerts alone, which is why the nanoid/postcss advisory produced a PR while this config
+  # listed only github-actions. Routine VERSION updates do read this file, so without the
+  # entries below those lockfiles drift until an advisory forces them forward.
+  - package-ecosystem: "npm"
+    directory: "/htdocs/themes/xtailwind"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "javascript"
+    open-pull-requests-limit: 3
+    groups:
+      # Build tooling moves together; one grouped PR beats a stream of single bumps.
+      npm-build:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/htdocs/themes/xtailwind2"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "javascript"
+    open-pull-requests-limit: 3
+    groups:
+      npm-build:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/htdocs/themes/xtailwind/package-lock.json
+++ b/htdocs/themes/xtailwind/package-lock.json
@@ -536,9 +536,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true,
             "funding": [
                 {
@@ -632,9 +632,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "dev": true,
             "funding": [
                 {
@@ -652,7 +652,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },

--- a/htdocs/themes/xtailwind2/package-lock.json
+++ b/htdocs/themes/xtailwind2/package-lock.json
@@ -536,9 +536,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true,
             "funding": [
                 {
@@ -632,9 +632,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "dev": true,
             "funding": [
                 {
@@ -652,7 +652,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },


### PR DESCRIPTION
## Summary

Two related dependency-maintenance changes for the Tailwind theme build tooling.

1. **`chore(deps)`** — bump `nanoid` 3.3.12 → 3.3.16 and `postcss` 8.5.15 → 8.5.23 in
   `htdocs/themes/xtailwind/package-lock.json` and `htdocs/themes/xtailwind2/package-lock.json`.
   Cherry-picked from the Dependabot PR raised on the `mambax7` fork, with authorship preserved.
2. **`chore(ci)`** — add the `npm` ecosystem to `.github/dependabot.yml` for those two directories.

## Why the config change matters

Dependabot **is** already enabled here — vulnerability alerts and automated security fixes are
both on. But `.github/dependabot.yml` listed only `github-actions`, and that file governs
*version* updates only. *Security* updates fire from vulnerability alerts and ignore it
completely.

That is precisely how the current advisory produced a PR against a config that never mentions
npm — and why these lockfiles had drifted several patch releases behind before an advisory
forced them forward. With npm declared, routine bumps arrive weekly instead.

Minor and patch updates are grouped, so each theme yields one PR rather than a stream of
individual bumps. `open-pull-requests-limit` is 3 per directory.

## Scope

npm here builds the theme CSS; **nothing in these lockfiles is served at runtime**, so real-world
exposure from the advisory was low. This is hygiene, not an incident.

## Verification

- `dependabot.yml` parses (PyYAML): 3 update blocks, `npm-build` group present on both npm entries.
- Both configured directories contain a real `package.json`.
- Lockfile diff is 14 insertions / 14 deletions across the two files, versions only — no
  dependency-tree changes.
- Branched from `upstream/master`, which is identical to the current `master`.

## Note

Separate from #130 (PHP 8.5 hardening for 2.7.3-Beta1) on purpose — mixing a dependency bump into
a release-hardening PR would muddy the review and the changelog for both.

## Summary by Sourcery

Configure Dependabot to track npm-based Tailwind theme build tooling and update related lockfile dependencies.

New Features:
- Enable weekly Dependabot version updates for npm dependencies in the xtailwind and xtailwind2 theme build directories.

Enhancements:
- Update nanoid and postcss patch versions in the xtailwind and xtailwind2 theme package-lock.json files to address recent advisories.

CI:
- Extend Dependabot configuration to include grouped npm updates for the Tailwind theme build tooling, with per-directory PR limits and labels.