### PR TITLE
fix(php85): drop deprecated curl_close() calls

### DIFF
--- a/htdocs/class/captcha/recaptcha2.php
+++ b/htdocs/class/captcha/recaptcha2.php
@@ -79,7 +79,6 @@ class XoopsCaptchaRecaptcha2 extends XoopsCaptchaMethod
                 $usedCurl = true;
                 $recaptchaCheck = json_decode($curlReturn, true);
             }
-            curl_close($curlHandle);
         }
         if (false === $usedCurl) {
             $recaptchaCheck = file_get_contents($recaptchaVerifyURL);

--- a/htdocs/class/snoopy.php
+++ b/htdocs/class/snoopy.php
@@ -1064,12 +1064,10 @@ class Snoopy
 
         if ($response === false || !is_string($response)) {
             $this->error = 'cURL error: ' . curl_error($ch);
-            curl_close($ch);
             return false;
         }
 
         $header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-        curl_close($ch);
 
         $header_text = substr($response, 0, $header_size);
         $results     = substr($response, $header_size);

--- a/htdocs/class/xoopshttpget.php
+++ b/htdocs/class/xoopshttpget.php
@@ -167,7 +167,6 @@ class XoopsHttpGet
             $httpcode    = (int) curl_getinfo($curlHandle, CURLINFO_HTTP_CODE);
             $redirectUrl = (string) curl_getinfo($curlHandle, CURLINFO_REDIRECT_URL);
             $curlError   = curl_error($curlHandle);
-            curl_close($curlHandle);
 
             if (false === $response) {
                 $this->error = $curlError;

--- a/htdocs/xoops_lib/modules/protector/class/protector.php
+++ b/htdocs/xoops_lib/modules/protector/class/protector.php
@@ -1213,9 +1213,12 @@ class Protector
         if (false === $result) {
             $result = curl_getinfo($ch);
         } else {
-            $result = json_decode(curl_exec($ch), true);
+            // Decode the response already in hand. This line previously called
+            // curl_exec($ch) a second time, issuing another request to
+            // stopforumspam.com on every successful lookup and decoding that
+            // second response instead of the one just tested for failure.
+            $result = json_decode($result, true);
         }
-        curl_close($ch);
 
         return $result;
     }


### PR DESCRIPTION
curl_close() is deprecated as of PHP 8.5 and has been a no-op since PHP 8.0, when the curl handle became a CurlHandle object released by refcount:

    Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0

Removed all seven call sites across class/ and xoops_lib/. In each case the handle is not referenced after the removed line -- curl_error()/curl_getinfo() already ran and captured into locals -- so behaviour is unchanged on every supported version (PHP_MIN 8.2).

## Summary by Sourcery

Remove deprecated and unnecessary cURL handle closing and correct duplicate request behavior in stopForumSpam lookup.

Bug Fixes:
- Decode the existing cURL response in stopForumSpam lookup instead of issuing a second request via curl_exec().

Enhancements:
- Eliminate redundant curl_close() calls now deprecated and ineffective on supported PHP versions.