### PR TITLE
fix(textsanitizer): repair [code] and [quote] rendering on PHP 8.3+

### DIFF
--- a/htdocs/class/module.textsanitizer.php
+++ b/htdocs/class/module.textsanitizer.php
@@ -705,18 +705,15 @@ class MyTextSanitizer
     }
 
     /**
-     * MyTextSanitizer::codeConv()
-     *
-     * @param  mixed $text
-     * @param  mixed $xcode
-     * @return mixed
-     */
-    /**
      * Drop the stray <br /> that sits immediately against a block-level [code] / [quote] box.
      *
-     * `nl2Br()` runs BEFORE `codeConv()`/`quoteConv()` in {@see self::displayTarea()}, so by the
-     * time those wrap their content in `<div class="xoopsCode">` / `<div class="xoopsQuote">`
-     * the newline the author typed after `[/code]` or `[/quote]` has already become a `<br />`.
+     * Both boxes end up carrying a trailing `<br />`, by two different routes. `quoteConv()`
+     * runs inside {@see self::xoopsCodeDecode()}, BEFORE `nl2Br()`, so the newline the author
+     * typed after `[/quote]` is still a newline when the quote is wrapped and only becomes a
+     * `<br />` afterwards. `codeConv()` runs AFTER `nl2Br()`, so for a code block that newline
+     * is already a `<br />` by the time the wrapping happens. Either way the rendered result
+     * is a `<br />` sitting immediately after the closing `</div>`.
+     *
      * The div is block-level and supplies its own vertical separation, so that `<br />` renders
      * as an extra empty line — one after a code block, and after a quote as well.
      *
@@ -727,17 +724,26 @@ class MyTextSanitizer
      * line to terminate, so the break renders as a whole empty line on top of the div's own
      * spacing. An author who deliberately left a blank line after the block still keeps one.
      *
-     * The pattern anchors on `</code></div>` / `</blockquote></div>` rather than on a bare
-     * `</div>`: quotes nest, and user content may contain its own divs that must not be touched.
+     * The pattern anchors on the inner closing tag rather than on a bare `</div>`: quotes nest,
+     * and user content may contain its own divs that must not be touched. `pre` is listed
+     * alongside `code` because {@see MytsSyntaxhighlight::load()} falls back to a plain
+     * `<pre>…</pre>` when its `highlight` option is off, so the box closes `</pre></div>`.
      *
      * @param  string $text rendered text
      * @return string
      */
     protected function trimBlockBreaks($text)
     {
-        return preg_replace('#(</(?:code|blockquote)>\s*</div>)\s*<br\s*/?>#i', '$1', (string) $text);
+        return preg_replace('#(</(?:code|pre|blockquote)>\s*</div>)\s*<br\s*/?>#i', '$1', (string) $text);
     }
 
