### PR TITLE
fix(core): stop the login redirect accumulating escaped ampersands

### DIFF
--- a/htdocs/include/file_safety.php
+++ b/htdocs/include/file_safety.php
@@ -216,6 +216,37 @@ if (!function_exists('xoops_remove_file_quietly')) {
     }
 }
 
+if (!function_exists('xoops_normalizeUrlSeparators')) {
+    /**
+     * Collapse escaped-ampersand layers in a URL back to a single separator.
+     *
+     * A URL is not HTML, so "&amp;" in a query string is already wrong: to anything that
+     * parses the URL rather than renders it, the following parameter is named
+     * "amp;name". It went unnoticed because a browser decodes the entity before
+     * requesting, which hides the fault for exactly one hop.
+     *
+     * It stops hiding once a semicolon has been percent-encoded somewhere along the
+     * chain. "&amp%3B" is not a complete entity, so the browser can no longer collapse
+     * it, and every later escape adds another layer. xoops.org was logging
+     *
+     *     ?start=0&amp%3Bamp%3Bamp%3Bforum=0
+     *
+     * for a URL that should read "?start=0&forum=0" -- three rounds of escaping deep and
+     * growing by one on each pass through the login redirect.
+     *
+     * Both spellings are collapsed, so a URI that already carries the damage is healed
+     * rather than carried forward. A parameter genuinely named "amp" is untouched: the
+     * pattern matches only "amp;" or "amp%3B" directly following an ampersand.
+     *
+     * @param string $url candidate URL
+     * @return string the URL with "&amp;" / "&amp%3B" runs reduced to "&"
+     */
+    function xoops_normalizeUrlSeparators($url)
+    {
+        return (string) preg_replace('/&(?:amp;|amp%3B)+/i', '&', (string) $url);
+    }
+}
+
 if (!function_exists('xoops_isLocalUrl')) {
     /**
      * Decide whether an absolute or scheme-relative URL points at this site.
@@ -230,6 +261,30 @@ if (!function_exists('xoops_isLocalUrl')) {
      *
      * @param string $url candidate URL
      * @return bool true when the target is same-origin or a root-relative path
+     */
+    /**
+     * Collapse escaped-ampersand layers in a URL back to a single separator.
+     *
+     * A URL is not HTML, so "&amp;" in a query string is already wrong: it names the
+     * following parameter "amp;name" to anything that parses the URL rather than renders
+     * it. It went unnoticed because a browser decodes the entity before requesting, which
+     * hides the fault for exactly one hop.
+     *
+     * It stops hiding once a semicolon has been percent-encoded somewhere along the chain.
+     * "&amp%3B" is not a complete entity, so the browser can no longer collapse it, and
+     * every later escape adds another layer. xoops.org was logging
+     *
+     *     ?start=0&amp%3Bamp%3Bamp%3Bforum=0
+     *
+     * for a URL that should read "?start=0&forum=0" -- three rounds of escaping deep, and
+     * growing by one on every pass through the login redirect.
+     *
+     * Both spellings are collapsed, so a URI that already carries the damage is healed
+     * rather than carried forward. A parameter genuinely named "amp" is untouched: the
+     * pattern only matches "amp;" or "amp%3B" immediately following an ampersand.
+     *
+     * @param string $url candidate URL
+     * @return string the URL with "&amp;"/"&amp%3B" runs reduced to "&"
      */
     function xoops_isLocalUrl($url)
     {

--- a/htdocs/include/file_safety.php
+++ b/htdocs/include/file_safety.php
@@ -262,30 +262,6 @@ if (!function_exists('xoops_isLocalUrl')) {
      * @param string $url candidate URL
      * @return bool true when the target is same-origin or a root-relative path
      */
-    /**
-     * Collapse escaped-ampersand layers in a URL back to a single separator.
-     *
-     * A URL is not HTML, so "&amp;" in a query string is already wrong: it names the
-     * following parameter "amp;name" to anything that parses the URL rather than renders
-     * it. It went unnoticed because a browser decodes the entity before requesting, which
-     * hides the fault for exactly one hop.
-     *
-     * It stops hiding once a semicolon has been percent-encoded somewhere along the chain.
-     * "&amp%3B" is not a complete entity, so the browser can no longer collapse it, and
-     * every later escape adds another layer. xoops.org was logging
-     *
-     *     ?start=0&amp%3Bamp%3Bamp%3Bforum=0
-     *
-     * for a URL that should read "?start=0&forum=0" -- three rounds of escaping deep, and
-     * growing by one on every pass through the login redirect.
-     *
-     * Both spellings are collapsed, so a URI that already carries the damage is healed
-     * rather than carried forward. A parameter genuinely named "amp" is untouched: the
-     * pattern only matches "amp;" or "amp%3B" immediately following an ampersand.
-     *
-     * @param string $url candidate URL
-     * @return string the URL with "&amp;"/"&amp%3B" runs reduced to "&"
-     */
     function xoops_isLocalUrl($url)
     {
         $decoded = html_entity_decode((string) $url, ENT_QUOTES | ENT_HTML5, 'UTF-8');

--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -860,10 +860,24 @@ function redirect_header($url, $time = 3, $message = '', $addredirect = true, $a
         $xoopsTpl->assign('time', (int) $time);
     }
     if (!empty($_SERVER['REQUEST_URI']) && $addredirect && false !== strpos($url, 'user.php')) {
+        // Heal any escaped-ampersand layers the incoming URI already carries, rather than
+        // folding them into the next hop's redirect and passing the damage along. See
+        // xoops_normalizeUrlSeparators() for how the layers accumulate.
+        //
+        // Required here rather than relied upon: the include above runs only when
+        // $allowExternalLink is false, so on the other path the helper would be missing
+        // and the normalisation would silently not happen.
+        require_once __DIR__ . '/file_safety.php';
+        $requestUri = xoops_normalizeUrlSeparators($_SERVER['REQUEST_URI']);
+
         if (false === strpos($url, '?')) {
-            $url .= '?xoops_redirect=' . urlencode($_SERVER['REQUEST_URI']);
+            $url .= '?xoops_redirect=' . urlencode($requestUri);
         } else {
-            $url .= '&amp;xoops_redirect=' . urlencode($_SERVER['REQUEST_URI']);
+            // A plain "&" separator. This wrote the HTML entity "&amp;" straight into the
+            // query string, which names the parameter "amp;xoops_redirect" as far as any
+            // parser is concerned, and seeded the layering described above. Escaping for
+            // HTML belongs at output, not in the value.
+            $url .= '&xoops_redirect=' . urlencode($requestUri);
         }
     }
 //    if (defined('SID') && SID && (!isset($_COOKIE[session_name()]) || ($xoopsConfig['use_mysession'] && $xoopsConfig['session_name'] != '' && !isset($_COOKIE[$xoopsConfig['session_name']])))) {

--- a/tests/unit/htdocs/include/RedirectValidationTest.php
+++ b/tests/unit/htdocs/include/RedirectValidationTest.php
@@ -63,6 +63,58 @@ final class RedirectValidationTest extends TestCase
         self::assertTrue(xoops_isLocalUrl($url), $url);
     }
 
+    /** @return array<string, array{string, string}> */
+    public static function separatorUrls(): array
+    {
+        return [
+            // The live xoops.org entry: three rounds of escaping, with the semicolons
+            // percent-encoded so the browser could no longer collapse them.
+            'three layers, encoded' => [
+                '/modules/newbb/viewpost.php?start=0&amp%3Bamp%3Bamp%3Bforum=0',
+                '/modules/newbb/viewpost.php?start=0&forum=0',
+            ],
+            'one layer, literal'  => ['/a.php?x=1&amp;forum=0', '/a.php?x=1&forum=0'],
+            'two layers, literal' => ['/a.php?x=1&amp;amp;forum=0', '/a.php?x=1&forum=0'],
+            'mixed spellings'     => ['/a.php?x=1&amp;amp%3Bforum=0', '/a.php?x=1&forum=0'],
+            'already correct'     => ['/a.php?x=1&forum=0', '/a.php?x=1&forum=0'],
+            // Must not eat a parameter that is genuinely named "amp", nor a value.
+            'parameter named amp' => ['/a.php?amp=1&other=2', '/a.php?amp=1&other=2'],
+            'value containing amp' => ['/a.php?q=amp;stuff&x=1', '/a.php?q=amp;stuff&x=1'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('separatorUrls')]
+    public function escapedAmpersandLayersAreCollapsed(string $url, string $expected): void
+    {
+        self::assertSame($expected, xoops_normalizeUrlSeparators($url));
+    }
+
+    #[Test]
+    public function collapsingIsIdempotent(): void
+    {
+        // The property that matters: twice must equal once, or the helper becomes another
+        // source of drift in a chain that already had one.
+        $url  = '/modules/newbb/viewpost.php?start=0&amp%3Bamp%3Bamp%3Bforum=0&amp;viewmode=flat';
+        $once = xoops_normalizeUrlSeparators($url);
+
+        self::assertSame($once, xoops_normalizeUrlSeparators($once));
+    }
+
+    #[Test]
+    public function redirectHeaderDoesNotPutAnHtmlEntityInTheQueryString(): void
+    {
+        // "&amp;xoops_redirect=" names the parameter "amp;xoops_redirect" to anything that
+        // parses the URL rather than rendering it, and it seeded the layering above.
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/include/functions.php');
+        self::assertNotFalse($src);
+        self::assertSame(
+            0,
+            preg_match('/&amp;xoops_redirect=/', $src),
+            'redirect_header() must use a plain & separator; escaping belongs at output.'
+        );
+    }
+
     #[Test]
     public function commentDeleteDoesNotRedirectToRawReferer(): void
     {


### PR DESCRIPTION
## Summary

`redirect_header()` appended the **HTML entity** `&amp;` as a query-string separator. A URL is not HTML — to anything that parses one rather than renders it, that names the following parameter `amp;xoops_redirect`:

```
parse_str of the url it built  ->  keys: foo, amp;xoops_redirect
parse_str after this change    ->  keys: foo, xoops_redirect
```

## Motivation

Found in xoops.org's live log:

```
?start=0&amp%3Bamp%3Bamp%3Bforum=0     ← should read ?start=0&forum=0
```

The ampersand had been HTML-escaped **three times**, and was growing by one layer per pass through the login redirect.

**Why it hid for so long:** a browser decodes `&amp;` before requesting, so the fault self-corrects for exactly one hop. I verified that round trip with the real XMF filter — escape, decode, back to the original, stable.

**Why it stops hiding:** once a semicolon is percent-encoded anywhere along the chain, `&amp%3B` is no longer a complete entity, the browser can no longer collapse it, and every later escape adds a layer. The existing output filter is idempotent, so nothing removes the layers once present — it carried them forward forever.

Replaying four hops:

```
before fix:  layers = 1, 2, 3, 4 ...
after fix:   layers = 1, 1, 1, 1
```

## Approach

Two changes:

1. **A plain `&` separator.** Escaping for HTML belongs at output, and `redirect_header()` already escapes there.
2. **Normalise the incoming `REQUEST_URI`** before folding it into the next hop, so a URI that already carries the damage is healed rather than passed on.

The normalisation is a helper beside `xoops_isLocalUrl()` so the other `xoops_redirect` consumers can reach it. It leaves a parameter genuinely named `amp` alone, and is idempotent — otherwise it would become another source of drift in a chain that already had one.

**Deliberately not changed:** the `htmlspecialchars` + un-escape at the end of `redirect_header()`, and the template's unescaped `<{$url}>`. Both are load-bearing, and the fix does not need them.

## Testing

**Behaviour-preserving, verified:** the URL a browser finally requests is byte-identical before and after, because it was decoding the entity anyway. The change is only visible to code that parses the URL.

New data provider covering the live entry, one/two/mixed layers, already-correct input, and the two false-positive cases (`?amp=1`, a value containing `amp;`), plus idempotency and a source assertion that the entity does not come back.

## Summary by Sourcery

Normalize login redirect URLs to prevent escaped ampersand entities from accumulating in query strings and ensure xoops_redirect is appended with a proper separator.

Bug Fixes:
- Fix login redirect URLs incorrectly appending the HTML entity &amp; as a query-string separator, which caused parameters like xoops_redirect to be misnamed and amp; layers to accumulate across hops.

Enhancements:
- Introduce a reusable URL normalisation helper that collapses escaped-ampersand sequences in query strings while preserving genuine amp parameters.

Tests:
- Add unit tests covering URL separator normalisation for multiple escaped-ampersand layers, mixed encodings, false-positive cases, and idempotency, plus a source assertion that redirect_header uses a plain & separator.