### PR TITLE
feat(debug): central debug config and a rotating file logger

### DIFF
--- a/htdocs/class/logger/filelogger.php
+++ b/htdocs/class/logger/filelogger.php
@@ -119,7 +119,8 @@ class XoopsFileLogger
         if (1 !== preg_match(self::FILENAME_PATTERN, $name)) {
             $name = self::DEFAULT_FILENAME;
         }
-        if (in_array(strtoupper((string) strtok($name, '.')), self::RESERVED_STEMS, true)) {
+        $stem = strtoupper((string) strstr($name, '.', true));
+        if (in_array($stem, self::RESERVED_STEMS, true)) {
             $name = self::DEFAULT_FILENAME;
         }
 
@@ -140,7 +141,12 @@ class XoopsFileLogger
         $this->maxFiles = $this->clamp($config['max_files'] ?? 5, 1, self::MAX_FILES);
 
         $channels       = $config['channels'] ?? ['messages', 'Queries', 'Deprecated'];
-        $this->channels = is_array($channels) ? array_values(array_filter($channels, 'is_string')) : [];
+        // Compared case-insensitively: debug.php is hand-edited and the channel names
+        // are themselves inconsistent ( messages lowercase, Queries/Blocks/Extra/
+        // Deprecated capitalised ), so a reasonable-looking 'queries' would otherwise
+        // produce a logger that silently records nothing.
+        $channels       = is_array($channels) ? array_filter($channels, 'is_string') : [];
+        $this->channels = array_values(array_map('strtolower', $channels));
 
         $this->queriesWithErrorsOnly = (bool) ($config['queries_with_errors_only'] ?? true);
         $this->backtrace             = (bool) ($config['backtrace'] ?? true);
@@ -171,13 +177,26 @@ class XoopsFileLogger
      */
     protected function isBelowDocumentRoot()
     {
+        // Fails CLOSED. Every branch that cannot answer the question returns true, i.e.
+        // "assume web-reachable", so logging is refused rather than permitted. Returning
+        // false here would have been a fail-OPEN default, made worse by write() creating
+        // the directory recursively — an unresolvable path would have produced a fresh,
+        // unprotected log directory.
         if (!defined('XOOPS_ROOT_PATH')) {
-            return false;
+            return true;
         }
         $root = realpath(XOOPS_ROOT_PATH);
-        $dir  = realpath(dirname($this->file)) ?: realpath(XOOPS_VAR_PATH);
-        if (!is_string($root) || !is_string($dir) || '' === $root || '' === $dir) {
-            return false;
+        if (false === $root || '' === $root) {
+            return true;
+        }
+        // The log directory may legitimately not exist yet on a first run, so fall back
+        // to its parent and then to XOOPS_VAR_PATH before giving up.
+        $dir = realpath(dirname($this->file));
+        if (false === $dir) {
+            $dir = realpath(XOOPS_VAR_PATH);
+        }
+        if (false === $dir || '' === $dir) {
+            return true;
         }
         $root = rtrim(str_replace('\\', '/', $root), '/') . '/';
         $dir  = rtrim(str_replace('\\', '/', $dir), '/') . '/';
@@ -215,7 +234,7 @@ class XoopsFileLogger
         }
 
         $channel = (string) ($context['channel'] ?? 'messages');
-        if (!in_array($channel, $this->channels, true)) {
+        if (!in_array(strtolower($channel), $this->channels, true)) {
             return;
         }
         if ('Queries' === $channel) {
@@ -406,7 +425,11 @@ class XoopsFileLogger
             }
         }
 
-        return (string) $text;
+        // Every untrusted value reaches the file through here, so this is the one place
+        // to strip control characters. A newline inside a message, a URI or an SQL
+        // fragment would otherwise let a crafted request forge additional log lines --
+        // the entry structure below is the only thing allowed to introduce them.
+        return (string) preg_replace('/[\x00-\x08\x0A-\x1F\x7F]/', ' ', (string) $text);
     }
 
     /**
@@ -418,19 +441,31 @@ class XoopsFileLogger
             return 'cli';
         }
         $uri = $_SERVER['REQUEST_URI'] ?? '-';
-        if (!is_string($uri)) {
-            return '-';
-        }
 
-        // A URL-borne session id has to go even before session_start() has run, when
-        // session_id() is still empty and the hash replacement in sanitize() cannot match.
-        //
-        // Redacting on the RAW string was not enough: PHP decodes query keys, so
-        // "?PHP%53ESSID=secret" is a live session id that a literal-name regex walks
-        // straight past. The query is parsed and rebuilt from DECODED keys instead, which
-        // catches every encoding of the name. Rebuilding normalises the encoding, which is
-        // of no consequence in a log line.
-        $name = function_exists('session_name') ? (string) session_name() : 'PHPSESSID';
+        return is_string($uri) ? $this->redactSessionId($uri) : '-';
+    }
+
+    /**
+     * Remove a URL-borne session id from a request URI.
+     *
+     * Split out from currentUri() so it can be exercised directly: currentUri() short
+     * circuits to 'cli' under a CLI SAPI, and a test suite runs under exactly that, so
+     * asserting on its output would confirm nothing at all.
+     *
+     * This has to work even before session_start() has run, when session_id() is still
+     * empty and the hash replacement in sanitize() has nothing to match.
+     *
+     * Redacting the RAW string was not enough: PHP decodes query keys, so
+     * "?PHP%53ESSID=secret" carries a live session id that a literal-name regex walks
+     * straight past. The query is parsed and rebuilt from DECODED keys instead, which
+     * catches every encoding of the name.
+     *
+     * @param  string $uri raw request uri
+     * @return string
+     */
+    protected function redactSessionId($uri)
+    {
+        $name  = function_exists('session_name') ? (string) session_name() : 'PHPSESSID';
         $split = explode('?', $uri, 2);
         if ('' !== $name && isset($split[1]) && '' !== $split[1]) {
             parse_str($split[1], $params);
@@ -442,7 +477,11 @@ class XoopsFileLogger
                 }
             }
             if ($touched) {
-                $uri = $split[0] . '?' . urldecode(http_build_query($params));
+                // NOT run through urldecode(). http_build_query() percent-encodes its
+                // output, and decoding it again reinstates every raw byte of the original
+                // attacker-supplied query -- including %0A, which lets a crafted request
+                // forge entire log entries. The encoded form is less pretty and safe.
+                $uri = $split[0] . '?' . http_build_query($params);
             }
         }
 
@@ -522,12 +561,23 @@ class XoopsFileLogger
             return;
         }
 
-        @unlink($this->file . '.' . $this->maxFiles);
+        // Failures are tolerated but not ignored. Losing an old rotation costs nothing,
+        // so those are best-effort; failing to move the LIVE file is different -- the
+        // next append would go straight back onto an already-oversized file -- so that
+        // one disables the logger for the request rather than growing without bound.
+        if (is_file($this->file . '.' . $this->maxFiles) && !@unlink($this->file . '.' . $this->maxFiles)) {
+            $this->writeFailed = true;
+
+            return;
+        }
         for ($i = $this->maxFiles - 1; $i >= 1; --$i) {
             if (is_file($this->file . '.' . $i)) {
+                // Best effort: an unmovable intermediate rotation just stays where it is.
                 @rename($this->file . '.' . $i, $this->file . '.' . ($i + 1));
             }
         }
-        @rename($this->file, $this->file . '.1');
+        if (!@rename($this->file, $this->file . '.1')) {
+            $this->writeFailed = true;
+        }
     }
 }

--- a/htdocs/class/logger/filelogger.php
+++ b/htdocs/class/logger/filelogger.php
@@ -53,6 +53,20 @@ class XoopsFileLogger
 
     private const DEFAULT_FILENAME = 'debug.log';
 
+    /**
+     * Windows treats these stems as devices whatever extension follows: "NUL.log" opens
+     * the null device and silently swallows every entry, "COM1.log" talks to a serial
+     * port. They satisfy FILENAME_PATTERN, so they need rejecting separately.
+     */
+    private const RESERVED_STEMS = [
+        'CON', 'PRN', 'AUX', 'NUL',
+        'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9',
+        'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9',
+    ];
+
+    /** Cap on any single field before sanitising, so a huge value cannot exhaust memory. */
+    private const MAX_FIELD = 8192;
+
     /** Rotation bounds. An unbounded max_files would spin the rotation loop for ever. */
     private const MIN_SIZE  = 65536;        // 64 KB
     private const MAX_SIZE  = 536870912;    // 512 MB
@@ -105,8 +119,23 @@ class XoopsFileLogger
         if (1 !== preg_match(self::FILENAME_PATTERN, $name)) {
             $name = self::DEFAULT_FILENAME;
         }
+        if (in_array(strtoupper((string) strtok($name, '.')), self::RESERVED_STEMS, true)) {
+            $name = self::DEFAULT_FILENAME;
+        }
 
-        $this->file     = XOOPS_VAR_PATH . '/logs/' . $name;
+        $this->file = XOOPS_VAR_PATH . '/logs/' . $name;
+
+        // Fail CLOSED when the log directory is reachable over the web.
+        //
+        // The shipped .htaccess protects Apache only; on nginx, IIS, or Apache with
+        // AllowOverride None it does nothing, and /xoops_data/logs/debug.log is then a
+        // plain static file full of SQL, user ids and paths. Documentation alone is not a
+        // control, so logging is refused unless the administrator has either moved
+        // xoops_data outside the document root -- the right answer -- or explicitly
+        // accepted the risk in debug.php.
+        if (empty($config['allow_web_accessible_log']) && $this->isBelowDocumentRoot()) {
+            $this->writeFailed = true;
+        }
         $this->maxSize  = $this->clamp($config['max_size'] ?? 8388608, self::MIN_SIZE, self::MAX_SIZE);
         $this->maxFiles = $this->clamp($config['max_files'] ?? 5, 1, self::MAX_FILES);
 
@@ -117,6 +146,43 @@ class XoopsFileLogger
         $this->backtrace             = (bool) ($config['backtrace'] ?? true);
         $this->backtraceLimit        = $this->clamp($config['backtrace_limit'] ?? 12, 1, 50);
         $this->requestId             = substr(md5(uniqid('', true)), 0, 8);
+    }
+
+    /**
+     * Cut a single field down to MAX_FIELD before any further processing.
+     *
+     * @param  string $value
+     * @return string
+     */
+    protected function trim($value)
+    {
+        return strlen($value) > self::MAX_FIELD
+            ? substr($value, 0, self::MAX_FIELD) . '...[' . strlen($value) . ' bytes]'
+            : $value;
+    }
+
+    /**
+     * Does the log directory sit inside the served document root?
+     *
+     * XOOPS_ROOT_PATH *is* the document root by definition, so a log directory beneath it
+     * is web-reachable unless the server is configured to refuse it.
+     *
+     * @return bool true when the log would be publicly fetchable on an unprotected server
+     */
+    protected function isBelowDocumentRoot()
+    {
+        if (!defined('XOOPS_ROOT_PATH')) {
+            return false;
+        }
+        $root = realpath(XOOPS_ROOT_PATH);
+        $dir  = realpath(dirname($this->file)) ?: realpath(XOOPS_VAR_PATH);
+        if (!is_string($root) || !is_string($dir) || '' === $root || '' === $dir) {
+            return false;
+        }
+        $root = rtrim(str_replace('\\', '/', $root), '/') . '/';
+        $dir  = rtrim(str_replace('\\', '/', $dir), '/') . '/';
+
+        return 0 === stripos($dir, $root);
     }
 
     /**
@@ -212,7 +278,10 @@ class XoopsFileLogger
             $this->currentUid()
         );
 
-        $message = $this->sanitize($message);
+        // Truncate BEFORE sanitising. MAX_ENTRY alone was not enough: a 16 MB SQL string
+        // was regex-processed and concatenated first, and the peak allocation of that
+        // exhausted the memory limit long before the finished entry could be trimmed.
+        $message = $this->sanitize($this->trim($message));
         $body    = '  ' . $message;
 
         $detail = [];
@@ -220,7 +289,7 @@ class XoopsFileLogger
             if (!isset($context[$key]) || '' === $context[$key] || !is_scalar($context[$key])) {
                 continue;
             }
-            $value = $this->sanitize((string) $context[$key]);
+            $value = $this->sanitize($this->trim((string) $context[$key]));
             // addQuery() passes the SQL as BOTH the message and context['sql']; writing it
             // twice doubles the file size and the time spent holding the lock.
             if ('sql' === $key && $value === $message) {
@@ -354,14 +423,27 @@ class XoopsFileLogger
         }
 
         // A URL-borne session id has to go even before session_start() has run, when
-        // session_id() is still empty and the hash replacement below cannot match it.
+        // session_id() is still empty and the hash replacement in sanitize() cannot match.
+        //
+        // Redacting on the RAW string was not enough: PHP decodes query keys, so
+        // "?PHP%53ESSID=secret" is a live session id that a literal-name regex walks
+        // straight past. The query is parsed and rebuilt from DECODED keys instead, which
+        // catches every encoding of the name. Rebuilding normalises the encoding, which is
+        // of no consequence in a log line.
         $name = function_exists('session_name') ? (string) session_name() : 'PHPSESSID';
-        if ('' !== $name) {
-            $uri = preg_replace(
-                '/([?&])' . preg_quote($name, '/') . '=[^&]*/i',
-                '$1' . $name . '=sid%23redacted',
-                $uri
-            );
+        $split = explode('?', $uri, 2);
+        if ('' !== $name && isset($split[1]) && '' !== $split[1]) {
+            parse_str($split[1], $params);
+            $touched = false;
+            foreach (array_keys($params) as $key) {
+                if (0 === strcasecmp((string) $key, $name)) {
+                    $params[$key] = 'sid#redacted';
+                    $touched      = true;
+                }
+            }
+            if ($touched) {
+                $uri = $split[0] . '?' . urldecode(http_build_query($params));
+            }
         }
 
         return substr((string) $uri, 0, 300);

