### PR TITLE
fix(profile): assign redirect_page so the default theme's login form is clean

### DIFF
--- a/docs/changelog.270.txt
+++ b/docs/changelog.270.txt
@@ -27,6 +27,9 @@ Search:
 - assign "showing" and "module_name" even when a module returns nothing, so an empty showall page stops emitting Undefined array key warnings (mamba) in #130
 - require both isactive and hassearch on the showall route, and normalise the rows a module returns before they reach the template (mamba) in #130
 
+Login form:
+- assign redirect_page whether or not the login form was reached through a redirect. The shipped xbootstrap5 profile form renders it without a |default: guard, so a guest opening that form raised "Undefined array key redirect_page" and "Attempt to read property value on null" on every render — the same shape as anon_canpost, on the default theme. Assigned in PHP so it holds for every theme, and the theme template gained the guard its siblings already had (mamba)
+
 Comments:
 - assign anon_canpost even when anonymous posting is disabled; a guest on such a module produced two warnings per comment row, 253 pairs in nine minutes of xoops.org traffic and the single largest source of log noise (mamba) in #130
 

--- a/htdocs/modules/profile/user.php
+++ b/htdocs/modules/profile/user.php
@@ -34,12 +34,18 @@ if ($op === 'main') {
         $GLOBALS['xoopsTpl']->assign('lang_username', _USERNAME);
         // Assigned unconditionally. The template reads $redirect_page whether or not the
         // form was reached through a redirect, and a theme is free to render it without a
-        // |default: guard -- the shipped xbootstrap5 profile form does exactly that, so a
-        // guest opening the login form raised "Undefined array key redirect_page" plus
-        // "Attempt to read property value on null" on every render. Assigning here fixes
-        // it for every theme, including ones outside this repository.
+        // |default: guard -- the shipped xbootstrap5 profile form did so before this fix,
+        // so a guest opening the login form raised "Undefined array key redirect_page"
+        // plus "Attempt to read property value on null" on every render. That template is
+        // guarded now too, but assigning here is what holds for every theme, including
+        // ones outside this repository.
+        //
+        // ENT_SUBSTITUTE matters here, not just the explicit charset: without it
+        // htmlspecialchars() returns an EMPTY STRING for a target containing an invalid
+        // UTF-8 sequence, so a malformed redirect silently discarded where the visitor was
+        // going rather than losing the one bad byte. Verified on PHP 8.2.
         $GLOBALS['xoopsTpl']->assign('redirect_page', Request::hasVar('xoops_redirect', 'GET')
-            ? htmlspecialchars(Request::getUrl('xoops_redirect', 'GET'), ENT_QUOTES | ENT_HTML5)
+            ? htmlspecialchars(Request::getUrl('xoops_redirect', 'GET'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
             : '');
         if ($GLOBALS['xoopsConfig']['usercookie']) {
             $GLOBALS['xoopsTpl']->assign('lang_rememberme', _US_REMEMBERME);

--- a/htdocs/modules/profile/user.php
+++ b/htdocs/modules/profile/user.php
@@ -32,9 +32,15 @@ if ($op === 'main') {
         include $GLOBALS['xoops']->path('header.php');
         $GLOBALS['xoopsTpl']->assign('lang_login', _LOGIN);
         $GLOBALS['xoopsTpl']->assign('lang_username', _USERNAME);
-        if (Request::hasVar('xoops_redirect', 'GET')) {
-            $GLOBALS['xoopsTpl']->assign('redirect_page', htmlspecialchars(Request::getUrl('xoops_redirect', 'GET'), ENT_QUOTES | ENT_HTML5));
-        }
+        // Assigned unconditionally. The template reads $redirect_page whether or not the
+        // form was reached through a redirect, and a theme is free to render it without a
+        // |default: guard -- the shipped xbootstrap5 profile form does exactly that, so a
+        // guest opening the login form raised "Undefined array key redirect_page" plus
+        // "Attempt to read property value on null" on every render. Assigning here fixes
+        // it for every theme, including ones outside this repository.
+        $GLOBALS['xoopsTpl']->assign('redirect_page', Request::hasVar('xoops_redirect', 'GET')
+            ? htmlspecialchars(Request::getUrl('xoops_redirect', 'GET'), ENT_QUOTES | ENT_HTML5)
+            : '');
         if ($GLOBALS['xoopsConfig']['usercookie']) {
             $GLOBALS['xoopsTpl']->assign('lang_rememberme', _US_REMEMBERME);
         }

--- a/htdocs/themes/xbootstrap5/modules/profile/profile_userform.tpl
+++ b/htdocs/themes/xbootstrap5/modules/profile/profile_userform.tpl
@@ -23,7 +23,7 @@
             </div>
 
             <input type="hidden" name="op" value="login" class="form-control">
-            <input type="hidden" name="xoops_redirect" value="<{$redirect_page}>" class="form-control">
+            <input type="hidden" name="xoops_redirect" value="<{$redirect_page|default:''}>" class="form-control">
             <button type="submit" class="btn btn-secondary"><{$lang_login}></button>
         </form>
         <br>

--- a/htdocs/user.php
+++ b/htdocs/user.php
@@ -34,12 +34,18 @@ if ($op === 'main') {
         $GLOBALS['xoopsTpl']->assign('lang_username', _USERNAME);
         // Assigned unconditionally. The template reads $redirect_page whether or not the
         // form was reached through a redirect, and a theme is free to render it without a
-        // |default: guard -- the shipped xbootstrap5 profile form does exactly that, so a
-        // guest opening the login form raised "Undefined array key redirect_page" plus
-        // "Attempt to read property value on null" on every render. Assigning here fixes
-        // it for every theme, including ones outside this repository.
+        // |default: guard -- the shipped xbootstrap5 profile form did so before this fix,
+        // so a guest opening the login form raised "Undefined array key redirect_page"
+        // plus "Attempt to read property value on null" on every render. That template is
+        // guarded now too, but assigning here is what holds for every theme, including
+        // ones outside this repository.
+        //
+        // ENT_SUBSTITUTE matters here, not just the explicit charset: without it
+        // htmlspecialchars() returns an EMPTY STRING for a target containing an invalid
+        // UTF-8 sequence, so a malformed redirect silently discarded where the visitor was
+        // going rather than losing the one bad byte. Verified on PHP 8.2.
         $GLOBALS['xoopsTpl']->assign('redirect_page', Request::hasVar('xoops_redirect', 'GET')
-            ? htmlspecialchars(Request::getUrl('xoops_redirect', 'GET'), ENT_QUOTES | ENT_HTML5)
+            ? htmlspecialchars(Request::getUrl('xoops_redirect', 'GET'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
             : '');
         if ($GLOBALS['xoopsConfig']['usercookie']) {
             $GLOBALS['xoopsTpl']->assign('lang_rememberme', _US_REMEMBERME);

--- a/htdocs/user.php
+++ b/htdocs/user.php
@@ -32,9 +32,15 @@ if ($op === 'main') {
         include $GLOBALS['xoops']->path('header.php');
         $GLOBALS['xoopsTpl']->assign('lang_login', _LOGIN);
         $GLOBALS['xoopsTpl']->assign('lang_username', _USERNAME);
-        if (Request::hasVar('xoops_redirect', 'GET')) {
-            $GLOBALS['xoopsTpl']->assign('redirect_page', htmlspecialchars(Request::getUrl('xoops_redirect', 'GET'), ENT_QUOTES | ENT_HTML5));
-        }
+        // Assigned unconditionally. The template reads $redirect_page whether or not the
+        // form was reached through a redirect, and a theme is free to render it without a
+        // |default: guard -- the shipped xbootstrap5 profile form does exactly that, so a
+        // guest opening the login form raised "Undefined array key redirect_page" plus
+        // "Attempt to read property value on null" on every render. Assigning here fixes
+        // it for every theme, including ones outside this repository.
+        $GLOBALS['xoopsTpl']->assign('redirect_page', Request::hasVar('xoops_redirect', 'GET')
+            ? htmlspecialchars(Request::getUrl('xoops_redirect', 'GET'), ENT_QUOTES | ENT_HTML5)
+            : '');
         if ($GLOBALS['xoopsConfig']['usercookie']) {
             $GLOBALS['xoopsTpl']->assign('lang_rememberme', _US_REMEMBERME);
         }


### PR DESCRIPTION
## Summary

The login form template reads `$redirect_page` whether or not the form was reached through a redirect, but PHP only assigned it when the request carried `xoops_redirect`.

Every template in the repository guards the read with `|default:''` **except one** — and it is the shipped **default** theme:

```
themes/xbootstrap5/modules/profile/profile_userform.tpl:26
  <input type="hidden" name="xoops_redirect" value="<{$redirect_page}>" class="form-control">
```

So on a default install, a guest opening the profile login form without `?xoops_redirect=` raised:

```
Undefined array key "redirect_page"
Attempt to read property "value" on null
```

Two notices per render — the same shape as the `anon_canpost` fix in #130, which accounted for 253 warning pairs in nine minutes of xoops.org traffic.

## Approach

Assigned **unconditionally in PHP**, not merely guarded in the template. Themes are user-editable and live outside this repository, so a theme that omits the modifier must not be able to reintroduce this. The xbootstrap5 template also gains the guard its siblings already had, so both layers agree.

Applied to `htdocs/user.php` as well as the profile module — both carry the identical block, and the system templates only *happen* to guard it today.

## Testing

Verified the two shapes directly:

```
bare        <{$redirect_page}>            -> 2 notices
|default:'' <{$redirect_page|default:''}> -> 0 notices
```

And confirmed no unguarded `redirect_page` template remains anywhere in the tree, and no conditional assign remains at either PHP site.

## Summary by Sourcery

Ensure login forms always receive a defined redirect_page value to avoid template notices and make behavior consistent across themes.

Bug Fixes:
- Prevent undefined redirect_page notices on the profile and core login forms when accessed without a xoops_redirect parameter.

Enhancements:
- Guard the default xbootstrap5 profile login template’s redirect_page usage with a default value to be robust against missing redirects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved login form rendering when no redirect URL is provided.
  - Prevented undefined-value warnings and related template issues across themes.
  - Ensured redirect values are safely handled and default to an empty value when unavailable.
- **Documentation**
  - Added a changelog entry documenting the login form rendering improvement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->