### PR TITLE
fix(database): return the documented failure value for a non-result argument

### DIFF
--- a/docs/changelog.270.txt
+++ b/docs/changelog.270.txt
@@ -9,7 +9,11 @@ Debugging and logging:
 - keep the log out of reach: the filename is restricted to a plain .log name, a log resolving below the document root is refused, the file is created 0640, and directory guards ship alongside it (mamba) in #139
 - redact what reaches the file: server paths, session ids, and the session table's own rows, so a debug log cannot become a source of live CSRF token seeds or a hijacking primitive (mamba) in #139
 - strip control characters from every untrusted value written, so a crafted URI or SQL fragment cannot forge additional log lines (mamba) in #139
-- note for upgrades: mainfile.php is not replaced by an upgrade, so an existing site picks this up only once its mainfile.php is updated from the new dist; fresh installs get it automatically (mamba) in #139
+- note for upgrades: file logging needs no change to mainfile.php, because include/common.php reads debug.php itself. Updating mainfile.php from the new dist adds two further things: the XOOPS_DEBUG and XOOPS_DB_LEGACY_LOG constants, and error reporting raised earlier than common.php runs, which matters only for failures during bootstrap (mamba) in #139
+- note on visibility: display_errors from debug.php is applied at include/common.php, while the debugLevel setting in xoops_data/configs/xoopsconfig.php clamps error_reporting to 0 for non-admins later in the same file, after authentication. Errors raised before that point — the database connection, config loading, preloads — are therefore still displayed to any visitor. Set display_errors to false on a public site and read the log instead; it records the same bootstrap window (mamba) in #139
+
+Database:
+- return the documented failure value instead of fataling when a result-set method is handed something that is not one. A failed query returns false and a mis-wired caller can pass the SQL string itself; PHP 8 turns both into an uncaught TypeError inside mysqli, so one bad call from one module blanked the whole page. Observed on xoops.org from modules/core/brokenfile.php. The misuse is still reported, so the caller's bug stays visible (mamba)
 
 Security:
 - escape the untrusted values rendered in the logger's debug panel; a PHP warning quotes the offending request value and a database error quotes the offending column, so crafted input reached the administrator's browser as live markup through the error, query, block and deprecation channels (mamba) in #140

--- a/htdocs/class/database/mysqldatabase.php
+++ b/htdocs/class/database/mysqldatabase.php
@@ -98,6 +98,39 @@ abstract class XoopsMySQLDatabase extends XoopsDatabase
     }
 
     /**
+     * Report a call that handed us something other than a result set.
+     *
+     * The methods below receive whatever the caller got back from query(). On a failed
+     * query that is false, and a mis-wired caller can pass the SQL string itself. PHP 8
+     * turns both into an uncaught TypeError inside mysqli, so one bad call from one
+     * module takes the whole page down with a blank screen -- which is how this surfaced
+     * on xoops.org, from modules/core/brokenfile.php passing a string to getRowsNum().
+     *
+     * The '@' on the mysqli calls never covered that: it suppresses diagnostics, not
+     * thrown errors. Each caller now returns the failure value it already documents,
+     * which keeps the page alive and hands the caller the answer it is written to expect.
+     *
+     * Reported rather than swallowed, through the same channel this class already uses
+     * for caller misuse, so the module bug stays visible instead of quietly becoming an
+     * empty result.
+     *
+     * @param  string $method calling method
+     * @param  mixed  $result the value handed to us
+     *
+     * @return void
+     */
+    protected function reportInvalidResult($method, $result)
+    {
+        $given   = is_object($result) ? get_class($result) : gettype($result);
+        $message = $method . '() expects a mysqli_result, ' . $given . ' given';
+
+        if (is_object($this->logger)) {
+            $this->logger->addExtra('DB', $message);
+        }
+        trigger_error($message, E_USER_WARNING);
+    }
+
+    /**
      * Get a result row as an enumerated array
      *
      * @param \mysqli_result $result
@@ -106,6 +139,10 @@ abstract class XoopsMySQLDatabase extends XoopsDatabase
      */
     public function fetchRow($result)
     {
+        if (!$this->isResultSet($result)) {
+            $this->reportInvalidResult(__FUNCTION__, $result);
+            return false;
+        }
         $row = @mysqli_fetch_row($result);
         return $row ?? false;
     }