--- a/htdocs/class/logger/filelogger.php
+++ b/htdocs/class/logger/filelogger.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * XOOPS file logger
+ *
+ * You may not change or alter any portion of this comment or credits
+ * of supporting developers from this source code or any supporting source code
+ * which is considered copyrighted (c) material of the original comment or credit authors.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @category            Logger
+ * @copyright       (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license             GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @package             kernel
+ * @link                https://xoops.org
+ * @since               2.7.3
+ * @author              XOOPS Team
+ */
+
+if (!defined('XOOPS_ROOT_PATH')) {
+    die('Restricted access');
+}
+
+/**
+ * Writes XoopsLogger events to a rotating file under XOOPS_VAR_PATH/logs.
+ *
+ * Registers with XoopsLogger::addLogger(), the same seat DebugBar occupies, so it
+ * receives every event the in-page debug output receives — notices, warnings, errors,
+ * deprecations and SQL — without any change to the producers.
+ *
+ * It exists because the in-page output is only visible to an administrator on a page
+ * that actually renders. When a request dies before output, or fails for a guest, or
+ * only misbehaves under real traffic, the file is the only record.
+ *
+ * Two things are deliberately not written:
+ *  - the session id, which would let anyone reading the log hijack a session;
+ *  - absolute server paths, which are reduced to installation-relative form.
+ */
+class XoopsFileLogger
+{
+    /** @var string absolute path of the current log file */
+    protected $file;
+
+    /** @var int rotate once the file exceeds this many bytes */
+    protected $maxSize;
+
+    /** @var int how many rotated files to keep */
+    protected $maxFiles;
+
+    /** @var string[] channels to record */
+    protected $channels;
+
+    /** @var bool record only failing SQL rather than every statement */
+    protected $queriesWithErrorsOnly;
+
+    /** @var bool append a backtrace to each entry */
+    protected $backtrace;
+
+    /** @var int frames to keep in the backtrace */
+    protected $backtraceLimit;
+
+    /** @var bool set by quiet(); suppresses all further writes */
+    protected $quiet = false;
+
+    /** @var bool one-shot guard so a broken log destination cannot spam */
+    protected $writeFailed = false;
+
+    /** @var string stable per-request id, so interleaved requests can be separated */
+    protected $requestId;
+
+    /**
+     * @param array $config the 'log' section of xoops_data/data/debug.php
+     */
+    public function __construct(array $config = [])
+    {
+        $dir = XOOPS_VAR_PATH . '/logs';
+        $name = isset($config['file']) ? basename((string) $config['file']) : 'debug.log';
+        if ('' === $name || '.' === $name[0]) {
+            $name = 'debug.log';
+        }
+
+        $this->file                  = $dir . '/' . $name;
+        $this->maxSize               = max(0, (int) ($config['max_size'] ?? 8388608));
+        $this->maxFiles              = max(0, (int) ($config['max_files'] ?? 5));
+        $this->channels              = (array) ($config['channels'] ?? ['messages', 'Queries', 'Deprecated']);
+        $this->queriesWithErrorsOnly = (bool) ($config['queries_with_errors_only'] ?? true);
+        $this->backtrace             = (bool) ($config['backtrace'] ?? true);
+        $this->backtraceLimit        = max(1, (int) ($config['backtrace_limit'] ?? 12));
+        $this->requestId             = substr(md5(uniqid('', true)), 0, 8);
+    }
+
+    /**
+     * Receive one event from XoopsLogger.
+     *
+     * Signature matches the PSR-3 shape XoopsLogger dispatches with.
+     *
+     * @param  string $level   psr-3 level
+     * @param  string $message
+     * @param  array  $context dispatch context; 'channel' selects the collector
+     * @return void
+     */
+    public function log($level, $message, array $context = [])
+    {
+        if ($this->quiet || $this->writeFailed) {
+            return;
+        }
+
+        $channel = (string) ($context['channel'] ?? 'messages');
+        if (!in_array($channel, $this->channels, true)) {
+            return;
+        }
+        if ('Queries' === $channel && $this->queriesWithErrorsOnly && empty($context['error'])) {
+            return;
+        }
+
+        $this->write($this->format($level, (string) $message, $channel, $context));
+    }
+
+    /**
+     * Stop writing for the remainder of the request.
+     *
+     * XoopsLogger calls this for output-sensitive requests such as AJAX. The file is not
+     * output, but honouring it keeps behaviour consistent with the other loggers.
+     *
+     * @return void
+     */
+    public function quiet()
+    {
+        $this->quiet = true;
+    }
+
+    /**
+     * Build one log entry.
+     *
+     * @param  string $level
+     * @param  string $message
+     * @param  string $channel
+     * @param  array  $context
+     * @return string
+     */
+    protected function format($level, $message, $channel, array $context)
+    {
+        $head = sprintf(
+            "[%s] %s.%s req=%s uri=%s uid=%s",
+            date('Y-m-d H:i:s'),
+            $channel,
+            strtoupper($level),
+            $this->requestId,
+            $this->currentUri(),
+            $this->currentUid()
+        );
+
+        $body = '  ' . $this->sanitize($message);
+
+        $detail = [];
+        foreach (['errno', 'errfile', 'errline', 'sql', 'error', 'query_time'] as $key) {
+            if (isset($context[$key]) && '' !== $context[$key] && is_scalar($context[$key])) {
+                $detail[] = $key . '=' . $this->sanitize((string) $context[$key]);
+            }
+        }
+        if ([] !== $detail) {
+            $body .= "\n  " . implode(' ', $detail);
+        }
+
+        if ($this->backtrace) {
+            $trace = $this->renderTrace($context['trace'] ?? null);
+            if ('' !== $trace) {
+                $body .= "\n" . $trace;
+            }
+        }
+
+        return $head . "\n" . $body . "\n";
+    }
+
+    /**
+     * Render a backtrace, preferring one supplied by the producer.
+     *
+     * @param  array|null $trace
+     * @return string
+     */
+    protected function renderTrace($trace)
+    {
+        if (!is_array($trace)) {
+            if (!function_exists('debug_backtrace')) {
+                return '';
+            }
+            $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $this->backtraceLimit + 6);
+            // Drop the frames belonging to the logger itself.
+            $trace = array_values(array_filter($trace, function ($frame) {
+                return !isset($frame['class']) || !in_array($frame['class'], [self::class, 'XoopsLogger'], true);
+            }));
+        }
+
+        $lines = [];
+        foreach (array_slice($trace, 0, $this->backtraceLimit) as $frame) {
+            if (!isset($frame['file'])) {
+                continue;
+            }
+            $lines[] = '    ' . $this->sanitize((string) $frame['file'])
+                . ':' . ($frame['line'] ?? '?')
+                . (isset($frame['function']) ? ' ' . $frame['function'] . '()' : '');
+        }
+
+        return [] === $lines ? '' : implode("\n", $lines);
+    }
+
+    /**
+     * Strip absolute server paths and anything session-identifying.
+     *
+     * @param  string $text
+     * @return string
+     */
+    protected function sanitize($text)
+    {
+        // Both separator styles must be replaced. The constants normally hold forward
+        // slashes while PHP reports __FILE__ and backtrace frames with the platform
+        // separator, so matching only the constant's own form silently leaks the full
+        // server path on Windows -- and in backtraces on any platform where the two
+        // disagree. Longest first, so XOOPS_ROOT_PATH cannot truncate a longer
+        // XOOPS_TRUST_PATH that lives beneath it.
+        $paths = [];
+        foreach (['XOOPS_VAR_PATH', 'XOOPS_PATH', 'XOOPS_TRUST_PATH', 'XOOPS_ROOT_PATH'] as $constant) {
+            if (!defined($constant)) {
+                continue;
+            }
+            $value = (string) constant($constant);
+            if ('' === $value) {
+                continue;
+            }
+            $paths[] = str_replace('\\', '/', $value);
+            $paths[] = str_replace('/', '\\', $value);
+        }
+        if ([] !== $paths) {
+            $paths = array_unique($paths);
+            usort($paths, static function ($a, $b) {
+                return strlen($b) <=> strlen($a);
+            });
+            $text = str_replace($paths, '', $text);
+        }
+
+        // A session id in a log file is a hijacking primitive. Keep a short hash so
+        // entries from one visitor can still be correlated.
+        if (function_exists('session_id')) {
+            $sid = session_id();
+            if (is_string($sid) && strlen($sid) > 7) {
+                $text = str_replace($sid, 'sid#' . substr(md5($sid), 0, 8), $text);
+            }
+        }
+
+        return $text;
+    }
+
+    /**
+     * @return string request uri, or 'cli'
+     */
+    protected function currentUri()
+    {
+        if ('cli' === PHP_SAPI || 'phpdbg' === PHP_SAPI) {
+            return 'cli';
+        }
+        $uri = $_SERVER['REQUEST_URI'] ?? '-';
+
+        return is_string($uri) ? substr($uri, 0, 300) : '-';
+    }
+
+    /**
+     * @return int current uid, 0 for a guest
+     */
+    protected function currentUid()
+    {
+        $user = $GLOBALS['xoopsUser'] ?? null;
+
+        return is_object($user) && method_exists($user, 'getVar') ? (int) $user->getVar('uid') : 0;
+    }
+
+    /**
+     * Append to the log, rotating first when it has grown past max_size.
+     *
+     * A failure here disables this logger for the rest of the request rather than
+     * repeating a warning for every subsequent event.
+     *
+     * @param  string $entry
+     * @return void
+     */
+    protected function write($entry)
+    {
+        $dir = dirname($this->file);
+        if (!is_dir($dir) && !@mkdir($dir, 0775, true) && !is_dir($dir)) {
+            $this->writeFailed = true;
+
+            return;
+        }
+
+        $this->rotateIfNeeded();
+
+        if (false === @file_put_contents($this->file, $entry, FILE_APPEND | LOCK_EX)) {
+            $this->writeFailed = true;
+        }
+    }
+
+    /**
+     * Roll debug.log to debug.log.1, shifting existing rotations along and
+     * discarding the oldest.
+     *
+     * @return void
+     */
+    protected function rotateIfNeeded()
+    {
+        if ($this->maxSize <= 0 || !is_file($this->file)) {
+            return;
+        }
+        $size = @filesize($this->file);
+        if (false === $size || $size < $this->maxSize) {
+            return;
+        }
+
+        if ($this->maxFiles < 1) {
+            @unlink($this->file);
+
+            return;
+        }
+
+        @unlink($this->file . '.' . $this->maxFiles);
+        for ($i = $this->maxFiles - 1; $i >= 1; --$i) {
+            if (is_file($this->file . '.' . $i)) {
+                @rename($this->file . '.' . $i, $this->file . '.' . ($i + 1));
+            }
+        }
+        @rename($this->file, $this->file . '.1');
+    }
+}