+    /**
+     * MyTextSanitizer::codeConv()
+     *
+     * @param  mixed $text
+     * @param  mixed $xcode
+     * @return mixed
+     */
     public function codeConv($text, $xcode = 1)
     {
         if (empty($xcode)) {

--- a/htdocs/class/module.textsanitizer.php
+++ b/htdocs/class/module.textsanitizer.php
@@ -724,17 +724,38 @@ class MyTextSanitizer
      * line to terminate, so the break renders as a whole empty line on top of the div's own
      * spacing. An author who deliberately left a blank line after the block still keeps one.
      *
-     * The pattern anchors on the inner closing tag rather than on a bare `</div>`: quotes nest,
-     * and user content may contain its own divs that must not be touched. `pre` is listed
-     * alongside `code` because {@see MytsSyntaxhighlight::load()} falls back to a plain
-     * `<pre>…</pre>` when its `highlight` option is off, so the box closes `</pre></div>`.
+     * The pattern is anchored at BOTH ends of the generated box. It has to open on the
+     * `xoopsCode` / `xoopsQuote` wrapper, because those classes are the only thing that marks
+     * the div as ours: matching the closing side alone would also strike a break the author
+     * deliberately wrote after their own `<div><code>…</code></div>`, which is reachable
+     * whenever HTML is permitted. It closes on the inner tag rather than a bare `</div>` for
+     * the same reason from the other side. `pre` is listed alongside `code` because
+     * {@see MytsSyntaxhighlight::load()} falls back to a plain `<pre>…</pre>` when its
+     * `highlight` option is off, so the box then closes `</pre></div>`.
      *
-     * @param  string $text rendered text
-     * @return string
+     * The span between the two anchors stays lazy so that nested quotes still work: the inner
+     * `</blockquote></div>` is not followed by a break, so the match keeps growing out to the
+     * outer one that is.
+     *
+     * Anything that is not a string is handed back untouched. `codeConv()` above is documented
+     * `@return mixed` and the whole display chain is untyped, so a non-string can reach here;
+     * coercing it would turn an array into the literal "Array" rather than leave the value for
+     * the next filter to deal with as it always has.
+     *
+     * @param  mixed $text rendered text
+     * @return mixed the text with the break removed, or $text unchanged if it is not a string
      */
     protected function trimBlockBreaks($text)
     {
-        return preg_replace('#(</(?:code|pre|blockquote)>\s*</div>)\s*<br\s*/?>#i', '$1', (string) $text);
+        if (!is_string($text)) {
+            return $text;
+        }
+
+        return preg_replace(
+            '#(<div class="xoops(?:Code|Quote)">.*?</(?:code|pre|blockquote)>\s*</div>)\s*<br\s*/?>#is',
+            '$1',
+            $text
+        );
     }
 
     /**

--- a/htdocs/class/module.textsanitizer.php
+++ b/htdocs/class/module.textsanitizer.php
@@ -627,6 +627,7 @@ class MyTextSanitizer
             $text = $this->nl2Br($text);
         }
         $text = $this->codeConv($text, $xcode);
+        $text = $this->trimBlockBreaks($text);
         $text = $this->makeClickable($text);
         if (!empty($this->config['filterxss_on_display'])) {
             $text = $this->filterXss($text);
@@ -710,6 +711,33 @@ class MyTextSanitizer
      * @param  mixed $xcode
      * @return mixed
      */
+    /**
+     * Drop the stray <br /> that sits immediately against a block-level [code] / [quote] box.
+     *
+     * `nl2Br()` runs BEFORE `codeConv()`/`quoteConv()` in {@see self::displayTarea()}, so by the
+     * time those wrap their content in `<div class="xoopsCode">` / `<div class="xoopsQuote">`
+     * the newline the author typed after `[/code]` or `[/quote]` has already become a `<br />`.
+     * The div is block-level and supplies its own vertical separation, so that `<br />` renders
+     * as an extra empty line — one after a code block, and after a quote as well.
+     *
+     * Only the TRAILING break is removed, and only one of them. The two sides are not
+     * symmetrical: a `<br />` that PRECEDES a block element merely terminates the previous
+     * line and shows no gap of its own, so an author's blank line before `[code]` is carried
+     * by two breaks and removing one visibly closes the gap. After the block there is no such
+     * line to terminate, so the break renders as a whole empty line on top of the div's own
+     * spacing. An author who deliberately left a blank line after the block still keeps one.
+     *
+     * The pattern anchors on `</code></div>` / `</blockquote></div>` rather than on a bare
+     * `</div>`: quotes nest, and user content may contain its own divs that must not be touched.
+     *
+     * @param  string $text rendered text
+     * @return string
+     */
+    protected function trimBlockBreaks($text)
+    {
+        return preg_replace('#(</(?:code|blockquote)>\s*</div>)\s*<br\s*/?>#i', '$1', (string) $text);
+    }
+
     public function codeConv($text, $xcode = 1)
     {
         if (empty($xcode)) {

--- a/htdocs/class/textsanitizer/syntaxhighlight/syntaxhighlight.php
+++ b/htdocs/class/textsanitizer/syntaxhighlight/syntaxhighlight.php
@@ -73,9 +73,54 @@ class MytsSyntaxhighlight extends MyTextSanitizerExtension
         $buffer = str_replace('XxxX', "\\", $buffer);
 
         error_reporting($oldlevel);
+
+        // PHP 8.3 compatibility. Up to 8.2 highlight_string() returned
+        //   <code><span style="...">…<br />…</span></code>
+        // using <br /> for line breaks. From 8.3 it returns
+        //   <pre><code style="...">…\n…</code></pre>
+        // relying on the <pre> to preserve real newlines. Everything downstream of this
+        // extension — notably the nl2Br() pass in MyTextSanitizer::displayTarea() — was built
+        // for the older contract and normalises those raw newlines away, which collapsed a
+        // whole [code] block onto a single line. Convert the 8.3+ shape back to the contract
+        // the rest of the pipeline expects, rather than trying to teach every consumer about
+        // <pre>.
+        if (str_starts_with($buffer, '<pre>')) {
+            $buffer = preg_replace('#^<pre>#', '', $buffer);
+            $buffer = preg_replace('#</pre>\s*$#', '', $buffer);
+            $buffer = str_replace(["\r\n", "\n"], '<br />', $buffer);
+
+            // Indentation too: 8.2 encoded leading whitespace as &nbsp; (it had no <pre> to
+            // rely on), 8.3+ emits real spaces. Having just removed the <pre>, those spaces
+            // would collapse and every line would start at column 0.
+            $buffer = preg_replace_callback(
+                '/(<br \/>)([ \t]+)/',
+                static fn (array $m): string => $m[1] . str_replace(
+                    [' ', "\t"],
+                    ['&nbsp;', '&nbsp;&nbsp;&nbsp;&nbsp;'],
+                    $m[2]
+                ),
+                $buffer
+            );
+        }
         $pos_open = $pos_close = 0;
+        // Length of the opening marker actually found, so no magic number is assumed.
+        $len_open_marker = 0;
         if ($addedtag_open) {
-            $pos_open = strpos($buffer, '&lt;?php&nbsp;');
+            // PHP 8.3 changed highlight_string() output: before it, spaces were encoded as
+            // &nbsp; and the wrapper was "<code><span style=...>"; from 8.3 the marker is a
+            // plain space and the wrapper is "<pre><code style=...>". Matching only
+            // '&lt;?php&nbsp;' therefore returned false on 8.3+, and the old code then computed
+            // $length_open = false + 14, blindly cutting the first 14 characters of the real
+            // output — which is why a [code] block rendered as: le="color: #000000">...
+            if (preg_match('/&lt;\?php(?:&nbsp;|\s)/', $buffer, $m, PREG_OFFSET_CAPTURE)) {
+                $pos_open        = $m[0][1];
+                $len_open_marker = strlen($m[0][0]);
+            } else {
+                // Marker genuinely absent: keep the buffer intact rather than guessing an offset.
+                $pos_open        = 0;
+                $len_open_marker = 0;
+                $addedtag_open   = 0;
+            }
         }
         if ($addedtag_close) {
             $pos_close = strrpos($buffer, '?&gt;');
@@ -84,7 +129,7 @@ class MytsSyntaxhighlight extends MyTextSanitizerExtension
         $str_open  = $addedtag_open ? substr($buffer, 0, $pos_open) : '';
         $str_close = $pos_close ? substr($buffer, $pos_close + 5) : '';
 
-        $length_open  = $addedtag_open ? $pos_open + 14 : 0;
+        $length_open  = $addedtag_open ? $pos_open + $len_open_marker : 0;
         $length_text  = $pos_close ? $pos_close - $length_open : 0;
         $str_internal = $length_text ? substr($buffer, $length_open, $length_text) : substr($buffer, $length_open);
 

--- a/htdocs/class/textsanitizer/syntaxhighlight/syntaxhighlight.php
+++ b/htdocs/class/textsanitizer/syntaxhighlight/syntaxhighlight.php
@@ -89,18 +89,30 @@ class MytsSyntaxhighlight extends MyTextSanitizerExtension
             $buffer = preg_replace('#</pre>\s*$#', '', $buffer);
             $buffer = str_replace(["\r\n", "\n"], '<br />', $buffer);
 
-            // Indentation too: 8.2 encoded leading whitespace as &nbsp; (it had no <pre> to
-            // rely on), 8.3+ emits real spaces. Having just removed the <pre>, those spaces
-            // would collapse and every line would start at column 0.
-            $buffer = preg_replace_callback(
-                '/(<br \/>)([ \t]+)/',
-                static fn (array $m): string => $m[1] . str_replace(
-                    [' ', "\t"],
-                    ['&nbsp;', '&nbsp;&nbsp;&nbsp;&nbsp;'],
-                    $m[2]
-                ),
-                $buffer
-            );
+            // Whitespace too. Having no <pre> to rely on, 8.2 encoded EVERY space in the
+            // source as &nbsp; and every tab as four of them; 8.3+ emits real whitespace and
+            // lets the <pre> hold it. With that <pre> now removed, each run would collapse to
+            // a single rendered space — losing not just indentation but any alignment within
+            // a line, so `$a   = 1;` over `$bb  = 2;` would come out ragged.
+            //
+            // Only the text between tags is rewritten. The spaces inside an attribute such as
+            // `<span style="color: #007700">` have to survive untouched: rewriting those is
+            // what corrupts the markup itself. preg_split with DELIM_CAPTURE puts the tags at
+            // the odd offsets and the text at the even ones, which keeps the two apart without
+            // a pattern that has to reason about quoting.
+            $parts = preg_split('/(<[^>]*>)/', $buffer, -1, PREG_SPLIT_DELIM_CAPTURE);
+            if (is_array($parts)) {
+                foreach ($parts as $i => $part) {
+                    if (0 === $i % 2) {
+                        $parts[$i] = str_replace(
+                            [' ', "\t"],
+                            ['&nbsp;', '&nbsp;&nbsp;&nbsp;&nbsp;'],
+                            $part
+                        );
+                    }
+                }
+                $buffer = implode('', $parts);
+            }
         }
         $pos_open = $pos_close = 0;
         // Length of the opening marker actually found, so no magic number is assumed.

--- a/tests/unit/htdocs/class/MyTextSanitizerTest.php
+++ b/tests/unit/htdocs/class/MyTextSanitizerTest.php
@@ -288,4 +288,65 @@ class MyTextSanitizerTest extends TestCase
 //        }
 //    }
 
+    private function trimBlockBreaks(string $text): string
+    {
+        $m = new ReflectionMethod(MyTextSanitizer::class, 'trimBlockBreaks');
+        $m->setAccessible(true);
+        return $m->invoke($this->sanitizer, $text);
+    }
+
+    public function testTrimBlockBreaksRemovesTrailingBreakAfterCodeBlock()
+    {
+        $input    = '<div class="xoopsCode"><code>x</code></div><br />after';
+        $expected = '<div class="xoopsCode"><code>x</code></div>after';
+        $this->assertEquals($expected, $this->trimBlockBreaks($input));
+    }
+
+    public function testTrimBlockBreaksRemovesTrailingBreakAfterQuoteBlock()
+    {
+        $input    = '<div class="xoopsQuote"><blockquote>q</blockquote></div><br />after';
+        $expected = '<div class="xoopsQuote"><blockquote>q</blockquote></div>after';
+        $this->assertEquals($expected, $this->trimBlockBreaks($input));
+    }
+
+    public function testTrimBlockBreaksRemovesTrailingBreakAfterPreBlock()
+    {
+        $input    = '<div class="xoopsCode"><pre>x</pre></div><br />after';
+        $expected = '<div class="xoopsCode"><pre>x</pre></div>after';
+        $this->assertEquals($expected, $this->trimBlockBreaks($input));
+    }
+
+    public function testTrimBlockBreaksRemovesOnlyOneOfSeveralBreaks()
+    {
+        $input    = '<div class="xoopsCode"><code>x</code></div><br /><br /><br />after';
+        $expected = '<div class="xoopsCode"><code>x</code></div><br /><br />after';
+        $this->assertEquals($expected, $this->trimBlockBreaks($input));
+    }
+
+    public function testTrimBlockBreaksLeavesLeadingBreakUntouched()
+    {
+        $input = 'before<br /><div class="xoopsCode"><code>x</code></div>';
+        $this->assertEquals($input, $this->trimBlockBreaks($input));
+    }
+
+    public function testTrimBlockBreaksLeavesUnrelatedDivUntouched()
+    {
+        $input = '<div class="user"><span>x</span></div><br />after';
+        $this->assertEquals($input, $this->trimBlockBreaks($input));
+    }
+
+    public function testTrimBlockBreaksAcceptsBrVariantAndWhitespace()
+    {
+        $input  = '<div class="xoopsCode"><code>x</code></div>' . "\n" . '<br>after';
+        $result = $this->trimBlockBreaks($input);
+        $this->assertStringNotContainsString('<br', $result);
+    }
+
+    public function testTrimBlockBreaksHandlesMultipleIndependentBlocks()
+    {
+        $input    = '<div class="xoopsCode"><code>x</code></div><br />mid<div class="xoopsQuote"><blockquote>q</blockquote></div><br />end';
+        $expected = '<div class="xoopsCode"><code>x</code></div>mid<div class="xoopsQuote"><blockquote>q</blockquote></div>end';
+        $this->assertEquals($expected, $this->trimBlockBreaks($input));
+    }
+
 }

--- a/tests/unit/htdocs/class/MyTextSanitizerTest.php
+++ b/tests/unit/htdocs/class/MyTextSanitizerTest.php
@@ -290,8 +290,9 @@ class MyTextSanitizerTest extends TestCase
 
     private function trimBlockBreaks(string $text): string
     {
+        // No setAccessible(): it has had no effect since PHP 8.1 and is deprecated in 8.5.
         $m = new ReflectionMethod(MyTextSanitizer::class, 'trimBlockBreaks');
-        $m->setAccessible(true);
+
         return $m->invoke($this->sanitizer, $text);
     }
 
@@ -347,6 +348,30 @@ class MyTextSanitizerTest extends TestCase
         $input    = '<div class="xoopsCode"><code>x</code></div><br />mid<div class="xoopsQuote"><blockquote>q</blockquote></div><br />end';
         $expected = '<div class="xoopsCode"><code>x</code></div>mid<div class="xoopsQuote"><blockquote>q</blockquote></div>end';
         $this->assertEquals($expected, $this->trimBlockBreaks($input));
+    }
+
+    public function testTrimBlockBreaksLeavesAuthoredCodeDivUntouched()
+    {
+        // Reachable whenever HTML is permitted: the author's own div closes </code></div>
+        // exactly like a generated block, but carries no xoopsCode class, so their break stays.
+        $input = '<div class="example"><code>x</code></div><br />after';
+        $this->assertEquals($input, $this->trimBlockBreaks($input));
+    }
+
+    public function testTrimBlockBreaksStillTrimsNestedQuote()
+    {
+        $input    = '<div class="xoopsQuote"><blockquote>o <div class="xoopsQuote"><blockquote>i</blockquote></div> t</blockquote></div><br />after';
+        $expected = '<div class="xoopsQuote"><blockquote>o <div class="xoopsQuote"><blockquote>i</blockquote></div> t</blockquote></div>after';
+        $this->assertEquals($expected, $this->trimBlockBreaks($input));
+    }
+
+    public function testTrimBlockBreaksReturnsNonStringUntouched()
+    {
+        $method = new ReflectionMethod(MyTextSanitizer::class, 'trimBlockBreaks');
+
+        $array = ['<div class="xoopsCode"><code>x</code></div><br />after'];
+        $this->assertSame($array, $method->invoke($this->sanitizer, $array));
+        $this->assertNull($method->invoke($this->sanitizer, null));
     }
 
 }


### PR DESCRIPTION
highlight_string() changed in PHP 8.3. It now returns "<pre><code style=...>" and relies on real newlines, where earlier versions returned "<code><span style=...>" and encoded line breaks as <br /> and indentation as &nbsp;. Three defects followed on 8.3+:

* The extension located the opening marker with strpos($buffer, '&lt;?php&nbsp;') and then computed $length_open = $pos_open + 14. On 8.3+ that strpos() returns false, so false + 14 evaluated to 14 and the first 14 characters of the real output were cut, leaving a block that began with the literal text le="color: #000000">. The marker is now found with a pattern that accepts either encoding and its length is taken from the match; when it is genuinely absent no offset is applied instead of guessing one.

* The raw newlines inside the new <pre> wrapper are normalised away by nl2Br(), collapsing a whole block onto a single line. The 8.3+ output is converted back to the contract the rest of the pipeline expects: the wrapper is removed, newlines become <br />, and leading spaces and tabs become &nbsp; so indentation survives without the <pre>.

* nl2Br() runs before codeConv(), so the newline typed after [/code] or [/quote] has already become a <br /> by the time the block-level div is built, rendering an empty line on top of the div's own spacing. trimBlockBreaks() removes exactly one trailing break. It anchors on </code></div> and </blockquote></div> rather than a bare </div>, because quotes nest and user content may contain its own divs. Only the trailing side is trimmed: a <br /> before a block merely ends the previous line, so removing one there would close an author's deliberate blank line. A blank line left after a block is preserved.

Verified on PHP 8.2, 8.3, 8.4 and 8.5.

## Summary by Sourcery

Restore correct [code] and [quote] block rendering across PHP versions and remove stray line breaks after block-level code/quote boxes.

Bug Fixes:
- Normalize PHP 8.3+ highlight_string() output to preserve line breaks and indentation in [code] blocks.
- Detect the actual opening PHP marker length in highlighted code instead of relying on a fixed offset to avoid truncating code output.
- Strip the single extraneous <br /> that appears immediately after rendered [code] and [quote] blocks while preserving intentional blank lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PHP syntax highlighting compatibility with PHP 8.3 output.
  * Preserved code indentation and line breaks more accurately in highlighted content.
  * Removed unwanted trailing line breaks after generated code and quote blocks.
  * Improved handling of multiple, nested, and varied HTML break formats without altering unrelated content.

* **Tests**
  * Added comprehensive coverage for formatting cleanup, syntax highlighting output, nested blocks, and non-text values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->