@@ -119,6 +156,10 @@ abstract class XoopsMySQLDatabase extends XoopsDatabase
      */
     public function fetchArray($result)
     {
+        if (!$this->isResultSet($result)) {
+            $this->reportInvalidResult(__FUNCTION__, $result);
+            return false;
+        }
         $row = @mysqli_fetch_assoc($result);
         return $row ?? false;
 
@@ -133,6 +174,10 @@ abstract class XoopsMySQLDatabase extends XoopsDatabase
      */
     public function fetchBoth($result)
     {
+        if (!$this->isResultSet($result)) {
+            $this->reportInvalidResult(__FUNCTION__, $result);
+            return false;
+        }
         $row = @mysqli_fetch_array($result, MYSQLI_BOTH);
         return $row ?? false;
     }
@@ -145,6 +190,10 @@ abstract class XoopsMySQLDatabase extends XoopsDatabase
      */
     public function fetchObject($result)
     {
+        if (!$this->isResultSet($result)) {
+            $this->reportInvalidResult(__FUNCTION__, $result);
+            return false;
+        }
         $row = @mysqli_fetch_object($result);
         return $row ?? false;
     }
@@ -168,6 +217,10 @@ abstract class XoopsMySQLDatabase extends XoopsDatabase
      */
     public function getRowsNum($result)
     {
+        if (!$this->isResultSet($result)) {
+            $this->reportInvalidResult(__FUNCTION__, $result);
+            return 0;
+        }
         return (int)@mysqli_num_rows($result);
     }
 
@@ -200,6 +253,11 @@ abstract class XoopsMySQLDatabase extends XoopsDatabase
      */
     public function freeRecordSet($result)
     {
+        if (!$this->isResultSet($result)) {
+            $this->reportInvalidResult(__FUNCTION__, $result);
+
+            return;
+        }
         mysqli_free_result($result);
     }
 
@@ -397,6 +455,10 @@ abstract class XoopsMySQLDatabase extends XoopsDatabase
      */
     public function getFieldName($result, $offset)
     {
+        if (!$this->isResultSet($result)) {
+            $this->reportInvalidResult(__FUNCTION__, $result);
+            return '';
+        }
         return $result->fetch_field_direct($offset)->name;
     }
 
@@ -410,6 +472,10 @@ abstract class XoopsMySQLDatabase extends XoopsDatabase
      */
     public function getFieldType($result, $offset)
     {
+        if (!$this->isResultSet($result)) {
+            $this->reportInvalidResult(__FUNCTION__, $result);
+            return '';
+        }
         $typecode = $result->fetch_field_direct($offset)->type;
         switch ($typecode) {
             case MYSQLI_TYPE_DECIMAL:
@@ -507,6 +573,10 @@ abstract class XoopsMySQLDatabase extends XoopsDatabase
      */
     public function getFieldsNum($result)
     {
+        if (!$this->isResultSet($result)) {
+            $this->reportInvalidResult(__FUNCTION__, $result);
+            return 0;
+        }
         return mysqli_num_fields($result);
     }
 


### PR DESCRIPTION
## Summary

Stops a single module's bad call from blanking an entire page, and corrects a factual error in the 2.7.3 release notes.

## Motivation

The result-set methods in `XoopsMySQLDatabase` pass their argument straight to mysqli. Two things reach them in practice:

- a **failed query**, which returns `false`
- a **mis-wired caller** passing the SQL string itself

PHP 8 turns both into an uncaught `TypeError` *inside* mysqli, so one bad call takes the whole request down. The `@` on those calls never helped — it suppresses diagnostics, not thrown errors.

Observed on xoops.org: `modules/core/brokenfile.php` reached `getRowsNum()` with a string.

```
TypeError: mysqli_num_rows(): Argument #1 ($result) must be of type mysqli_result, string given
File: /class/database/mysqldatabase.php  Line: 171
  /modules/core/brokenfile.php:103
```

## Approach

Each method returns the failure value **it already documents** — `false` for the fetch family, `0` for the counts, `''` for field names. That is what these return at end of data or on error anyway, so every caller is already written to handle it.

The check reuses the **existing public `isResultSet()`**; only the reporting is new. Misuse goes through `addExtra()` plus `E_USER_WARNING` — the same channel this class already uses when a caller misuses `query()`/`exec()` — so the module's bug stays visible rather than quietly becoming an empty result.

## Also: a correction to the 2.7.3 notes

The notes claimed a site picks up the new logging *"only once its mainfile.php is updated from the new dist."* **That was wrong** — `include/common.php` reads `debug.php` itself, so file logging needs no `mainfile.php` change. Updating `mainfile.php` adds the `XOOPS_DEBUG` / `XOOPS_DB_LEGACY_LOG` constants and raises reporting earlier than `common.php` runs.

A visibility note is added beside it: `debugLevel` clamps `error_reporting` to 0 for non-admins, but *after* authentication, while `display_errors` is applied much earlier — so bootstrap-time errors are still shown to any visitor.

## Testing

All nine guarded methods exercised against both production shapes (`false` and a SQL string), using the real base classes and the real `XoopsLogger`: **18/18** return the documented value rather than throwing, with 18 logger entries and 18 warnings raised.

## Summary by Sourcery

Guard MySQL result-set helper methods against invalid arguments to avoid PHP 8 type errors and ensure they return their documented failure values, and correct related release notes documentation.

Bug Fixes:
- Prevent PHP 8 TypeError crashes in MySQL result-set helper methods when they are called with non-result arguments by returning the documented failure values instead.

Enhancements:
- Add centralized reporting for invalid MySQL result-set arguments via logger extras and user warnings to keep module misuse visible without breaking the page.

Documentation:
- Correct the 2.7.3 changelog description of when database logging takes effect and clarify the interaction between debug level, error reporting, and display_errors visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database result operations now handle invalid inputs safely, returning documented fallback values instead of causing PHP errors or blank pages.
  * Invalid database usage now generates a warning and includes additional diagnostic logging when available.
  * Improved handling of early bootstrap errors and file-based debugging settings.

* **Documentation**
  * Updated upgrade guidance and clarified debugging, logging, and error-display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->