### PR TITLE
chore(ci): stop proposing Tailwind and DaisyUI major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    # Tailwind 4 and DaisyUI 5 are MIGRATIONS, not upgrades. See the note at the
+    # bottom of this file before removing either entry.
+    ignore:
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "daisyui"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/htdocs/themes/xtailwind2"
@@ -47,3 +54,41 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "tailwindcss"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "daisyui"
+        update-types: ["version-update:semver-major"]
+
+# -----------------------------------------------------------------------------
+# Why tailwindcss and daisyui majors are ignored
+# -----------------------------------------------------------------------------
+# Security updates are NOT affected: they come from vulnerability alerts and
+# ignore this file entirely, so a patched Tailwind still reaches us. Only routine
+# major version-bump PRs are suppressed.
+#
+# Moving the xtailwind themes from Tailwind 3 to 4 is a port, not a version bump.
+# Four separate things break, and the last one breaks silently:
+#
+#   1. The CLI is gone from the package. tailwindcss@3 ships
+#      bin: {tailwind, tailwindcss}; tailwindcss@4 ships no bin at all -- it moved
+#      to @tailwindcss/cli. Both themes build with
+#      "tailwindcss -i ./css/input.css -o ./css/styles.css", so `npm run build`
+#      fails at the first command.
+#   2. css/input.css opens with @tailwind base/components/utilities, replaced in
+#      v4 by @import "tailwindcss".
+#   3. tailwind.config.js is a CommonJS export. v4 is CSS-first and needs an
+#      explicit @config directive to read a JS config at all.
+#   4. tailwind.config.js carries a 30+ entry `safelist`, which v4 removed in
+#      favour of @source inline(...). Those classes are listed precisely because
+#      XoopsFormRendererTailwind emits them at REQUEST time, where the JIT scanner
+#      cannot see them. Losing the safelist does not fail the build -- it produces
+#      a stylesheet missing every form class, so forms render unstyled while CI
+#      stays green.
+#
+# DaisyUI 5 targets Tailwind 4 and is loaded with @plugin "daisyui" from CSS
+# rather than the JS plugins array, so the two have to move together.
+#
+# Remove these ignore entries as part of a deliberate port that updates the build
+# script, input.css, the config format and the safelist together.
+# -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adding npm to Dependabot (#131) produced six PRs. Two are useful; four are framework
majors that cannot be merged as-is. This ignores **major** updates for `tailwindcss` and
`daisyui` in both theme directories, leaving everything else flowing.

- Merge: #132, #133 — `@tailwindcss/typography` 0.5.19 → 0.5.20, a patch.
- Close: #134, #135 (DaisyUI 4 → 5) and #136, #137 (Tailwind 3 → 4).

## Security updates are not affected

Dependabot **security** updates come from vulnerability alerts and ignore this file
entirely — that is exactly how the nanoid/postcss advisory produced a PR while the config
listed only `github-actions`. A patched Tailwind would still reach us. Only routine major
version-bump PRs are suppressed.

## Why Tailwind 3 → 4 cannot simply be merged

Four things break, and the fourth breaks **silently**:

| current | Tailwind 4 |
|---|---|
| `build`: `tailwindcss -i ./css/input.css -o ./css/styles.css` | CLI moved to `@tailwindcss/cli` |
| `css/input.css`: `@tailwind base/components/utilities` | `@import "tailwindcss"` |
| `tailwind.config.js` (CommonJS) | CSS-first; needs an explicit `@config` |
| `safelist: [...]`, 30+ entries | removed, replaced by `@source inline(...)` |

The first is verifiable from the registry:

```
tailwindcss 3.4.19  bin: {"tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js"}
tailwindcss 4.3.3   bin: (none)
```

so `npm run build` fails at the first command.

The **safelist** is the one that matters most. Those classes are listed precisely because
`XoopsFormRendererTailwind` emits them at *request* time, where Tailwind's JIT scanner
cannot see them. Dropping the safelist does not fail the build — it produces a stylesheet
missing every form class, so forms render unstyled while CI stays green.

DaisyUI 5 targets Tailwind 4 and loads via `@plugin "daisyui"` from CSS rather than the JS
plugins array, so the two have to move together.

## Not a permanent decision

The reasoning is recorded in `dependabot.yml` itself, so whoever removes these entries
knows what the port involves: build script, `input.css`, config format and safelist,
together.

## Verification

`dependabot.yml` parses (PyYAML): 3 update blocks, `npm-build` group intact on both npm
entries, ignore rules present on both, `github-actions` unchanged.

## Summary by Sourcery

Build:
- Update Dependabot configuration to restrict npm updates for the xtailwind themes to minor and patch releases while ignoring Tailwind CSS and DaisyUI major versions.