--- a/htdocs/class/logger/filelogger.php
+++ b/htdocs/class/logger/filelogger.php
@@ -33,16 +33,38 @@ if (!defined('XOOPS_ROOT_PATH')) {
  * that actually renders. When a request dies before output, or fails for a guest, or
  * only misbehaves under real traffic, the file is the only record.
  *
- * Two things are deliberately not written:
- *  - the session id, which would let anyone reading the log hijack a session;
- *  - absolute server paths, which are reduced to installation-relative form.
+ * SAFETY RULES, each of which exists because a log file is an attacker's best friend:
+ *  - the filename is restricted to a plain "*.log". Anything else, notably any
+ *    PHP-executable extension, is refused: log content is written verbatim, so a logged
+ *    statement containing PHP tags inside a *.php log would be stored, executable code;
+ *  - neither the log file nor its directory may be a symlink, so a planted link cannot
+ *    redirect appends onto mainfile.php or any other writable file;
+ *  - session ids are replaced with a short hash wherever they appear, including in the
+ *    request URI, and including before session_start() has run;
+ *  - session-table SQL is never recorded, because serialised session data carries CSRF
+ *    token seeds and module state;
+ *  - absolute server paths are reduced to installation-relative form;
+ *  - backtraces render file, line and function only. Arguments are never emitted.
  */
 class XoopsFileLogger
 {
+    /** Only a plain "name.log" is accepted. Anything else falls back to the default. */
+    private const FILENAME_PATTERN = '/^[A-Za-z0-9_-]{1,64}\.log$/';
+
+    private const DEFAULT_FILENAME = 'debug.log';
+
+    /** Rotation bounds. An unbounded max_files would spin the rotation loop for ever. */
+    private const MIN_SIZE  = 65536;        // 64 KB
+    private const MAX_SIZE  = 536870912;    // 512 MB
+    private const MAX_FILES = 20;
+
+    /** Hard cap for a single entry, so one enormous statement cannot defeat rotation. */
+    private const MAX_ENTRY = 65536;
+
     /** @var string absolute path of the current log file */
     protected $file;
 
-    /** @var int rotate once the file exceeds this many bytes */
+    /** @var int rotate once the file would exceed this many bytes */
     protected $maxSize;
 
     /** @var int how many rotated files to keep */
@@ -74,26 +96,46 @@ class XoopsFileLogger
      */
     public function __construct(array $config = [])
     {
-        $dir = XOOPS_VAR_PATH . '/logs';
-        $name = isset($config['file']) ? basename((string) $config['file']) : 'debug.log';
-        if ('' === $name || '.' === $name[0]) {
-            $name = 'debug.log';
+        $name = isset($config['file']) && is_string($config['file'])
+            ? basename($config['file'])
+            : self::DEFAULT_FILENAME;
+
+        // basename() alone is NOT enough. It stops directory traversal but happily returns
+        // "debug.php", and this class writes attacker-influenced text verbatim.
+        if (1 !== preg_match(self::FILENAME_PATTERN, $name)) {
+            $name = self::DEFAULT_FILENAME;
         }
 
-        $this->file                  = $dir . '/' . $name;
-        $this->maxSize               = max(0, (int) ($config['max_size'] ?? 8388608));
-        $this->maxFiles              = max(0, (int) ($config['max_files'] ?? 5));
-        $this->channels              = (array) ($config['channels'] ?? ['messages', 'Queries', 'Deprecated']);
+        $this->file     = XOOPS_VAR_PATH . '/logs/' . $name;
+        $this->maxSize  = $this->clamp($config['max_size'] ?? 8388608, self::MIN_SIZE, self::MAX_SIZE);
+        $this->maxFiles = $this->clamp($config['max_files'] ?? 5, 1, self::MAX_FILES);
+
+        $channels       = $config['channels'] ?? ['messages', 'Queries', 'Deprecated'];
+        $this->channels = is_array($channels) ? array_values(array_filter($channels, 'is_string')) : [];
+
         $this->queriesWithErrorsOnly = (bool) ($config['queries_with_errors_only'] ?? true);
         $this->backtrace             = (bool) ($config['backtrace'] ?? true);
-        $this->backtraceLimit        = max(1, (int) ($config['backtrace_limit'] ?? 12));
+        $this->backtraceLimit        = $this->clamp($config['backtrace_limit'] ?? 12, 1, 50);
         $this->requestId             = substr(md5(uniqid('', true)), 0, 8);
     }
 
     /**
-     * Receive one event from XoopsLogger.
+     * Coerce a setting into a sane range rather than trusting the file.
      *
-     * Signature matches the PSR-3 shape XoopsLogger dispatches with.
+     * @param  mixed $value
+     * @param  int   $min
+     * @param  int   $max
+     * @return int
+     */
+    protected function clamp($value, $min, $max)
+    {
+        $value = is_numeric($value) ? (int) $value : $min;
+
+        return max($min, min($max, $value));
+    }
+
+    /**
+     * Receive one event from XoopsLogger.
      *
      * @param  string $level   psr-3 level
      * @param  string $message
@@ -110,8 +152,15 @@ class XoopsFileLogger
         if (!in_array($channel, $this->channels, true)) {
             return;
         }
-        if ('Queries' === $channel && $this->queriesWithErrorsOnly && empty($context['error'])) {
-            return;
+        if ('Queries' === $channel) {
+            if ($this->queriesWithErrorsOnly && empty($context['error'])) {
+                return;
+            }
+            // Session rows hold serialised session state, which includes XOOPS security
+            // token seeds. Recording that statement would put live CSRF secrets in a file.
+            if ($this->touchesSessionTable((string) ($context['sql'] ?? $message))) {
+                return;
+            }
         }
 
         $this->write($this->format($level, (string) $message, $channel, $context));
@@ -120,14 +169,26 @@ class XoopsFileLogger
     /**
      * Stop writing for the remainder of the request.
      *
-     * XoopsLogger calls this for output-sensitive requests such as AJAX. The file is not
-     * output, but honouring it keeps behaviour consistent with the other loggers.
-     *
      * @return void
      */
     public function quiet()
     {
         $this->quiet = true;
+    }
+
+    /**
+     * Does this statement read or write the session table?
+     *
+     * @param  string $sql
+     * @return bool
+     */
+    protected function touchesSessionTable($sql)
+    {
+        if (!defined('XOOPS_DB_PREFIX')) {
+            return false;
+        }
+
+        return false !== stripos($sql, XOOPS_DB_PREFIX . '_session');
     }
 
     /**
@@ -142,22 +203,30 @@ class XoopsFileLogger
     protected function format($level, $message, $channel, array $context)
     {
         $head = sprintf(
-            "[%s] %s.%s req=%s uri=%s uid=%s",
+            '[%s] %s.%s req=%s uri=%s uid=%s',
             date('Y-m-d H:i:s'),
             $channel,
             strtoupper($level),
             $this->requestId,
-            $this->currentUri(),
+            $this->sanitize($this->currentUri()),
             $this->currentUid()
         );
 
-        $body = '  ' . $this->sanitize($message);
+        $message = $this->sanitize($message);
+        $body    = '  ' . $message;
 
         $detail = [];
         foreach (['errno', 'errfile', 'errline', 'sql', 'error', 'query_time'] as $key) {
-            if (isset($context[$key]) && '' !== $context[$key] && is_scalar($context[$key])) {
-                $detail[] = $key . '=' . $this->sanitize((string) $context[$key]);
+            if (!isset($context[$key]) || '' === $context[$key] || !is_scalar($context[$key])) {
+                continue;
             }
+            $value = $this->sanitize((string) $context[$key]);
+            // addQuery() passes the SQL as BOTH the message and context['sql']; writing it
+            // twice doubles the file size and the time spent holding the lock.
+            if ('sql' === $key && $value === $message) {
+                continue;
+            }
+            $detail[] = $key . '=' . $value;
         }
         if ([] !== $detail) {
             $body .= "\n  " . implode(' ', $detail);
@@ -170,11 +239,22 @@ class XoopsFileLogger
             }
         }
 
-        return $head . "\n" . $body . "\n";
+        $entry = $head . "\n" . $body . "\n";
+
+        // One entry must never be able to defeat rotation on its own.
+        if (strlen($entry) > self::MAX_ENTRY) {
+            $entry = substr($entry, 0, self::MAX_ENTRY) . "\n  ...[truncated]\n";
+        }
+
+        return $entry;
     }
 
     /**
      * Render a backtrace, preferring one supplied by the producer.
+     *
+     * Only file, line and function are emitted. Arguments are never rendered, and the
+     * self-captured trace uses DEBUG_BACKTRACE_IGNORE_ARGS, so a database password
+     * passed to a connect call cannot reach the file.
      *
      * @param  array|null $trace
      * @return string
@@ -186,7 +266,6 @@ class XoopsFileLogger
                 return '';
             }
             $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, $this->backtraceLimit + 6);
-            // Drop the frames belonging to the logger itself.
             $trace = array_values(array_filter($trace, function ($frame) {
                 return !isset($frame['class']) || !in_array($frame['class'], [self::class, 'XoopsLogger'], true);
             }));
@@ -194,7 +273,7 @@ class XoopsFileLogger
 
         $lines = [];
         foreach (array_slice($trace, 0, $this->backtraceLimit) as $frame) {
-            if (!isset($frame['file'])) {
+            if (!is_array($frame) || !isset($frame['file'])) {
                 continue;
             }
             $lines[] = '    ' . $this->sanitize((string) $frame['file'])
@@ -216,9 +295,9 @@ class XoopsFileLogger
         // Both separator styles must be replaced. The constants normally hold forward
         // slashes while PHP reports __FILE__ and backtrace frames with the platform
         // separator, so matching only the constant's own form silently leaks the full
-        // server path on Windows -- and in backtraces on any platform where the two
-        // disagree. Longest first, so XOOPS_ROOT_PATH cannot truncate a longer
-        // XOOPS_TRUST_PATH that lives beneath it.
+        // server path on Windows. realpath() variants cover a symlinked installation.
+        // Longest first, so XOOPS_ROOT_PATH cannot truncate a longer XOOPS_TRUST_PATH
+        // that lives beneath it.
         $paths = [];
         foreach (['XOOPS_VAR_PATH', 'XOOPS_PATH', 'XOOPS_TRUST_PATH', 'XOOPS_ROOT_PATH'] as $constant) {
             if (!defined($constant)) {
@@ -228,8 +307,12 @@ class XoopsFileLogger
             if ('' === $value) {
                 continue;
             }
-            $paths[] = str_replace('\\', '/', $value);
-            $paths[] = str_replace('/', '\\', $value);
+            foreach ([$value, realpath($value)] as $candidate) {
+                if (is_string($candidate) && '' !== $candidate) {
+                    $paths[] = str_replace('\\', '/', $candidate);
+                    $paths[] = str_replace('/', '\\', $candidate);
+                }
+            }
         }
         if ([] !== $paths) {
             $paths = array_unique($paths);
@@ -239,16 +322,22 @@ class XoopsFileLogger
             $text = str_replace($paths, '', $text);
         }
 
+        // Anything still absolute came from outside the installation -- a shared include
+        // directory, a temp file, a vendor path outside the tree. Reduce it to its
+        // basename rather than publishing the server's directory layout.
+        $text = preg_replace('#\b[A-Za-z]:[\\\\/][^\s"\'<>()]*[\\\\/]([^\\\\/\s"\'<>()]+)#', '.../$1', (string) $text);
+        $text = preg_replace('#(?<![\w:])/(?:home|usr|var|opt|srv|tmp|etc|root)/[^\s"\'<>()]*/([^/\s"\'<>()]+)#', '.../$1', (string) $text);
+
         // A session id in a log file is a hijacking primitive. Keep a short hash so
         // entries from one visitor can still be correlated.
         if (function_exists('session_id')) {
             $sid = session_id();
             if (is_string($sid) && strlen($sid) > 7) {
-                $text = str_replace($sid, 'sid#' . substr(md5($sid), 0, 8), $text);
+                $text = str_replace($sid, 'sid#' . substr(md5($sid), 0, 8), (string) $text);
             }
         }
 
-        return $text;
+        return (string) $text;
     }
 
     /**
@@ -260,8 +349,22 @@ class XoopsFileLogger
             return 'cli';
         }
         $uri = $_SERVER['REQUEST_URI'] ?? '-';
+        if (!is_string($uri)) {
+            return '-';
+        }
 
-        return is_string($uri) ? substr($uri, 0, 300) : '-';
+        // A URL-borne session id has to go even before session_start() has run, when
+        // session_id() is still empty and the hash replacement below cannot match it.
+        $name = function_exists('session_name') ? (string) session_name() : 'PHPSESSID';
+        if ('' !== $name) {
+            $uri = preg_replace(
+                '/([?&])' . preg_quote($name, '/') . '=[^&]*/i',
+                '$1' . $name . '=sid%23redacted',
+                $uri
+            );
+        }
+
+        return substr((string) $uri, 0, 300);
     }
 
     /**
@@ -275,10 +378,10 @@ class XoopsFileLogger
     }
 
     /**
-     * Append to the log, rotating first when it has grown past max_size.
+     * Append to the log, rotating first when the entry would push it past max_size.
      *
-     * A failure here disables this logger for the rest of the request rather than
-     * repeating a warning for every subsequent event.
+     * A failure disables this logger for the rest of the request rather than repeating a
+     * warning for every subsequent event.
      *
      * @param  string $entry
      * @return void
@@ -292,32 +395,48 @@ class XoopsFileLogger
             return;
         }
 
-        $this->rotateIfNeeded();
-
-        if (false === @file_put_contents($this->file, $entry, FILE_APPEND | LOCK_EX)) {
+        // A symlinked directory or log file would let an append land on any writable file
+        // the web user owns -- mainfile.php being the obvious target. basename() does not
+        // protect against this at all.
+        if (is_link($dir) || is_link($this->file)) {
             $this->writeFailed = true;
+
+            return;
         }
+
+        $this->rotateIfNeeded(strlen($entry));
+
+        $handle = @fopen($this->file, 'ab');
+        if (false === $handle) {
+            $this->writeFailed = true;
+
+            return;
+        }
+        // Non-blocking: a lock held by a stalled process must not park this request in a
+        // queue behind it. Losing one debug line beats holding a worker.
+        if (flock($handle, LOCK_EX | LOCK_NB)) {
+            fwrite($handle, $entry);
+            flock($handle, LOCK_UN);
+        }
+        fclose($handle);
     }
 
     /**
-     * Roll debug.log to debug.log.1, shifting existing rotations along and
-     * discarding the oldest.
+     * Roll debug.log to debug.log.1, shifting existing rotations along and discarding
+     * the oldest.
      *
+     * @param  int $incoming size of the entry about to be appended
      * @return void
      */
-    protected function rotateIfNeeded()
+    protected function rotateIfNeeded($incoming = 0)
     {
-        if ($this->maxSize <= 0 || !is_file($this->file)) {
+        if (!is_file($this->file)) {
             return;
         }
         $size = @filesize($this->file);
-        if (false === $size || $size < $this->maxSize) {
-            return;
-        }
-
-        if ($this->maxFiles < 1) {
-            @unlink($this->file);
-
+        // Projected size, so an entry that would push the file past the limit rotates
+        // before it is written rather than after.
+        if (false === $size || ($size + $incoming) < $this->maxSize) {
             return;
         }
 

--- a/htdocs/class/logger/filelogger.php
+++ b/htdocs/class/logger/filelogger.php
@@ -233,11 +233,16 @@ class XoopsFileLogger
             return;
         }
 
-        $channel = (string) ($context['channel'] ?? 'messages');
-        if (!in_array(strtolower($channel), $this->channels, true)) {
+        // Compared in one normalised form throughout. The membership test below was
+        // already case-insensitive, so a producer dispatching 'queries' reached the guards
+        // that follow -- and an exact-case comparison there would skip them, including the
+        // session-table exclusion, which is a privacy control rather than a volume one.
+        $channel    = (string) ($context['channel'] ?? 'messages');
+        $normalised = strtolower($channel);
+        if (!in_array($normalised, $this->channels, true)) {
             return;
         }
-        if ('Queries' === $channel) {
+        if ('queries' === $normalised) {
             if ($this->queriesWithErrorsOnly && empty($context['error'])) {
                 return;
             }
@@ -527,11 +532,22 @@ class XoopsFileLogger
 
         $this->rotateIfNeeded(strlen($entry));
 
+        // Checked before the append, and after rotateIfNeeded() has possibly renamed the
+        // live file away, so a freshly rotated log is treated as new too.
+        $isNew  = !is_file($this->file);
         $handle = @fopen($this->file, 'ab');
         if (false === $handle) {
             $this->writeFailed = true;
 
             return;
+        }
+        // Owner and group only. The contents are precisely what the redaction above works
+        // to keep unreachable, and on shared hosting the file mode is the last control
+        // standing once xoops_data has been moved out of the web root as the docs advise.
+        // Left best-effort deliberately: the file exists either way by this point, so
+        // refusing to write would not make a mode we failed to tighten any safer.
+        if ($isNew) {
+            @chmod($this->file, 0640);
         }
         // Non-blocking: a lock held by a stalled process must not park this request in a
         // queue behind it. Losing one debug line beats holding a worker.
@@ -561,19 +577,27 @@ class XoopsFileLogger
             return;
         }
 
-        // Failures are tolerated but not ignored. Losing an old rotation costs nothing,
-        // so those are best-effort; failing to move the LIVE file is different -- the
-        // next append would go straight back onto an already-oversized file -- so that
-        // one disables the logger for the request rather than growing without bound.
+        // Every step of the cascade is checked, because none of them can be shrugged off:
+        // once a move fails, the following one renames onto the slot that failed to empty
+        // and destroys it. A failure therefore stops rotation and disables the logger for
+        // the request, rather than silently discarding data or appending to a file that
+        // is already over the limit.
         if (is_file($this->file . '.' . $this->maxFiles) && !@unlink($this->file . '.' . $this->maxFiles)) {
             $this->writeFailed = true;
 
             return;
         }
         for ($i = $this->maxFiles - 1; $i >= 1; --$i) {
-            if (is_file($this->file . '.' . $i)) {
-                // Best effort: an unmovable intermediate rotation just stays where it is.
-                @rename($this->file . '.' . $i, $this->file . '.' . ($i + 1));
+            if (!is_file($this->file . '.' . $i)) {
+                continue;
+            }
+            // Stopping here loses nothing. Carrying on would: the next iteration moves
+            // .($i - 1) onto .$i, overwriting the rotation that just failed to move --
+            // and that is newer data than the one the cascade set out to discard.
+            if (!@rename($this->file . '.' . $i, $this->file . '.' . ($i + 1))) {
+                $this->writeFailed = true;
+
+                return;
             }
         }
         if (!@rename($this->file, $this->file . '.1')) {

--- a/htdocs/class/logger/xoopslogger.php
+++ b/htdocs/class/logger/xoopslogger.php
@@ -322,11 +322,16 @@ class XoopsLogger
             // so the renderer cannot tell the two apart and escaping there would either
             // miss the message or destroy the trace markup.
             $this->deprecated[] = htmlspecialchars((string) $msg, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . $miniTrace;
-
-            // Dispatched with the RAW message: a file or PSR-3 logger wants the text, not
-            // HTML entities.
-            $this->log('warning', $msg, ['channel' => 'Deprecated']);
         }
+
+        // Dispatched OUTSIDE the activated guard, matching addQuery/addBlock/addExtra.
+        // activated gates the in-memory collectors that feed the in-page dump; a
+        // registered logger writing to a file has nothing to do with that, and a
+        // file-logging-only configuration switches the collectors off to save memory.
+        //
+        // Dispatched with the RAW message: a file or PSR-3 logger wants the text, not the
+        // HTML entities the panel entry above needs.
+        $this->log('warning', $msg, ['channel' => 'Deprecated']);
     }
 
     /**

--- a/htdocs/class/logger/xoopslogger.php
+++ b/htdocs/class/logger/xoopslogger.php
@@ -364,6 +364,11 @@ class XoopsLogger
                 'errno'   => $errno,
                 'errfile' => $errfile,
                 'errline' => $errline,
+                // Passed through so a logger can record where the error came from. Only
+                // forwarded when a caller supplied one -- building a backtrace here for
+                // every notice would cost more than the logging is worth, so a logger that
+                // wants one and did not get one captures its own.
+                'trace'   => $trace,
             ]);
         }
 

--- a/htdocs/class/xoopsload.php
+++ b/htdocs/class/xoopsload.php
@@ -186,6 +186,7 @@ class XoopsLoad
             'xoopskernel'                => XOOPS_ROOT_PATH . '/class/xoopskernel.php',
             'xoopssecurity'              => XOOPS_ROOT_PATH . '/class/xoopssecurity.php',
             'xoopslogger'                => XOOPS_ROOT_PATH . '/class/logger/xoopslogger.php',
+            'filelogger'                 => XOOPS_ROOT_PATH . '/class/logger/filelogger.php',
             'xoopspagenav'               => XOOPS_ROOT_PATH . '/class/pagenav.php',
             'xoopslists'                 => XOOPS_ROOT_PATH . '/class/xoopslists.php',
             'xoopslocal'                 => XOOPS_ROOT_PATH . '/include/xoopslocal.php',

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -157,16 +157,52 @@ $xoops->gzipCompression();
 
 /**
  * Start of Error Reporting.
+ *
+ * Two independent switches feed this:
+ *  - $xoopsConfig['debug_mode'], set in Admin -> Preferences, drives the in-page debug
+ *    output shown to administrators;
+ *  - xoops_data/data/debug.php, if present, drives file logging and PHP error settings.
+ *
+ * Either can be used alone. A site is normally left with debug_mode off and no
+ * debug.php, which is the historical behaviour and costs nothing.
+ *
+ * mainfile.php already loaded the config on a 2.7.3+ install; loading it again here is
+ * free (the result is cached) and is what lets an install whose mainfile.php predates
+ * 2.7.3 still get file logging, even though its XOOPS_DEBUG constant was fixed earlier.
  */
+include_once XOOPS_ROOT_PATH . '/include/debugconfig.php';
+$xoopsDebugConfig = xoops_getDebugConfig();
+
 if ($xoopsConfig['debug_mode'] == 1 || $xoopsConfig['debug_mode'] == 2) {
     xoops_loadLanguage('logger');
     error_reporting(E_ALL);
     $xoopsLogger->enableRendering();
     $xoopsLogger->usePopup = ($xoopsConfig['debug_mode'] == 2);
+} elseif ([] !== $xoopsDebugConfig) {
+    // File logging without the in-page output: the logger must stay ACTIVE and errors
+    // must still be reported, or there is nothing for it to record. Rendering is left
+    // off deliberately, so enabling this cannot change what a visitor sees.
+    xoops_loadLanguage('logger');
+    xoops_applyDebugConfig();
 } else {
     error_reporting(0);
     $xoopsLogger->activated = false;
 }
+
+/**
+ * Attach the file logger when xoops_data/data/debug.php asks for it.
+ *
+ * It registers in the same seat DebugBar uses, so it receives every event the in-page
+ * output receives -- notices, warnings, errors, deprecations and SQL -- and records them
+ * even when the request dies before rendering anything.
+ */
+if ([] !== $xoopsDebugConfig && !empty($xoopsDebugConfig['log']['enabled'])) {
+    XoopsLoad::load('filelogger');
+    if (class_exists('XoopsFileLogger', false)) {
+        $xoopsLogger->addLogger(new XoopsFileLogger((array) $xoopsDebugConfig['log']));
+    }
+}
+unset($xoopsDebugConfig);
 
 /**
  * Check Bad Ip Addressed against database and block bad ones, requires configs loaded

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -89,10 +89,19 @@ $xoopsLogger->startTime('XOOPS Boot');
  */
 include_once XOOPS_ROOT_PATH . '/include/debugconfig.php';
 $xoopsDebugConfig = xoops_getDebugConfig();
-if ([] !== $xoopsDebugConfig && !empty($xoopsDebugConfig['log']['enabled'])) {
-    XoopsLoad::load('filelogger');
-    if (class_exists('XoopsFileLogger', false)) {
-        $xoopsLogger->addLogger(new XoopsFileLogger((array) $xoopsDebugConfig['log']));
+if ([] !== $xoopsDebugConfig) {
+    // Applied HERE as well as further down. On an install whose mainfile.php predates
+    // 2.7.3 nothing has raised error_reporting yet, so php.ini still governs -- and if
+    // that is restrictive, handleError() discards the early errors before any logger sees
+    // them. Attaching the logger early is pointless unless reporting is raised with it.
+    // The call is idempotent and the config is cached, so repeating it costs nothing.
+    xoops_applyDebugConfig();
+
+    if (!empty($xoopsDebugConfig['log']['enabled'])) {
+        XoopsLoad::load('filelogger');
+        if (class_exists('XoopsFileLogger', false)) {
+            $xoopsLogger->addLogger(new XoopsFileLogger((array) $xoopsDebugConfig['log']));
+        }
     }
 }
 unset($xoopsDebugConfig);
@@ -190,11 +199,11 @@ $xoops->gzipCompression();
  * Either can be used alone. A site is normally left with debug_mode off and no
  * debug.php, which is the historical behaviour and costs nothing.
  *
- * mainfile.php already loaded the config on a 2.7.3+ install; loading it again here is
- * free (the result is cached) and is what lets an install whose mainfile.php predates
+ * The loader was already included above, where the file logger is attached; the result is
+ * cached, so reading it again here is free. That earlier point is also what lets an
+ * install whose mainfile.php predates
  * 2.7.3 still get file logging, even though its XOOPS_DEBUG constant was fixed earlier.
  */
-include_once XOOPS_ROOT_PATH . '/include/debugconfig.php';
 $xoopsDebugConfig = xoops_getDebugConfig();
 
 if ($xoopsConfig['debug_mode'] == 1 || $xoopsConfig['debug_mode'] == 2) {
@@ -222,6 +231,9 @@ if ($xoopsConfig['debug_mode'] == 1 || $xoopsConfig['debug_mode'] == 2) {
     error_reporting(0);
     $xoopsLogger->activated = false;
 }
+// Not left in the global scope: this array would otherwise be visible to every template
+// and module that reaches into globals. The earlier block unsets it for the same reason.
+unset($xoopsDebugConfig);
 
 
 /**

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -74,6 +74,30 @@ $xoopsLogger->startTime();
 $xoopsLogger->startTime('XOOPS Boot');
 
 /**
+ * Attach the file logger IMMEDIATELY when xoops_data/data/debug.php asks for it.
+ *
+ * Deliberately here and not beside the debug_mode block further down: everything between
+ * the two points -- the database connection, config loading, the theme resolve -- is
+ * where a broken site actually fails, and those are precisely the errors and queries
+ * worth having. Registering after them meant the most useful diagnostics were never
+ * written.
+ *
+ * Only XOOPS_VAR_PATH is required, which mainfile.php has already defined. The logger
+ * takes the same seat DebugBar uses, so it receives notices, warnings, errors,
+ * deprecations and SQL with no change to any producer. With no debug.php this is one
+ * file_exists() and nothing more.
+ */
+include_once XOOPS_ROOT_PATH . '/include/debugconfig.php';
+$xoopsDebugConfig = xoops_getDebugConfig();
+if ([] !== $xoopsDebugConfig && !empty($xoopsDebugConfig['log']['enabled'])) {
+    XoopsLoad::load('filelogger');
+    if (class_exists('XoopsFileLogger', false)) {
+        $xoopsLogger->addLogger(new XoopsFileLogger((array) $xoopsDebugConfig['log']));
+    }
+}
+unset($xoopsDebugConfig);
+
+/**
  * Include Required Files
  */
 include_once $xoops->path('kernel/object.php');
@@ -199,20 +223,6 @@ if ($xoopsConfig['debug_mode'] == 1 || $xoopsConfig['debug_mode'] == 2) {
     $xoopsLogger->activated = false;
 }
 
-/**
- * Attach the file logger when xoops_data/data/debug.php asks for it.
- *
- * It registers in the same seat DebugBar uses, so it receives every event the in-page
- * output receives -- notices, warnings, errors, deprecations and SQL -- and records them
- * even when the request dies before rendering anything.
- */
-if ([] !== $xoopsDebugConfig && !empty($xoopsDebugConfig['log']['enabled'])) {
-    XoopsLoad::load('filelogger');
-    if (class_exists('XoopsFileLogger', false)) {
-        $xoopsLogger->addLogger(new XoopsFileLogger((array) $xoopsDebugConfig['log']));
-    }
-}
-unset($xoopsDebugConfig);
 
 /**
  * Check Bad Ip Addressed against database and block bad ones, requires configs loaded

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -179,11 +179,21 @@ if ($xoopsConfig['debug_mode'] == 1 || $xoopsConfig['debug_mode'] == 2) {
     $xoopsLogger->enableRendering();
     $xoopsLogger->usePopup = ($xoopsConfig['debug_mode'] == 2);
 } elseif ([] !== $xoopsDebugConfig) {
-    // File logging without the in-page output: the logger must stay ACTIVE and errors
-    // must still be reported, or there is nothing for it to record. Rendering is left
-    // off deliberately, so enabling this cannot change what a visitor sees.
+    // File logging WITHOUT the in-page output.
+    //
+    // errors must still be reported or there is nothing to record, and rendering stays
+    // off so enabling this cannot change what a visitor sees.
+    //
+    // activated stays FALSE on purpose. It gates the in-memory collectors ($queries,
+    // $blocks, $extra) that exist only to be rendered into the page -- and nothing is
+    // going to render here. Leaving it true accumulated every statement of every request
+    // for a dump that never happens, which a long import would turn into an out-of-memory
+    // failure. Dispatch to registered loggers is deliberately outside that guard in
+    // addQuery/addBlock/addExtra/handleError, so the file logger still receives
+    // everything.
     xoops_loadLanguage('logger');
     xoops_applyDebugConfig();
+    $xoopsLogger->activated = false;
 } else {
     error_reporting(0);
     $xoopsLogger->activated = false;

--- a/htdocs/include/debugconfig.php
+++ b/htdocs/include/debugconfig.php
@@ -84,6 +84,13 @@ if (!function_exists('xoops_getDebugConfig')) {
         $loaded['log']      = isset($loaded['log']) && is_array($loaded['log']) ? $loaded['log'] : [];
         $loaded['database'] = isset($loaded['database']) && is_array($loaded['database']) ? $loaded['database'] : [];
 
+        // The nested switches need the same strict treatment as the top-level one.
+        // Downstream reads them with !empty(), and the string 'false' is not empty, so
+        // 'enabled' => 'false' switched logging ON -- precisely the trap closed above,
+        // one level further down.
+        $loaded['log']['enabled']         = true === ($loaded['log']['enabled'] ?? false);
+        $loaded['database']['legacy_log'] = true === ($loaded['database']['legacy_log'] ?? false);
+
         $config = $loaded;
 
         return $config;

--- a/htdocs/include/debugconfig.php
+++ b/htdocs/include/debugconfig.php
@@ -57,10 +57,32 @@ if (!function_exists('xoops_getDebugConfig')) {
             return $config;
         }
 
-        $loaded = include $file;
-        if (!is_array($loaded) || empty($loaded['enabled'])) {
+        // A hand-edited file WILL eventually contain a syntax error or throw. Without this
+        // boundary that becomes an uncaught ParseError during bootstrap -- a debugging aid
+        // taking the whole site down. Failing closed, to production behaviour, is the only
+        // acceptable outcome.
+        try {
+            $loaded = include $file;
+        } catch (\Throwable $e) {
+            trigger_error(
+                'xoops_data/data/debug.php could not be loaded (' . get_class($e)
+                . '); continuing with debugging disabled.',
+                E_USER_WARNING
+            );
+
             return $config;
         }
+
+        // 'enabled' must be a real boolean. A string from an environment-backed config is
+        // truthy whatever it happens to say, so 'false' would switch debugging ON.
+        if (!is_array($loaded) || true !== ($loaded['enabled'] ?? false)) {
+            return $config;
+        }
+
+        // Normalise the nested shapes now, so nothing downstream has to defend itself
+        // against an object or a string where an array belongs.
+        $loaded['log']      = isset($loaded['log']) && is_array($loaded['log']) ? $loaded['log'] : [];
+        $loaded['database'] = isset($loaded['database']) && is_array($loaded['database']) ? $loaded['database'] : [];
 
         $config = $loaded;
 
@@ -84,12 +106,20 @@ if (!function_exists('xoops_applyDebugConfig')) {
             return false;
         }
 
+        // Strict booleans only: a string such as 'false' is truthy and would turn
+        // display_errors ON against the stated intent.
         if (array_key_exists('display_errors', $config)) {
-            ini_set('display_errors', $config['display_errors'] ? '1' : '0');
+            ini_set('display_errors', true === $config['display_errors'] ? '1' : '0');
         }
-        if (array_key_exists('error_reporting', $config)) {
-            error_reporting((int) $config['error_reporting']);
-        }
+
+        // error_reporting defaults to E_ALL when debugging is enabled but the key is
+        // absent or not an integer. Leaving php.ini's value in place would silently
+        // produce an enabled logger that records nothing -- if error_reporting is 0,
+        // XoopsLogger::handleError() discards every error before it reaches a logger.
+        // A string like 'E_ALL' casts to 0, which is exactly that trap, so only a real
+        // integer is honoured.
+        $reporting = $config['error_reporting'] ?? null;
+        error_reporting(is_int($reporting) ? $reporting : E_ALL);
 
         return true;
     }

--- a/htdocs/include/debugconfig.php
+++ b/htdocs/include/debugconfig.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * XOOPS debug configuration loader
+ *
+ * You may not change or alter any portion of this comment or credits
+ * of supporting developers from this source code or any supporting source code
+ * which is considered copyrighted (c) material of the original comment or credit authors.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @category            Debug
+ * @copyright       (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license             GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @package             core
+ * @link                https://xoops.org
+ * @since               2.7.3
+ * @author              XOOPS Team
+ */
+
+if (!defined('XOOPS_ROOT_PATH')) {
+    die('Restricted access');
+}
+
+if (!function_exists('xoops_getDebugConfig')) {
+    /**
+     * Read xoops_data/data/debug.php, once per request.
+     *
+     * Returns an empty array when the file is absent, unreadable, does not return an
+     * array, or has 'enabled' set to false — in every one of those cases XOOPS behaves
+     * exactly as it did before this file existed. That is the point: the whole feature
+     * is opt-in and its absence is the normal state.
+     *
+     * Loaded from two places, whichever comes first:
+     *  - mainfile.php (new installs), early enough to define XOOPS_DEBUG itself;
+     *  - include/common.php, which every install reaches, so a site whose mainfile.php
+     *    predates 2.7.3 still gets the logging even though its XOOPS_DEBUG constant was
+     *    already fixed by then.
+     *
+     * @return array the settings, or [] when debugging is not configured
+     */
+    function xoops_getDebugConfig()
+    {
+        static $config = null;
+
+        if (null !== $config) {
+            return $config;
+        }
+        $config = [];
+
+        if (!defined('XOOPS_VAR_PATH')) {
+            return $config;
+        }
+
+        $file = XOOPS_VAR_PATH . '/data/debug.php';
+        if (!is_file($file) || !is_readable($file)) {
+            return $config;
+        }
+
+        $loaded = include $file;
+        if (!is_array($loaded) || empty($loaded['enabled'])) {
+            return $config;
+        }
+
+        $config = $loaded;
+
+        return $config;
+    }
+}
+
+if (!function_exists('xoops_applyDebugConfig')) {
+    /**
+     * Apply the PHP-level settings: display_errors and error_reporting.
+     *
+     * Kept separate from xoops_getDebugConfig() so the configuration can be inspected
+     * without side effects — the upgrade tooling and tests need to do exactly that.
+     *
+     * @return bool true when debugging is enabled and was applied
+     */
+    function xoops_applyDebugConfig()
+    {
+        $config = xoops_getDebugConfig();
+        if ([] === $config) {
+            return false;
+        }
+
+        if (array_key_exists('display_errors', $config)) {
+            ini_set('display_errors', $config['display_errors'] ? '1' : '0');
+        }
+        if (array_key_exists('error_reporting', $config)) {
+            error_reporting((int) $config['error_reporting']);
+        }
+
+        return true;
+    }
+}

--- a/htdocs/mainfile.dist.php
+++ b/htdocs/mainfile.dist.php
@@ -73,13 +73,19 @@ if (!defined('XOOPS_MAINFILE_INCLUDED')) {
         }
     }
 
-    // Production: disable logging for performance
-    define('XOOPS_DB_LEGACY_LOG', false);
-    define('XOOPS_DEBUG', false);
+    // Debug settings are read from xoops_data/data/debug.php when that file exists.
+    // Copy debug.dist.php beside it to switch debugging on, instead of editing this
+    // file -- mainfile.php also holds your database credentials and is never replaced
+    // on upgrade, which is what made the old approach awkward.
+    //
+    // No debug.php present means production behaviour, exactly as before.
+    include_once XOOPS_ROOT_PATH . '/include/debugconfig.php';
+    $xoopsDebugConfig = xoops_getDebugConfig();
+    xoops_applyDebugConfig();
 
-    // Development/Staging: enable to track legacy usage
-    //    define('XOOPS_DB_LEGACY_LOG', true);
-    //    define('XOOPS_DEBUG', true); // Also shows E_USER_DEPRECATED notices
+    define('XOOPS_DB_LEGACY_LOG', !empty($xoopsDebugConfig['database']['legacy_log']));
+    define('XOOPS_DEBUG', [] !== $xoopsDebugConfig); // Also shows E_USER_DEPRECATED notices
+    unset($xoopsDebugConfig);
 
     // Secure file
     require XOOPS_VAR_PATH . '/data/secure.php';

--- a/htdocs/mainfile.dist.php
+++ b/htdocs/mainfile.dist.php
@@ -79,9 +79,18 @@ if (!defined('XOOPS_MAINFILE_INCLUDED')) {
     // on upgrade, which is what made the old approach awkward.
     //
     // No debug.php present means production behaviour, exactly as before.
-    include_once XOOPS_ROOT_PATH . '/include/debugconfig.php';
-    $xoopsDebugConfig = xoops_getDebugConfig();
-    xoops_applyDebugConfig();
+    // Guarded: include_once only WARNS on a missing file, and calling the function would
+    // then be a fatal "Call to undefined function" -- taking the whole site down before
+    // secure.php is even read. mainfile.php survives upgrades while include/ is replaced,
+    // so a partial or interrupted upgrade can genuinely produce this pairing.
+    $xoopsDebugConfig = [];
+    if (is_readable(XOOPS_ROOT_PATH . '/include/debugconfig.php')) {
+        include_once XOOPS_ROOT_PATH . '/include/debugconfig.php';
+        if (function_exists('xoops_getDebugConfig')) {
+            $xoopsDebugConfig = xoops_getDebugConfig();
+            xoops_applyDebugConfig();
+        }
+    }
 
     define('XOOPS_DB_LEGACY_LOG', !empty($xoopsDebugConfig['database']['legacy_log']));
     define('XOOPS_DEBUG', [] !== $xoopsDebugConfig); // Also shows E_USER_DEPRECATED notices

--- a/htdocs/xoops_data/data/.htaccess
+++ b/htdocs/xoops_data/data/.htaccess
@@ -1,7 +1,13 @@
-<Files "secure.php">
-Deny from all
-</Files>
-
-<Files "debug.php">
-Deny from all
-</Files>
+# secure.php holds the database credentials; debug.php controls error display and
+# logging. Neither may ever be served.
+#
+# Apache only -- on nginx or IIS these directives are ignored.
+<FilesMatch "^(secure|debug)\.php$">
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+    </IfModule>
+</FilesMatch>

--- a/htdocs/xoops_data/data/.htaccess
+++ b/htdocs/xoops_data/data/.htaccess
@@ -1,8 +1,10 @@
 # secure.php holds the database credentials; debug.php controls error display and
-# logging. Neither may ever be served.
+# logging. Neither may ever be served -- nor the editor leftovers that copying and
+# hand-editing a dist file reliably produces (debug.php~, debug.php.bak, .debug.php.swp),
+# which most servers hand out as plain text.
 #
 # Apache only -- on nginx or IIS these directives are ignored.
-<FilesMatch "^(secure|debug)\.php$">
+<FilesMatch "^\.?(secure|debug)\.php($|[~.])">
     <IfModule mod_authz_core.c>
         Require all denied
     </IfModule>

--- a/htdocs/xoops_data/data/.htaccess
+++ b/htdocs/xoops_data/data/.htaccess
@@ -1,3 +1,7 @@
 <Files "secure.php">
 Deny from all
 </Files>
+
+<Files "debug.php">
+Deny from all
+</Files>

--- a/htdocs/xoops_data/data/debug.dist.php
+++ b/htdocs/xoops_data/data/debug.dist.php
@@ -31,8 +31,29 @@
  *
  * NEVER enable this on a production site that serves real visitors:
  * display_errors reveals paths and query fragments to anyone who triggers an
- * error. The shipped .htaccess denies web access to debug.php, but that only
- * protects Apache installs — on nginx or IIS, confirm the rule yourself.
+ * error.
+ *
+ * ---------------------------------------------------------------------------
+ * READ THIS FIRST: is your log directory reachable over the web?
+ * ---------------------------------------------------------------------------
+ * The log records SQL, user ids, backtraces and file paths. XOOPS ships
+ * .htaccess files denying web access to this file and to xoops_data/logs, but
+ * .htaccess works on APACHE ONLY, and only where AllowOverride permits it. On
+ * nginx, IIS, or Apache with AllowOverride None, those files do nothing at all.
+ *
+ * The reliable fix is to keep xoops_data OUTSIDE the document root, which many
+ * installations already do. If it sits under the web root, add the equivalent
+ * rule yourself, then verify by requesting the log URL in a browser:
+ *
+ *   nginx:
+ *     location ^~ /xoops_data/ { deny all; return 404; }
+ *
+ *   IIS (web.config): add "xoops_data" to requestFiltering/hiddenSegments.
+ *
+ * The log filename is restricted to a plain "*.log" name, and any other value
+ * silently falls back to debug.log. That restriction is deliberate: log content
+ * is written verbatim, so a *.php log could be made to hold executable code.
+ * ---------------------------------------------------------------------------
  *
  * This is INDEPENDENT of Admin -> Preferences -> Debug Mode, which controls the
  * in-page debug output shown to administrators. Either can be used alone.

--- a/htdocs/xoops_data/data/debug.dist.php
+++ b/htdocs/xoops_data/data/debug.dist.php
@@ -77,6 +77,14 @@ return [
     'display_errors'  => true,
     'error_reporting' => E_ALL,
 
+    'database' => [
+        // Sets XOOPS_DB_LEGACY_LOG, which makes the database layer report legacy call
+        // patterns (deprecated Criteria forms, queryF() for writes, and similar). Useful
+        // when modernising a module, noisy otherwise — it is off in the production
+        // mainfile.php default for exactly that reason.
+        'legacy_log' => false,
+    ],
+
     /*
      * Persistent log file.
      *

--- a/htdocs/xoops_data/data/debug.dist.php
+++ b/htdocs/xoops_data/data/debug.dist.php
@@ -87,7 +87,18 @@ return [
     'log' => [
         'enabled' => true,
 
+        // Logging REFUSES to run while xoops_data sits inside the document root, because
+        // the log would then be a plain fetchable file on any server where .htaccess is
+        // ignored — nginx, IIS, or Apache with AllowOverride None. Documentation is not a
+        // control, so this fails closed.
+        //
+        // The right fix is to move xoops_data outside the web root. If instead you have
+        // added a server rule yourself AND verified it by requesting the log URL, set
+        // this to true to accept the remaining risk.
+        'allow_web_accessible_log' => false,
+
         // Written to xoops_data/logs/. Rotated files get .1, .2 … suffixes.
+        // Must be a plain "*.log" name; anything else falls back to debug.log.
         'file' => 'debug.log',
 
         // Rotate once the file passes this size, keeping this many older files.

--- a/htdocs/xoops_data/data/debug.dist.php
+++ b/htdocs/xoops_data/data/debug.dist.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * XOOPS debug settings
+ *
+ * You may not change or alter any portion of this comment or credits
+ * of supporting developers from this source code or any supporting source code
+ * which is considered copyrighted (c) material of the original comment or credit authors.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright       (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license             GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @package             core
+ * @since               2.7.3
+ */
+
+/*
+ * ---------------------------------------------------------------------------
+ * HOW TO USE
+ * ---------------------------------------------------------------------------
+ * Copy this file to debug.php in the same directory and edit it. While
+ * debug.php does not exist, XOOPS behaves exactly as before and nothing here
+ * has any effect — this is an opt-in development aid.
+ *
+ *     xoops_data/data/debug.dist.php  ->  xoops_data/data/debug.php
+ *
+ * It replaces hand-editing XOOPS_DEBUG in mainfile.php, which is awkward
+ * because mainfile.php also holds your database credentials and is not
+ * replaced on upgrade.
+ *
+ * NEVER enable this on a production site that serves real visitors:
+ * display_errors reveals paths and query fragments to anyone who triggers an
+ * error. The shipped .htaccess denies web access to debug.php, but that only
+ * protects Apache installs — on nginx or IIS, confirm the rule yourself.
+ *
+ * This is INDEPENDENT of Admin -> Preferences -> Debug Mode, which controls the
+ * in-page debug output shown to administrators. Either can be used alone.
+ * ---------------------------------------------------------------------------
+ */
+
+if (!defined('XOOPS_ROOT_PATH')) {
+    // Not reachable through the web server, and not useful standalone.
+    http_response_code(404);
+    exit();
+}
+
+return [
+    // Master switch. false leaves XOOPS in its normal production behaviour even
+    // if the rest of this file says otherwise.
+    'enabled' => true,
+
+    // Sets XOOPS_DEBUG, and PHP's display_errors / error_reporting, as early as
+    // the bootstrap allows. E_ALL includes the E_USER_DEPRECATED notices XOOPS
+    // raises for legacy module APIs.
+    'display_errors'  => true,
+    'error_reporting' => E_ALL,
+
+    /*
+     * Persistent log file.
+     *
+     * Records everything the in-page debug output shows, but to a file, so you
+     * still have it when a page dies before rendering — which is exactly when
+     * you need it most. Notices and warnings are included, not only errors.
+     */
+    'log' => [
+        'enabled' => true,
+
+        // Written to xoops_data/logs/. Rotated files get .1, .2 … suffixes.
+        'file' => 'debug.log',
+
+        // Rotate once the file passes this size, keeping this many older files.
+        // Left unbounded, a busy site can produce hundreds of MB in a day.
+        'max_size'  => 8388608, // 8 MB
+        'max_files' => 5,
+
+        // Which channels to record. 'messages' carries PHP notices, warnings and
+        // errors; 'Queries' carries SQL including failures. Blocks and Extra are
+        // verbose and off by default.
+        'channels' => ['messages', 'Queries', 'Deprecated'],
+
+        // Only record queries that failed. Turn off to log every statement —
+        // useful for N+1 hunting, but very large on a busy site.
+        'queries_with_errors_only' => true,
+
+        // Append a backtrace to each entry. This is what makes an entry
+        // actionable rather than merely informative.
+        'backtrace'       => true,
+        'backtrace_limit' => 12,
+    ],
+];

--- a/htdocs/xoops_data/logs/.htaccess
+++ b/htdocs/xoops_data/logs/.htaccess
@@ -1,0 +1,5 @@
+# Log files may contain query fragments, user ids and backtraces.
+# They must never be readable over the web.
+<FilesMatch "\.(log|txt)(\.[0-9]+)?$">
+Deny from all
+</FilesMatch>

--- a/htdocs/xoops_data/logs/.htaccess
+++ b/htdocs/xoops_data/logs/.htaccess
@@ -1,5 +1,18 @@
-# Log files may contain query fragments, user ids and backtraces.
+# Log files contain query fragments, user ids, backtraces and file paths.
 # They must never be readable over the web.
-<FilesMatch "\.(log|txt)(\.[0-9]+)?$">
-Deny from all
-</FilesMatch>
+#
+# This protects Apache only. On nginx or IIS, or with AllowOverride None, this file
+# does nothing at all -- see xoops_data/data/debug.dist.php for the server rules to
+# add. The safest configuration by far is to place xoops_data OUTSIDE the document
+# root, which makes all of this moot.
+
+# Apache 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache 2.2
+<IfModule !mod_authz_core.c>
+    Order allow,deny
+    Deny from all
+</IfModule>

--- a/htdocs/xoops_data/logs/index.php
+++ b/htdocs/xoops_data/logs/index.php
@@ -1,0 +1,3 @@
+<?php
+http_response_code(404);
+exit;

--- a/htdocs/xoops_data/logs/index.php
+++ b/htdocs/xoops_data/logs/index.php
@@ -1,3 +1,22 @@
 <?php
+/**
+ * XOOPS log directory guard
+ *
+ * You may not change or alter any portion of this comment or credits
+ * of supporting developers from this source code or any supporting source code
+ * which is considered copyrighted (c) material of the original comment or credit authors.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @copyright       (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license             GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @package             core
+ * @since               2.7.3
+ */
+
+// Prevents a directory listing only. It does NOT protect named files -- see the
+// .htaccess beside it, and the server-level rules documented in
+// xoops_data/data/debug.dist.php.
 http_response_code(404);
 exit;

--- a/tests/unit/htdocs/class/logger/XoopsFileLoggerTest.php
+++ b/tests/unit/htdocs/class/logger/XoopsFileLoggerTest.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace xoopslogger;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use XoopsFileLogger;
+
+/**
+ * Tests for XoopsFileLogger.
+ *
+ * The emphasis is on the properties that make a log file safe to have, because every one
+ * of them was a real defect at some point during review: a filename that could be made
+ * PHP-executable, a guard that failed open, a URI rebuild that reinstated raw newlines,
+ * and session data reaching the file.
+ *
+ * Note that the test bootstrap places XOOPS_VAR_PATH *inside* XOOPS_ROOT_PATH, so the log
+ * directory is "web accessible" as far as the logger is concerned. That is deliberate here:
+ * it exercises the fail-closed path, and every test that wants a write must opt in with
+ * allow_web_accessible_log.
+ */
+#[CoversClass(XoopsFileLogger::class)]
+class XoopsFileLoggerTest extends TestCase
+{
+    private string $logDir;
+
+    protected function setUp(): void
+    {
+        require_once XOOPS_ROOT_PATH . '/class/logger/filelogger.php';
+        $this->logDir = XOOPS_VAR_PATH . '/logs';
+        if (!is_dir($this->logDir)) {
+            mkdir($this->logDir, 0775, true);
+        }
+        $this->cleanUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUp();
+    }
+
+    /** Remove only the files these tests create. */
+    private function cleanUp(): void
+    {
+        foreach (glob($this->logDir . '/phpunit*.log*') ?: [] as $file) {
+            @unlink($file);
+        }
+    }
+
+    /** Build a logger that is allowed to write, so behaviour can be observed. */
+    private function makeLogger(array $overrides = []): XoopsFileLogger
+    {
+        return new XoopsFileLogger(array_merge([
+            'file'                     => 'phpunit.log',
+            'channels'                 => ['messages'],
+            'backtrace'                => false,
+            'allow_web_accessible_log' => true,
+        ], $overrides));
+    }
+
+    private function readLog(string $name = 'phpunit.log'): string
+    {
+        $path = $this->logDir . '/' . $name;
+
+        return is_file($path) ? (string) file_get_contents($path) : '';
+    }
+
+    private function property(XoopsFileLogger $logger, string $name): mixed
+    {
+        $property = new ReflectionProperty(XoopsFileLogger::class, $name);
+        $property->setAccessible(true);
+
+        return $property->getValue($logger);
+    }
+
+    // -----------------------------------------------------------------
+    // Filename: nothing PHP-executable, no Windows device stems
+    // -----------------------------------------------------------------
+
+    public static function unsafeFilenameProvider(): array
+    {
+        return [
+            'php extension'      => ['debug.php'],
+            'uppercase php'      => ['shell.PHP'],
+            'phtml'              => ['x.phtml'],
+            'double extension'   => ['debug.log.php'],
+            'traversal'          => ['../../../mainfile.php'],
+            'dotfile'            => ['.htaccess'],
+            'windows nul device' => ['NUL.log'],
+            'windows com port'   => ['COM1.log'],
+            'lowercase device'   => ['nul.log'],
+            'empty'              => [''],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('unsafeFilenameProvider')]
+    public function unsafeFilenamesFallBackToTheDefault(string $candidate): void
+    {
+        $logger = $this->makeLogger(['file' => $candidate]);
+
+        self::assertSame('debug.log', basename((string) $this->property($logger, 'file')));
+    }
+
+    public static function safeFilenameProvider(): array
+    {
+        return [
+            ['debug.log'],
+            ['phpunit.log'],
+            ['my-app_2.log'],
+            ['console.log'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('safeFilenameProvider')]
+    public function plainLogFilenamesAreAccepted(string $candidate): void
+    {
+        $logger = $this->makeLogger(['file' => $candidate]);
+
+        self::assertSame($candidate, basename((string) $this->property($logger, 'file')));
+    }
+
+    // -----------------------------------------------------------------
+    // Fail closed when the log directory is reachable over the web
+    // -----------------------------------------------------------------
+
+    #[Test]
+    public function refusesToWriteWhenTheLogDirectoryIsBelowTheDocumentRoot(): void
+    {
+        // No allow_web_accessible_log, and the bootstrap puts xoops_data under htdocs.
+        $logger = new XoopsFileLogger(['file' => 'phpunit.log', 'channels' => ['messages']]);
+
+        self::assertTrue((bool) $this->property($logger, 'writeFailed'));
+
+        $logger->log('error', 'must not be written', ['channel' => 'messages']);
+        self::assertSame('', $this->readLog());
+    }
+
+    #[Test]
+    public function writesWhenTheRiskIsExplicitlyAccepted(): void
+    {
+        $logger = $this->makeLogger();
+        $logger->log('error', 'written after opt-in', ['channel' => 'messages']);
+
+        self::assertStringContainsString('written after opt-in', $this->readLog());
+    }
+
+    // -----------------------------------------------------------------
+    // Log injection
+    // -----------------------------------------------------------------
+
+    #[Test]
+    public function newlinesInAMessageCannotForgeAnEntry(): void
+    {
+        $logger = $this->makeLogger();
+        $logger->log('error', "first line\n[2026-01-01 00:00:00] messages.ERROR FORGED", ['channel' => 'messages']);
+
+        $body = $this->readLog();
+        self::assertStringNotContainsString("\n[2026-01-01", $body);
+        self::assertStringContainsString('FORGED', $body, 'the text survives, only the newline is neutralised');
+    }
+
+    /**
+     * Call redactSessionId() directly.
+     *
+     * currentUri() short circuits to 'cli' under a CLI SAPI, which is exactly how this
+     * suite runs — asserting on a log entry's uri= field would pass without testing
+     * anything at all.
+     */
+    private function redact(XoopsFileLogger $logger, string $uri): string
+    {
+        $method = new \ReflectionMethod(XoopsFileLogger::class, 'redactSessionId');
+        $method->setAccessible(true);
+
+        return (string) $method->invoke($logger, $uri);
+    }
+
+    #[Test]
+    public function theRebuiltUriIsNotUrlDecoded(): void
+    {
+        $out = $this->redact($this->makeLogger(), '/index.php?PHPSESSID=abcdef0123456789abcdef01&x=%0A%5Bforged%5D');
+
+        // http_build_query() percent-encodes; decoding it again would put a real newline
+        // back and let the request forge a second log line.
+        self::assertStringNotContainsString("\n", $out);
+        self::assertStringNotContainsString('[forged]', $out);
+    }
+
+    #[Test]
+    public function aNewlineInTheUriCannotForgeAnEntry(): void
+    {
+        $_SERVER['REQUEST_URI'] = "/index.php?x=1\n[2026-01-01 00:00:00] messages.ERROR FORGED";
+        $logger                 = $this->makeLogger();
+        $logger->log('warning', 'a message', ['channel' => 'messages']);
+
+        // Whatever currentUri() yields, sanitize() strips control characters, so the entry
+        // is a header plus one body line and nothing more.
+        self::assertSame(2, substr_count($this->readLog(), "\n"));
+    }
+
+    // -----------------------------------------------------------------
+    // Session data must never reach the file
+    // -----------------------------------------------------------------
+
+    #[Test]
+    public function aSessionIdInTheUriIsRedacted(): void
+    {
+        $out = $this->redact($this->makeLogger(), '/index.php?PHPSESSID=abcdef0123456789abcdef01');
+
+        self::assertStringNotContainsString('abcdef0123456789', $out);
+        self::assertStringContainsString('redacted', $out);
+    }
+
+    #[Test]
+    public function aSessionIdIsRedactedEvenWhenTheKeyIsPercentEncoded(): void
+    {
+        // PHP decodes query keys, so this IS a live session id — a literal-name regex
+        // over the raw string walks straight past it.
+        $out = $this->redact($this->makeLogger(), '/index.php?PHP%53ESSID=abcdef0123456789abcdef01');
+
+        self::assertStringNotContainsString('abcdef0123456789', $out);
+    }
+
+    #[Test]
+    public function anUnrelatedQueryStringIsLeftAlone(): void
+    {
+        $out = $this->redact($this->makeLogger(), '/index.php?page=2&sort=name');
+
+        self::assertSame('/index.php?page=2&sort=name', $out);
+    }
+
+    #[Test]
+    public function sessionTableSqlIsNeverRecorded(): void
+    {
+        if (!defined('XOOPS_DB_PREFIX')) {
+            self::markTestSkipped('XOOPS_DB_PREFIX is not defined in this bootstrap');
+        }
+
+        $logger = $this->makeLogger([
+            'channels'                 => ['Queries'],
+            'queries_with_errors_only' => false,
+        ]);
+        $sessionSql = 'INSERT INTO ' . XOOPS_DB_PREFIX . "_session (sess_id, sess_data) VALUES ('a', 'secret')";
+        $logger->log('debug', $sessionSql, ['channel' => 'Queries', 'sql' => $sessionSql]);
+        $logger->log('debug', 'SELECT 1 FROM somewhere_else', ['channel' => 'Queries', 'sql' => 'SELECT 1 FROM somewhere_else']);
+
+        $body = $this->readLog();
+        self::assertStringNotContainsString('sess_data', $body);
+        self::assertStringContainsString('somewhere_else', $body);
+    }
+
+    // -----------------------------------------------------------------
+    // Configuration is clamped, not trusted
+    // -----------------------------------------------------------------
+
+    #[Test]
+    public function absurdRotationSettingsAreClamped(): void
+    {
+        $logger = $this->makeLogger([
+            'max_files'       => 1000000000,
+            'max_size'        => -1,
+            'backtrace_limit' => 99999,
+        ]);
+
+        self::assertLessThanOrEqual(20, (int) $this->property($logger, 'maxFiles'));
+        self::assertGreaterThanOrEqual(65536, (int) $this->property($logger, 'maxSize'));
+        self::assertLessThanOrEqual(50, (int) $this->property($logger, 'backtraceLimit'));
+    }
+
+    #[Test]
+    public function aNonArrayChannelListYieldsNoChannels(): void
+    {
+        $logger = $this->makeLogger(['channels' => 'not-an-array']);
+
+        self::assertSame([], $this->property($logger, 'channels'));
+    }
+
+    #[Test]
+    public function channelNamesMatchRegardlessOfCase(): void
+    {
+        $logger = $this->makeLogger([
+            'channels'                 => ['queries', 'MESSAGES'],
+            'queries_with_errors_only' => false,
+        ]);
+        $logger->log('debug', 'SELECT marker_one', ['channel' => 'Queries', 'sql' => 'SELECT marker_one']);
+        $logger->log('warning', 'marker_two', ['channel' => 'messages']);
+
+        $body = $this->readLog();
+        self::assertStringContainsString('marker_one', $body);
+        self::assertStringContainsString('marker_two', $body);
+    }
+
+    #[Test]
+    public function anUnlistedChannelIsIgnored(): void
+    {
+        $logger = $this->makeLogger(['channels' => ['messages']]);
+        $logger->log('debug', 'block_marker', ['channel' => 'Blocks', 'name' => 'block_marker']);
+
+        self::assertStringNotContainsString('block_marker', $this->readLog());
+    }
+
+    // -----------------------------------------------------------------
+    // Bounds and quiet()
+    // -----------------------------------------------------------------
+
+    #[Test]
+    public function anEnormousMessageIsTruncatedRatherThanWrittenWhole(): void
+    {
+        $logger = $this->makeLogger();
+        $logger->log('error', str_repeat('A', 2 * 1024 * 1024), ['channel' => 'messages']);
+
+        // Far below the 2 MB input: capped by MAX_FIELD, then MAX_ENTRY.
+        self::assertLessThan(131072, strlen($this->readLog()));
+    }
+
+    #[Test]
+    public function quietStopsFurtherWrites(): void
+    {
+        $logger = $this->makeLogger();
+        $logger->log('error', 'before quiet', ['channel' => 'messages']);
+        $sizeBefore = strlen($this->readLog());
+
+        $logger->quiet();
+        $logger->log('error', 'after quiet', ['channel' => 'messages']);
+
+        self::assertSame($sizeBefore, strlen($this->readLog()));
+        self::assertStringNotContainsString('after quiet', $this->readLog());
+    }
+
+    // -----------------------------------------------------------------
+    // Entry shape
+    // -----------------------------------------------------------------
+
+    #[Test]
+    public function anEntryCarriesTheChannelLevelMessageAndContext(): void
+    {
+        $logger = $this->makeLogger();
+        $logger->log('warning', 'the message', ['channel' => 'messages', 'errno' => 2]);
+
+        $body = $this->readLog();
+        self::assertStringContainsString('messages.WARNING', $body);
+        self::assertStringContainsString('the message', $body);
+        self::assertStringContainsString('errno=2', $body);
+        // Under a CLI SAPI — which is how this suite runs — the uri field is 'cli'.
+        self::assertStringContainsString('uri=cli', $body);
+    }
+}

--- a/tests/unit/htdocs/class/logger/XoopsFileLoggerTest.php
+++ b/tests/unit/htdocs/class/logger/XoopsFileLoggerTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use ReflectionProperty;
 use XoopsFileLogger;
 
@@ -29,6 +30,9 @@ class XoopsFileLoggerTest extends TestCase
 {
     private string $logDir;
 
+    /** @var string|null REQUEST_URI as found, so a forged one cannot outlive its test */
+    private ?string $originalRequestUri = null;
+
     protected function setUp(): void
     {
         require_once XOOPS_ROOT_PATH . '/class/logger/filelogger.php';
@@ -36,11 +40,17 @@ class XoopsFileLoggerTest extends TestCase
         if (!is_dir($this->logDir)) {
             mkdir($this->logDir, 0775, true);
         }
+        $this->originalRequestUri = $_SERVER['REQUEST_URI'] ?? null;
         $this->cleanUp();
     }
 
     protected function tearDown(): void
     {
+        if (null === $this->originalRequestUri) {
+            unset($_SERVER['REQUEST_URI']);
+        } else {
+            $_SERVER['REQUEST_URI'] = $this->originalRequestUri;
+        }
         $this->cleanUp();
     }
 
@@ -195,12 +205,24 @@ class XoopsFileLoggerTest extends TestCase
     #[Test]
     public function aNewlineInTheUriCannotForgeAnEntry(): void
     {
-        $_SERVER['REQUEST_URI'] = "/index.php?x=1\n[2026-01-01 00:00:00] messages.ERROR FORGED";
+        $forged                 = "/index.php?x=1\n[2026-01-01 00:00:00] messages.ERROR FORGED";
+        $_SERVER['REQUEST_URI'] = $forged;
         $logger                 = $this->makeLogger();
-        $logger->log('warning', 'a message', ['channel' => 'messages']);
 
-        // Whatever currentUri() yields, sanitize() strips control characters, so the entry
-        // is a header plus one body line and nothing more.
+        // Asserted through sanitize() rather than the finished entry. currentUri() returns
+        // 'cli' under this SAPI, so the URI never reaches the file here and a count of the
+        // entry's newlines would hold even with the control-character strip removed.
+        $sanitize = new ReflectionMethod(XoopsFileLogger::class, 'sanitize');
+        $sanitize->setAccessible(true);
+        $clean = (string) $sanitize->invoke($logger, $forged);
+
+        self::assertStringNotContainsString("\n", $clean, 'a newline would open a second log line');
+        // The payload text is not censored -- it is disarmed. The newline becomes a space,
+        // so the forged header stays inside the line it was injected into.
+        self::assertStringContainsString('/index.php?x=1 [2026-01-01', $clean);
+
+        // The entry itself is still a header plus one body line and nothing more.
+        $logger->log('warning', 'a message', ['channel' => 'messages']);
         self::assertSame(2, substr_count($this->readLog(), "\n"));
     }
 
@@ -253,6 +275,87 @@ class XoopsFileLoggerTest extends TestCase
         $body = $this->readLog();
         self::assertStringNotContainsString('sess_data', $body);
         self::assertStringContainsString('somewhere_else', $body);
+    }
+
+    #[Test]
+    public function aLowercaseQueriesChannelStillSkipsSessionRows(): void
+    {
+        if (!defined('XOOPS_DB_PREFIX')) {
+            self::markTestSkipped('XOOPS_DB_PREFIX is not defined in this bootstrap');
+        }
+
+        // The channel filter has always been case-insensitive, so 'queries' reaches the
+        // guards that follow. When those compared exact-case, a producer spelling the
+        // channel this way walked straight past the session exclusion -- which protects
+        // CSRF token seeds, so it must not depend on how the channel was capitalised.
+        $logger = $this->makeLogger([
+            'channels'                 => ['Queries'],
+            'queries_with_errors_only' => false,
+        ]);
+        $sessionSql = 'INSERT INTO ' . XOOPS_DB_PREFIX . "_session (sess_id, sess_data) VALUES ('a', 'secret')";
+        $logger->log('debug', $sessionSql, ['channel' => 'queries', 'sql' => $sessionSql]);
+        $logger->log('debug', 'SELECT 1 FROM somewhere_else', ['channel' => 'queries', 'sql' => 'SELECT 1 FROM somewhere_else']);
+
+        $body = $this->readLog();
+        self::assertStringNotContainsString('sess_data', $body);
+        self::assertStringContainsString('somewhere_else', $body, 'ordinary SQL must still be recorded');
+    }
+
+    // -----------------------------------------------------------------
+    // Rotation must not destroy what it is shifting
+    // -----------------------------------------------------------------
+
+    #[Test]
+    public function aFailedRotationStopsInsteadOfOverwritingTheNextSlot(): void
+    {
+        // .2 cannot move to .3 because .3 is a non-empty directory. Carrying on would
+        // rename .1 onto .2 and destroy it -- newer data than the rotation the cascade
+        // set out to discard -- so the cascade has to stop at the first failure.
+        $live    = $this->logDir . '/phpunit.log';
+        $blocked = $live . '.3';
+        file_put_contents($live, str_repeat('L', 70000));
+        file_put_contents($live . '.1', 'ROTATION-1');
+        file_put_contents($live . '.2', 'ROTATION-2');
+        if (!is_dir($blocked)) {
+            mkdir($blocked);
+        }
+        file_put_contents($blocked . '/blocker', 'x');
+
+        try {
+            $logger = $this->makeLogger(['max_size' => 65536, 'max_files' => 3]);
+            $rotate = new ReflectionMethod(XoopsFileLogger::class, 'rotateIfNeeded');
+            $rotate->setAccessible(true);
+            $rotate->invoke($logger, 1000);
+
+            $survived = false;
+            foreach (glob($live . '.*') ?: [] as $candidate) {
+                if (is_file($candidate) && file_get_contents($candidate) === 'ROTATION-2') {
+                    $survived = true;
+                }
+            }
+            self::assertTrue($survived, 'the rotation that could not move must not be overwritten');
+            self::assertTrue($this->property($logger, 'writeFailed'), 'a stalled rotation disables the logger');
+        } finally {
+            @unlink($blocked . '/blocker');
+            @rmdir($blocked);
+        }
+    }
+
+    #[Test]
+    public function aHealthyRotationStillShiftsEverythingAlong(): void
+    {
+        $live = $this->logDir . '/phpunit.log';
+        file_put_contents($live, str_repeat('L', 70000));
+        file_put_contents($live . '.1', 'ROTATION-1');
+
+        $logger = $this->makeLogger(['max_size' => 65536, 'max_files' => 3]);
+        $rotate = new ReflectionMethod(XoopsFileLogger::class, 'rotateIfNeeded');
+        $rotate->setAccessible(true);
+        $rotate->invoke($logger, 1000);
+
+        self::assertSame('ROTATION-1', file_get_contents($live . '.2'));
+        self::assertStringStartsWith('LLL', (string) file_get_contents($live . '.1'));
+        self::assertFalse($this->property($logger, 'writeFailed'));
     }
 
     // -----------------------------------------------------------------

--- a/tests/unit/htdocs/class/logger/XoopsFileLoggerTest.php
+++ b/tests/unit/htdocs/class/logger/XoopsFileLoggerTest.php
@@ -358,6 +358,24 @@ class XoopsFileLoggerTest extends TestCase
         self::assertFalse($this->property($logger, 'writeFailed'));
     }
 
+    #[Test]
+    public function aFreshLogFileIsNotWorldReadable(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('POSIX file modes only; Windows reports 0666 regardless');
+        }
+
+        $logger = $this->makeLogger();
+        $logger->log('error', 'first entry', ['channel' => 'messages']);
+
+        clearstatcache(true, $this->logDir . '/phpunit.log');
+
+        // This also pins where the is_file() check that drives the chmod sits: below
+        // rotateIfNeeded(), so a log that was just rotated away counts as new and is
+        // tightened too. Moving it back above would leave that file at the umask default.
+        self::assertSame(0640, fileperms($this->logDir . '/phpunit.log') & 0777);
+    }
+
     // -----------------------------------------------------------------
     // Configuration is clamped, not trusted
     // -----------------------------------------------------------------

--- a/tests/unit/htdocs/class/logger/XoopsFileLoggerTest.php
+++ b/tests/unit/htdocs/class/logger/XoopsFileLoggerTest.php
@@ -370,10 +370,35 @@ class XoopsFileLoggerTest extends TestCase
 
         clearstatcache(true, $this->logDir . '/phpunit.log');
 
-        // This also pins where the is_file() check that drives the chmod sits: below
-        // rotateIfNeeded(), so a log that was just rotated away counts as new and is
-        // tightened too. Moving it back above would leave that file at the umask default.
         self::assertSame(0640, fileperms($this->logDir . '/phpunit.log') & 0777);
+    }
+
+    #[Test]
+    public function aLogFileRecreatedByRotationIsAlsoNotWorldReadable(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            self::markTestSkipped('POSIX file modes only; Windows reports 0666 regardless');
+        }
+
+        // The case the fresh-file test above cannot reach. With no log present, is_file()
+        // is false both before and after rotateIfNeeded(), so that test passes wherever
+        // the $isNew check sits. Here the file exists and is rotated away mid-write, so
+        // only a check made AFTER rotation sees the replacement as new and tightens it.
+        $live = $this->logDir . '/phpunit.log';
+        file_put_contents($live, str_repeat('L', 70000));
+        chmod($live, 0666);
+
+        $logger = $this->makeLogger(['max_size' => 65536, 'max_files' => 3]);
+        $logger->log('error', 'after rotation', ['channel' => 'messages']);
+
+        clearstatcache();
+
+        self::assertFileExists($live . '.1', 'the oversized log should have been rotated away');
+        self::assertStringContainsString('after rotation', (string) file_get_contents($live));
+        // The rotated file keeps the loose mode it was given, which is what shows the
+        // assertion below is reading a genuinely new file rather than the original.
+        self::assertSame(0666, fileperms($live . '.1') & 0777);
+        self::assertSame(0640, fileperms($live) & 0777);
     }
 
     // -----------------------------------------------------------------

--- a/tests/unit/htdocs/class/logger/XoopsLoggerAdditionalTest.php
+++ b/tests/unit/htdocs/class/logger/XoopsLoggerAdditionalTest.php
@@ -660,17 +660,32 @@ class XoopsLoggerAdditionalTest extends TestCase
     }
 
     #[Test]
-    public function addDeprecatedDoesNotDispatchWhenDeactivated(): void
+    public function addDeprecatedDispatchesToLoggersEvenWhenDeactivated(): void
     {
         $collector = new \stdClass();
         $collector->received = [];
         $this->logger->addLogger(new AdditionalLogCollectorMock($collector));
         $this->logger->activated = false;
 
-        $this->logger->addDeprecated('should not dispatch');
+        $this->logger->addDeprecated('still dispatches');
 
-        // addDeprecated wraps dispatch inside the activated check
-        self::assertEmpty($collector->received);
+        // Same contract as addQuery, addBlock, addExtra and handleError, each of which
+        // has its own ...EvenWhenDeactivated test: `activated` gates the IN-MEMORY
+        // collectors that exist only to be rendered into the page, not dispatch to
+        // registered loggers.
+        //
+        // addDeprecated was the one producer that wrapped its dispatch inside that
+        // guard. The previous test asserted that as if it were the contract, but it
+        // only described the implementation -- and the effect was that a logger writing
+        // to a file lost every deprecation whenever in-page rendering was off, which is
+        // the normal production state.
+
+        // Not stored in the deprecated array
+        self::assertCount(0, $this->logger->deprecated);
+        // But still dispatched to loggers
+        self::assertCount(1, $collector->received);
+        self::assertSame('warning', $collector->received[0]['level']);
+        self::assertSame('Deprecated', $collector->received[0]['context']['channel']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Two related additions for 2.7.3, both **opt-in**. While `xoops_data/data/debug.php` does not
exist, XOOPS behaves exactly as before.

1. **A central place to turn debugging on.** `XOOPS_DEBUG` could previously only be set by
   hand-editing `mainfile.php` — a file that also holds the database credentials, differs
   per install, and is never replaced on upgrade. Settings now come from
   `xoops_data/data/debug.php`, following the existing `secure.dist.php` convention.
2. **A rotating file logger.** The in-page debug output is only visible to an administrator,
   on a page that actually renders. When a request dies before output, fails only for
   guests, or misbehaves only under real traffic, there was no record at all.

## Why the file logger earns its place

This came out of debugging www.xoops.org. Four production bugs were found from log files
and three could not have been found any other way — the pages died before the debug bar
could render. What made them findable was capturing notices and warnings, not just errors,
each with a backtrace and the request URI.

`XoopsFileLogger` registers through `XoopsLogger::addLogger()`, the same seat DebugBar
occupies, so it receives every channel — `messages`, `Queries`, `Blocks`, `Extra`,
`Deprecated` — with **no change to any producer**. The only edit to `xoopslogger.php` is
forwarding the existing `$trace` in the dispatch context, plus moving the `Deprecated`
dispatch outside the `activated` guard to match the other producers.

## Safety, because a log file is an attacker's best friend

- **Fails closed when the log directory is web-reachable.** If `xoops_data` sits under the
  document root, logging refuses to run unless `allow_web_accessible_log` is set explicitly.
  The shipped `.htaccess` protects Apache only — on nginx, IIS, or `AllowOverride None` it
  does nothing, and documentation is not a control.
- **Filename restricted to a plain `*.log`.** Content is written verbatim, so a `*.php` log
  would be stored executable code. Windows device stems (`NUL.log`, `COM1.log`) are rejected
  too.
- **Symlinked log file or directory refused**, so a planted link cannot redirect appends onto
  `mainfile.php`.
- **Session data never reaches the file:** session-table SQL is skipped (serialised session
  rows carry CSRF token seeds), and session ids are redacted from decoded query keys — so
  `?PHP%53ESSID=…` is caught, not just the literal spelling.
- **Absolute server paths** reduced to installation-relative form; backtraces render
  file/line/function only, never arguments.
- **Bounded:** size-based rotation, per-field and per-entry caps, non-blocking lock so a
  stalled holder cannot park a worker.

## Performance

In file-only mode `$xoopsLogger->activated` stays **false**. That flag gates the in-memory
collectors that exist purely to be rendered into the page, and nothing renders here —
leaving it true accumulated every statement of every request for a dump that never happens,
which a long import turns into an out-of-memory failure. Dispatch to registered loggers is
independent of it.

The logger attaches immediately after `XoopsLogger` is created, before the database
connection, so early bootstrap failures are captured — those are the ones worth having.

## Testing

Verified on a copy of the xoops.org database, and hardened across two adversarial review
rounds:

| check | result |
|---|---|
| no `debug.php` | front page unchanged, no log, production branch taken |
| default config, `xoops_data` under web root | refuses to log (fail closed) |
| with explicit override | captures with full backtraces, **0** absolute paths |
| `debug.php`, `shell.PHP`, `x.phtml`, `NUL.log`, `../../mainfile.php` | all fall back to `debug.log` |
| `max_files: 1e9`, `max_size: -1` | clamped |
| 16 MB message under a 32 MB limit | survives, no added peak |
| session-table SQL | never written |
| `?PHP%53ESSID=…` | redacted |
| syntactically broken `debug.php` | site still serves 200 |
| all five channels with `activated=false` | all dispatch, collectors stay empty |

## Known and documented, not fixed

A `function` redeclaration or `exit()` inside `debug.php` is not catchable; rotation is not
atomic across concurrent requests; a hardlink or a symlinked *ancestor* directory can still
redirect appends. All are noted in the code. Tracy and Ray are deliberately **not** included
— that is not a dependency core should carry.

## Summary by Sourcery

Introduce a central opt-in debug configuration file and a secure rotating file logger for XOOPS, without changing behaviour when debug config is absent.

New Features:
- Add a central debug configuration loader that reads xoops_data/data/debug.php to control XOOPS_DEBUG, PHP error settings, and database legacy logging.
- Introduce a rotating file logger that records selected XoopsLogger channels to disk with configurable limits and safety checks, including web-access constraints and session/PII safeguards.
- Provide a sample debug.dist.php configuration file to enable and document the new debugging and file logging options.

Enhancements:
- Attach the file logger early in the bootstrap process so failures during initialisation are captured without affecting existing behaviour when debugging is disabled.
- Adjust XoopsLogger to always dispatch deprecated notices to registered loggers and to pass optional backtraces, enabling richer file-based diagnostics.
- Register the file logger in the core autoloader and add protective index/.htaccess files for the logs directory to harden access to generated logs.

Documentation:
- Document debug configuration and logging behaviour via the distributed xoops_data/data/debug.dist.php template file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable file-based debug logging with channel filtering, request context, backtraces, and log rotation.
  * Added opt-in debug configuration for PHP errors, database logging, and diagnostic output.

* **Bug Fixes**
  * Improved protection against sensitive data, session information, unsafe paths, and log injection.
  * Deprecated messages are now forwarded to configured loggers even when in-memory logging is disabled.
  * Error traces are preserved for improved diagnostics.

* **Security**
  * Restricted web access to debug configuration and log files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->