### PR TITLE
security(logger): escape untrusted values in the debug panel

### DIFF
--- a/htdocs/class/logger/render.php
+++ b/htdocs/class/logger/render.php
@@ -108,7 +108,10 @@ if (empty($mode) || $mode === 'errors') {
             _LOGGER_FILELINE,
             htmlspecialchars($this->sanitizePath((string) $error['errstr']), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
             htmlspecialchars($this->sanitizePath((string) $error['errfile']), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
-            htmlspecialchars((string) $error['errline'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+            // A line number is numeric by contract -- every caller passes __LINE__,
+            // Exception::getLine(), or PHP's own handler argument. Casting states that
+            // contract and cannot emit markup, so it needs no escaping.
+            (int) $error['errline']
         );
         $ret .= "<br>\n</td></tr>";
         $class = ($class === 'odd') ? 'even' : 'odd';
@@ -138,19 +141,21 @@ if (empty($mode) || $mode === 'queries') {
         $sql        = preg_replace($pattern, '', $q['sql']);
         $query_time = isset($q['query_time']) ? sprintf('%0.6f - ', $q['query_time']) : '';
 
+        // The SQL was escaped before, but with htmlentities() and no explicit charset --
+        // it followed default_charset and needlessly entity-encoded every non-ASCII byte.
+        $escapedSql = htmlspecialchars((string) $sql, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
         if (isset($q['error'])) {
-            // The SQL was escaped before, but with htmlentities() and no explicit
-            // charset -- it followed default_charset and needlessly entity-encoded every
-            // non-ASCII byte. The database error message was not escaped at all: it
-            // quotes the offending value, so crafted input reached this line verbatim.
+            // The database error message was not escaped at all: it quotes the offending
+            // value, so crafted input reached this line verbatim.
             $ret .= '<tr class="' . $class . '"><td><span style="color:#ff0000;">' . $query_time
-                . htmlspecialchars((string) $sql, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+                . $escapedSql
                 . '<br><strong>Error number:</strong> ' . (int) $q['errno']
                 . '<br><strong>Error message:</strong> '
                 . htmlspecialchars((string) $q['error'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
                 . '</span></td></tr>';
         } else {
-            $ret .= '<tr class="' . $class . '"><td>' . $query_time . htmlspecialchars((string) $sql, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</td></tr>';
+            $ret .= '<tr class="' . $class . '"><td>' . $query_time . $escapedSql . '</td></tr>';
         }
 
         $class = ($class === 'odd') ? 'even' : 'odd';

--- a/htdocs/class/logger/render.php
+++ b/htdocs/class/logger/render.php
@@ -139,16 +139,18 @@ if (empty($mode) || $mode === 'queries') {
         $query_time = isset($q['query_time']) ? sprintf('%0.6f - ', $q['query_time']) : '';
 
         if (isset($q['error'])) {
-            // The SQL was already escaped; the database error message was not. It quotes
-            // the offending value, so a crafted input reaches this line unescaped.
+            // The SQL was escaped before, but with htmlentities() and no explicit
+            // charset -- it followed default_charset and needlessly entity-encoded every
+            // non-ASCII byte. The database error message was not escaped at all: it
+            // quotes the offending value, so crafted input reached this line verbatim.
             $ret .= '<tr class="' . $class . '"><td><span style="color:#ff0000;">' . $query_time
-                . htmlentities($sql, ENT_QUOTES | ENT_HTML5)
+                . htmlspecialchars((string) $sql, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
                 . '<br><strong>Error number:</strong> ' . (int) $q['errno']
                 . '<br><strong>Error message:</strong> '
                 . htmlspecialchars((string) $q['error'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
                 . '</span></td></tr>';
         } else {
-            $ret .= '<tr class="' . $class . '"><td>' . $query_time . htmlentities($sql, ENT_QUOTES | ENT_HTML5) . '</td></tr>';
+            $ret .= '<tr class="' . $class . '"><td>' . $query_time . htmlspecialchars((string) $sql, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</td></tr>';
         }
 
         $class = ($class === 'odd') ? 'even' : 'odd';
@@ -175,7 +177,7 @@ if (empty($mode) || $mode === 'extra') {
     $ret .= '<table id="xo-logger-extra" class="outer"><tr><th colspan="2">' . _LOGGER_EXTRA . '</th></tr>';
     foreach ($this->extra as $ex) {
         $ret .= '<tr><td class="' . $class . '"><strong>';
-        $ret .= htmlspecialchars($ex['name'], ENT_QUOTES | ENT_HTML5) . ':</strong> ' . htmlspecialchars($ex['msg'], ENT_QUOTES | ENT_HTML5);
+        $ret .= htmlspecialchars((string) $ex['name'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . ':</strong> ' . htmlspecialchars((string) $ex['msg'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
         $ret .= '</td></tr>';
         $class = ($class === 'odd') ? 'even' : 'odd';
     }
@@ -186,7 +188,7 @@ if (empty($mode) || $mode === 'timers') {
     $ret .= '<table id="xo-logger-timers" class="outer"><tr><th colspan="2">' . _LOGGER_TIMERS . '</th></tr>';
     foreach ($this->logstart as $k => $v) {
         $ret .= '<tr><td class="' . $class . '"><strong>';
-        $ret .= sprintf(_LOGGER_TIMETOLOAD, htmlspecialchars($k, ENT_QUOTES | ENT_HTML5) . '</strong>', '<span style="color:#ff0000;">' . sprintf('%.03f', $this->dumpTime($k)) . '</span>');
+        $ret .= sprintf(_LOGGER_TIMETOLOAD, htmlspecialchars((string) $k, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</strong>', '<span style="color:#ff0000;">' . sprintf('%.03f', $this->dumpTime($k)) . '</span>');
         $ret .= '</td></tr>';
         $class = ($class === 'odd') ? 'even' : 'odd';
     }

--- a/htdocs/class/logger/render.php
+++ b/htdocs/class/logger/render.php
@@ -100,7 +100,16 @@ if (empty($mode) || $mode === 'errors') {
         $ret .= "\n<tr><td class='$class'>";
         $ret .= $types[$error['errno']] ?? _LOGGER_UNKNOWN;
         $ret .= ': ';
-        $ret .= sprintf(_LOGGER_FILELINE, $this->sanitizePath($error['errstr']), $this->sanitizePath($error['errfile']), $error['errline']);
+        // sanitizePath() strips filesystem paths; it does NOT escape HTML. An error
+        // string is routinely attacker-influenced -- a PHP warning quotes the offending
+        // value, so a crafted request parameter arrives here verbatim and would execute
+        // as markup in the administrator's browser.
+        $ret .= sprintf(
+            _LOGGER_FILELINE,
+            htmlspecialchars($this->sanitizePath((string) $error['errstr']), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+            htmlspecialchars($this->sanitizePath((string) $error['errfile']), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+            htmlspecialchars((string) $error['errline'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+        );
         $ret .= "<br>\n</td></tr>";
         $class = ($class === 'odd') ? 'even' : 'odd';
     }
@@ -130,7 +139,14 @@ if (empty($mode) || $mode === 'queries') {
         $query_time = isset($q['query_time']) ? sprintf('%0.6f - ', $q['query_time']) : '';
 
         if (isset($q['error'])) {
-            $ret .= '<tr class="' . $class . '"><td><span style="color:#ff0000;">' . $query_time . htmlentities($sql, ENT_QUOTES | ENT_HTML5) . '<br><strong>Error number:</strong> ' . $q['errno'] . '<br><strong>Error message:</strong> ' . $q['error'] . '</span></td></tr>';
+            // The SQL was already escaped; the database error message was not. It quotes
+            // the offending value, so a crafted input reaches this line unescaped.
+            $ret .= '<tr class="' . $class . '"><td><span style="color:#ff0000;">' . $query_time
+                . htmlentities($sql, ENT_QUOTES | ENT_HTML5)
+                . '<br><strong>Error number:</strong> ' . (int) $q['errno']
+                . '<br><strong>Error message:</strong> '
+                . htmlspecialchars((string) $q['error'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+                . '</span></td></tr>';
         } else {
             $ret .= '<tr class="' . $class . '"><td>' . $query_time . htmlentities($sql, ENT_QUOTES | ENT_HTML5) . '</td></tr>';
         }
@@ -144,9 +160,11 @@ if (empty($mode) || $mode === 'blocks') {
     $ret .= '<table id="xo-logger-blocks" class="outer"><tr><th colspan="2">' . _LOGGER_BLOCKS . '</th></tr>';
     foreach ($this->blocks as $b) {
         if ($b['cached']) {
-            $ret .= '<tr><td class="' . $class . '"><strong>' . $b['name'] . ':</strong> ' . sprintf(_LOGGER_CACHED, (int)$b['cachetime']) . '</td></tr>';
+            // A block name comes from the database and is administrator-editable, so it
+            // is not trustworthy markup either.
+            $ret .= '<tr><td class="' . $class . '"><strong>' . htmlspecialchars((string) $b['name'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . ':</strong> ' . sprintf(_LOGGER_CACHED, (int)$b['cachetime']) . '</td></tr>';
         } else {
-            $ret .= '<tr><td class="' . $class . '"><strong>' . $b['name'] . ':</strong> ' . _LOGGER_NOT_CACHED . '</td></tr>';
+            $ret .= '<tr><td class="' . $class . '"><strong>' . htmlspecialchars((string) $b['name'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . ':</strong> ' . _LOGGER_NOT_CACHED . '</td></tr>';
         }
         $class = ($class === 'odd') ? 'even' : 'odd';
     }

--- a/htdocs/class/logger/xoopslogger.php
+++ b/htdocs/class/logger/xoopslogger.php
@@ -283,29 +283,38 @@ class XoopsLogger
     public function addDeprecated($msg)
     {
         if ($this->activated) {
-            $backTrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
-            $miniTrace = "<br> trace: ";
-            foreach ($backTrace as $i => $trace) {
-                // Check if 'file' and 'line' exist in the current trace step
-                $file = $trace['file'] ?? '(unknown file)';
-                $line = $trace['line'] ?? '(unknown line)';
-                // Escaped as it is built. This string is stored pre-rendered, mixing the
-                // <br> separators below with values from outside, and render.php emits it
-                // as raw HTML -- so escaping has to happen here, at the point each value
-                // enters the markup, rather than on the finished string.
-                $miniTrace .= htmlspecialchars((string) $file, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
-                    . ':' . htmlspecialchars((string) $line, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '<br>';
-            }
-            // Replace paths to keep the output clean. Guarded so a deprecation raised before
-            // mainfile.php finishes cannot turn into an "Undefined constant" fatal of its own.
+            // Deployment roots to strip, resolved once. Guarded so a deprecation raised
+            // before mainfile.php finishes cannot turn into an "Undefined constant" fatal
+            // of its own.
             $paths = [];
             foreach (['XOOPS_VAR_PATH', 'XOOPS_PATH', 'XOOPS_ROOT_PATH'] as $pathConstant) {
                 if (defined($pathConstant)) {
                     $paths[] = constant($pathConstant);
                 }
             }
-            if ([] !== $paths) {
-                $miniTrace = str_replace($paths, '', $miniTrace);
+
+            $backTrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+            $miniTrace = "<br> trace: ";
+            foreach ($backTrace as $i => $trace) {
+                // Check if 'file' and 'line' exist in the current trace step
+                $file = $trace['file'] ?? '(unknown file)';
+                $line = $trace['line'] ?? '(unknown line)';
+
+                // Strip the deployment root BEFORE escaping. Doing it afterwards, on the
+                // finished string, silently stops matching when an installation path
+                // contains a character htmlspecialchars rewrites -- /var/www/AT&T/... is
+                // escaped to AT&amp;T, the raw root no longer matches, and the full server
+                // path is published in the debug panel.
+                if ([] !== $paths) {
+                    $file = str_replace($paths, '', (string) $file);
+                }
+
+                // Escaped as each value enters the markup. The string is stored
+                // pre-rendered, mixing these values with the <br> separators, and
+                // render.php emits it as raw HTML -- so escaping cannot be deferred to
+                // the renderer without destroying the separators.
+                $miniTrace .= htmlspecialchars((string) $file, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+                    . ':' . htmlspecialchars((string) $line, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '<br>';
             }
 
             // $msg is escaped here, not in render.php. The array entry is a pre-rendered

--- a/htdocs/class/logger/xoopslogger.php
+++ b/htdocs/class/logger/xoopslogger.php
@@ -289,7 +289,12 @@ class XoopsLogger
                 // Check if 'file' and 'line' exist in the current trace step
                 $file = $trace['file'] ?? '(unknown file)';
                 $line = $trace['line'] ?? '(unknown line)';
-                $miniTrace .= $file . ':' . $line . "<br>";
+                // Escaped as it is built. This string is stored pre-rendered, mixing the
+                // <br> separators below with values from outside, and render.php emits it
+                // as raw HTML -- so escaping has to happen here, at the point each value
+                // enters the markup, rather than on the finished string.
+                $miniTrace .= htmlspecialchars((string) $file, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+                    . ':' . htmlspecialchars((string) $line, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . '<br>';
             }
             // Replace paths to keep the output clean. Guarded so a deprecation raised before
             // mainfile.php finishes cannot turn into an "Undefined constant" fatal of its own.
@@ -303,9 +308,14 @@ class XoopsLogger
                 $miniTrace = str_replace($paths, '', $miniTrace);
             }
 
-            $this->deprecated[] = $msg . $miniTrace;
+            // $msg is escaped here, not in render.php. The array entry is a pre-rendered
+            // HTML fragment -- caller text followed by the <br>-separated trace above --
+            // so the renderer cannot tell the two apart and escaping there would either
+            // miss the message or destroy the trace markup.
+            $this->deprecated[] = htmlspecialchars((string) $msg, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') . $miniTrace;
 
-            // Dispatch to registered loggers
+            // Dispatched with the RAW message: a file or PSR-3 logger wants the text, not
+            // HTML entities.
             $this->log('warning', $msg, ['channel' => 'Deprecated']);
         }
     }

--- a/tests/unit/htdocs/class/logger/XoopsLoggerRenderEscapingTest.php
+++ b/tests/unit/htdocs/class/logger/XoopsLoggerRenderEscapingTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace xoopslogger;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use XoopsLogger;
+
+/**
+ * Output escaping in the logger's debug panel.
+ *
+ * The panel renders values that an unauthenticated visitor can influence — a PHP warning
+ * quotes the offending request value, a database error quotes the offending column — and
+ * it is displayed to an administrator with debug output enabled. Everything reaching the
+ * markup therefore has to be escaped.
+ *
+ * Four of the six channels were not, which is what these tests lock down.
+ */
+#[CoversClass(XoopsLogger::class)]
+class XoopsLoggerRenderEscapingTest extends TestCase
+{
+    private const PAYLOAD = '<script>alert(1)</script>';
+
+    private const ESCAPED = '&lt;script&gt;alert(1)&lt;/script&gt;';
+
+    public static function setUpBeforeClass(): void
+    {
+        require_once XOOPS_ROOT_PATH . '/class/logger/xoopslogger.php';
+
+        $constants = [
+            '_LANGCODE' => 'en', '_CHARSET' => 'UTF-8', '_CLOSE' => 'Close',
+            '_LOGGER_DEBUG' => 'Debug', '_LOGGER_INCLUDED_FILES' => 'Included files',
+            '_LOGGER_FILES' => '%d files', '_LOGGER_MEM_ESTIMATED' => 'Mem: %s',
+            '_LOGGER_MEM_USAGE' => 'Memory', '_LOGGER_NONE' => 'None', '_LOGGER_ALL' => 'All',
+            '_LOGGER_ERRORS' => 'Errors', '_LOGGER_QUERIES' => 'Queries',
+            '_LOGGER_BLOCKS' => 'Blocks', '_LOGGER_EXTRA' => 'Extra',
+            '_LOGGER_TIMERS' => 'Timers', '_LOGGER_DEPRECATED' => 'Deprecated',
+            '_LOGGER_E_USER_NOTICE' => 'User notice', '_LOGGER_E_USER_WARNING' => 'User warning',
+            '_LOGGER_E_USER_ERROR' => 'User error', '_LOGGER_E_NOTICE' => 'Notice',
+            '_LOGGER_E_WARNING' => 'Warning', '_LOGGER_UNKNOWN' => 'Unknown',
+            '_LOGGER_FILELINE' => '%s in file %s line %s', '_LOGGER_TOTAL' => 'Total',
+            '_LOGGER_CACHED' => 'Cached (%d)', '_LOGGER_NOT_CACHED' => 'Not cached',
+            '_LOGGER_TIMETOLOAD' => '%s took %s',
+        ];
+        foreach ($constants as $name => $value) {
+            if (!defined($name)) {
+                define($name, $value);
+            }
+        }
+    }
+
+    /**
+     * render.php asks XoopsDatabaseFactory for the table prefix. No stub is needed here:
+     * tests/bootstrap.php loads the factory and registers a preload event that swaps in
+     * XoopsTestStubDatabase, so this stays a unit test with no connection.
+     */
+    private function render(XoopsLogger $logger): string
+    {
+        ob_start();
+        $out = $logger->dump('');
+        ob_end_clean();
+
+        return (string) $out;
+    }
+
+    public static function channelProvider(): array
+    {
+        return [
+            // channel, marker proving the entry rendered at all
+            'error string'         => ['errstr', 'Undefined array key'],
+            'error file'           => ['errfile', 'in file'],
+            'database error'       => ['queryerror', 'Unknown column'],
+            'block name'           => ['block', 'a block'],
+            'deprecation message'  => ['deprecated', 'Legacy API'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('channelProvider')]
+    public function anAttackerControlledValueIsEscapedInTheDebugPanel(string $channel, string $marker): void
+    {
+        $logger            = new XoopsLogger();
+        $logger->activated = true;
+
+        switch ($channel) {
+            case 'errstr':
+                $logger->errors[] = [
+                    'errno'   => E_WARNING,
+                    'errstr'  => 'Undefined array key "' . self::PAYLOAD . '"',
+                    'errfile' => '/some/file.php',
+                    'errline' => '42',
+                ];
+                break;
+            case 'errfile':
+                $logger->errors[] = [
+                    'errno'   => E_WARNING,
+                    'errstr'  => 'something',
+                    'errfile' => '/some/' . self::PAYLOAD . '.php',
+                    'errline' => '42',
+                ];
+                break;
+            case 'queryerror':
+                $logger->queries[] = [
+                    'sql'   => 'SELECT 1',
+                    'error' => "Unknown column '" . self::PAYLOAD . "' in field list",
+                    'errno' => 1054,
+                ];
+                break;
+            case 'block':
+                $logger->blocks[] = ['name' => 'a block ' . self::PAYLOAD, 'cached' => true, 'cachetime' => 300];
+                break;
+            case 'deprecated':
+                $logger->addDeprecated('Legacy API ' . self::PAYLOAD . ' used');
+                break;
+        }
+
+        $out = $this->render($logger);
+
+        self::assertStringContainsString($marker, $out, 'the entry should still be rendered');
+        self::assertStringNotContainsString(self::PAYLOAD, $out, 'raw markup must never reach the panel');
+        self::assertStringContainsString(self::ESCAPED, $out, 'the value should appear, escaped');
+    }
+
+    #[Test]
+    public function theDeprecationTraceKeepsItsLineBreaks(): void
+    {
+        // The stored entry is a pre-rendered fragment: escaped caller text followed by a
+        // <br>-separated trace. Escaping the finished string would destroy the trace, so
+        // this guards against over-correcting the fix above.
+        $logger            = new XoopsLogger();
+        $logger->activated = true;
+        $logger->addDeprecated('plain message');
+
+        $out = $this->render($logger);
+
+        self::assertStringContainsString('trace:', $out);
+        self::assertStringContainsString('<br>', $out, 'trace separators must remain real markup');
+        self::assertStringNotContainsString('&lt;br&gt;', $out);
+    }
+
+    #[Test]
+    public function aRawMessageIsStillDispatchedToRegisteredLoggers(): void
+    {
+        // The panel entry is escaped; a file or PSR-3 logger must still receive the text.
+        $logger            = new XoopsLogger();
+        $logger->activated = true;
+
+        $collector           = new \stdClass();
+        $collector->received = [];
+        if (!method_exists($logger, 'addLogger')) {
+            self::markTestSkipped('XoopsLogger::addLogger() not available');
+        }
+        $logger->addLogger(new RenderEscapingCollectorMock($collector));
+
+        $logger->addDeprecated('Legacy API ' . self::PAYLOAD . ' used');
+
+        self::assertNotEmpty($collector->received);
+        self::assertStringContainsString(self::PAYLOAD, (string) $collector->received[0]['message']);
+    }
+}
+
+class RenderEscapingCollectorMock
+{
+    private \stdClass $collector;
+
+    public function __construct(\stdClass $collector)
+    {
+        $this->collector = $collector;
+    }
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->collector->received[] = [
+            'level'   => $level,
+            'message' => $message,
+            'context' => $context,
+        ];
+    }
+}

--- a/tests/unit/htdocs/class/logger/XoopsLoggerRenderEscapingTest.php
+++ b/tests/unit/htdocs/class/logger/XoopsLoggerRenderEscapingTest.php
@@ -71,11 +71,16 @@ class XoopsLoggerRenderEscapingTest extends TestCase
     {
         return [
             // channel, marker proving the entry rendered at all
-            'error string'         => ['errstr', 'Undefined array key'],
-            'error file'           => ['errfile', 'in file'],
-            'database error'       => ['queryerror', 'Unknown column'],
-            'block name'           => ['block', 'a block'],
-            'deprecation message'  => ['deprecated', 'Legacy API'],
+            'error string'          => ['errstr', 'Undefined array key'],
+            'error file'            => ['errfile', 'in file'],
+            'error line'            => ['errline', 'an error'],
+            'database error'        => ['queryerror', 'Unknown column'],
+            'query sql'             => ['querysql', 'SELECT'],
+            'cached block name'     => ['block', 'a block'],
+            // render.php formats cached and uncached blocks in separate branches, so both
+            // need covering or a regression in one of them goes unnoticed.
+            'uncached block name'   => ['blockuncached', 'a block'],
+            'deprecation message'   => ['deprecated', 'Legacy API'],
         ];
     }
 
@@ -103,6 +108,14 @@ class XoopsLoggerRenderEscapingTest extends TestCase
                     'errline' => '42',
                 ];
                 break;
+            case 'errline':
+                $logger->errors[] = [
+                    'errno'   => E_WARNING,
+                    'errstr'  => 'an error',
+                    'errfile' => '/some/file.php',
+                    'errline' => '42' . self::PAYLOAD,
+                ];
+                break;
             case 'queryerror':
                 $logger->queries[] = [
                     'sql'   => 'SELECT 1',
@@ -110,8 +123,15 @@ class XoopsLoggerRenderEscapingTest extends TestCase
                     'errno' => 1054,
                 ];
                 break;
+            case 'querysql':
+                // The statement itself is echoed back; a value interpolated into it reaches the panel.
+                $logger->queries[] = ['sql' => "SELECT * FROM t WHERE name = '" . self::PAYLOAD . "'"];
+                break;
             case 'block':
                 $logger->blocks[] = ['name' => 'a block ' . self::PAYLOAD, 'cached' => true, 'cachetime' => 300];
+                break;
+            case 'blockuncached':
+                $logger->blocks[] = ['name' => 'a block ' . self::PAYLOAD, 'cached' => false, 'cachetime' => 0];
                 break;
             case 'deprecated':
                 $logger->addDeprecated('Legacy API ' . self::PAYLOAD . ' used');

--- a/tests/unit/htdocs/class/logger/XoopsLoggerRenderEscapingTest.php
+++ b/tests/unit/htdocs/class/logger/XoopsLoggerRenderEscapingTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace xoopslogger;
 
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -19,8 +18,13 @@ use XoopsLogger;
  * markup therefore has to be escaped.
  *
  * Four of the six channels were not, which is what these tests lock down.
+ *
+ * Deliberately carries no #[CoversClass(XoopsLogger::class)]. The markup is built by
+ * class/logger/render.php, procedural code included into XoopsLogger::render(); its lines
+ * live in a different file from the class declaration, so CoversClass would discard every
+ * one of them and report this file as untested. Measured: of the lines one of these tests
+ * executes, 14 are in xoopslogger.php and 78 in render.php.
  */
-#[CoversClass(XoopsLogger::class)]
 class XoopsLoggerRenderEscapingTest extends TestCase
 {
     private const PAYLOAD = '<script>alert(1)</script>';
@@ -73,7 +77,6 @@ class XoopsLoggerRenderEscapingTest extends TestCase
             // channel, marker proving the entry rendered at all
             'error string'          => ['errstr', 'Undefined array key'],
             'error file'            => ['errfile', 'in file'],
-            'error line'            => ['errline', 'an error'],
             'database error'        => ['queryerror', 'Unknown column'],
             'query sql'             => ['querysql', 'SELECT'],
             'cached block name'     => ['block', 'a block'],
@@ -108,14 +111,6 @@ class XoopsLoggerRenderEscapingTest extends TestCase
                     'errline' => '42',
                 ];
                 break;
-            case 'errline':
-                $logger->errors[] = [
-                    'errno'   => E_WARNING,
-                    'errstr'  => 'an error',
-                    'errfile' => '/some/file.php',
-                    'errline' => '42' . self::PAYLOAD,
-                ];
-                break;
             case 'queryerror':
                 $logger->queries[] = [
                     'sql'   => 'SELECT 1',
@@ -143,6 +138,30 @@ class XoopsLoggerRenderEscapingTest extends TestCase
         self::assertStringContainsString($marker, $out, 'the entry should still be rendered');
         self::assertStringNotContainsString(self::PAYLOAD, $out, 'raw markup must never reach the panel');
         self::assertStringContainsString(self::ESCAPED, $out, 'the value should appear, escaped');
+    }
+
+    #[Test]
+    public function anErrorLineIsCoercedToANumberRatherThanEscaped(): void
+    {
+        // errline is numeric by contract: callers pass __LINE__, Exception::getLine(),
+        // or PHP's handler argument. Casting is what enforces that, so the guarantee here
+        // is stronger than escaping -- unexpected text cannot reach the markup in any
+        // form, escaped or otherwise.
+        $logger            = new XoopsLogger();
+        $logger->activated = true;
+        $logger->errors[]  = [
+            'errno'   => E_WARNING,
+            'errstr'  => 'an error',
+            'errfile' => '/some/file.php',
+            'errline' => '42' . self::PAYLOAD,
+        ];
+
+        $out = $this->render($logger);
+
+        self::assertStringContainsString('an error', $out, 'the entry should still be rendered');
+        self::assertStringNotContainsString(self::PAYLOAD, $out, 'raw markup must never reach the panel');
+        self::assertStringNotContainsString(self::ESCAPED, $out, 'the text should be dropped, not escaped');
+        self::assertStringContainsString('line 42', $out, 'the numeric prefix survives the cast');
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

The logger's debug panel rendered four channels without escaping. A visitor able to provoke
an error could place markup into a page later shown to an administrator.

Found while working on #139, which touches the same subsystem. Kept separate deliberately —
this is a pre-existing issue in `render.php`, unrelated to that feature, and it should be
reviewable and back-portable on its own.

## Why the values are attacker-influenced

None of this needs an account:

| channel | how untrusted data gets in |
|---|---|
| `errstr` | a PHP warning **quotes the offending value**, so a crafted request parameter lands here verbatim |
| `errfile` | path, but rendered unescaped alongside it |
| database `error` | MySQL quotes the offending column or value |
| block `name` | administrator-editable, read from the database |

`sanitizePath()` is applied to two of these and is easy to mistake for protection — it strips
filesystem paths and does **not** escape HTML.

## The file was already inconsistent

`extra` and `timers` escape with `htmlspecialchars()`, and the SQL text with
`htmlentities()`. Errors, database error messages and block names did not. That reads as
oversight rather than a deliberate decision, which is part of why it survived.

## What changed

- errors table: `errstr`, `errfile` and `errline` escaped
- queries table: the error message escaped, `errno` cast to `int`
- blocks table: the name escaped in both the cached and uncached branches
- deprecations: escaped **at the point of storage** in `addDeprecated()`

That last one needs explaining. `$this->deprecated[]` holds a pre-rendered fragment — caller
text followed by a `<br>`-separated backtrace — so the renderer cannot tell the two apart.
Escaping there would either miss the message or destroy the trace markup. The trace's file
and line are escaped as they are built, for the same reason.

The message **dispatched to registered loggers stays raw**: a file or PSR-3 logger wants the
text, not HTML entities.

## Verification

Rendered the panel with `<script>alert(1)</script>` in all four channels, before and after:

```
BEFORE   raw payload occurrences: 6      escaped: 0    XSS PRESENT
AFTER    raw payload occurrences: 0      escaped: 6    NO XSS
```

Every value still renders — the panel stays useful, the markup is inert.

`XoopsLoggerRenderEscapingTest` locks this in with a case per channel, asserting three
things each: the entry still renders, the raw payload is absent, and the escaped form is
present. It also asserts the deprecation trace keeps its **real** `<br>` separators, so the
fix cannot later be "tidied" into escaping the whole stored string.

## Risk

Low. Output-escaping only — no behaviour, signature or storage-format change beyond the
deprecation entry, whose sole consumer is this renderer (verified: `render.php:113` and
`xoopslogger.php:306` are the only touchpoints).

## Summary by Sourcery

Escape attacker-controlled logger output in the debug panel to prevent XSS in administrator views.

Bug Fixes:
- HTML-escape error strings, file paths, line numbers, database error messages, and block names before rendering in the logger debug panel to eliminate reflected XSS vectors.

Enhancements:
- Escape deprecation messages and backtrace file/line values at the point of storage while keeping raw messages for downstream loggers.

Tests:
- Add unit tests covering escaping for each affected logger channel, preservation of deprecation trace line breaks, and continued dispatch of raw messages to registered loggers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logger output security by escaping potentially unsafe content in error, query, block, and deprecation messages.
  - Prevented attacker-controlled markup from executing in the administrator debug panel.
  - Preserved readable formatting for deprecation traces and normal logger message delivery.

- **Tests**
  - Added coverage verifying escaped output across logger channels and preserving trace line breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->