### PR TITLE
fix(criteria): render empty IN lists as a constant and convert core callers

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -155,6 +155,29 @@ if [ -n "$added" ]; then
         | grep -vE 'unset[[:space:]]*\(' || true)
     [ -n "$hits" ] && report "direct \$_GET/\$_POST/\$_REQUEST/\$_COOKIE — use Xmf\\Request::getX('k', def, 'GET'|'POST')" "$hits"
 
+    # 14. Legacy Criteria IN format — a preformatted "(1,2,3)" string as the
+    #     value argument. Criteria still accepts it for third-party modules
+    #     (emitting E_USER_DEPRECATED under XOOPS_DEBUG), but core must pass an
+    #     array so the class casts/quotes each element. A hand-built list that
+    #     fails Criteria's validation silently collapses to one quoted literal
+    #     and matches nothing. Matches the value argument opening with a quote
+    #     immediately followed by `(`, on a line that also names the operator.
+    #     The rarer indirect shape ($in = '(' . implode(...); then passed to a
+    #     Criteria) needs whole-file context, so it is covered by
+    #     tests/unit/htdocs/class/CriteriaLegacyInUsageTest.php instead.
+    hits=$(printf '%s\n' "$added" | grep -E "Criteria[[:space:]]*\(.*,[[:space:]]*[\"']\(.*[\"'](NOT )?IN[\"']" || true)
+    [ -n "$hits" ] && report "legacy Criteria IN format — pass an array: new Criteria('uid', \$ids, 'IN')" "$hits"
+
+    # 15. Error-suppressed call — @foo(...). Suppression hides the failure
+    #     instead of handling it; use an explicit guard or try/catch(\Throwable).
+    #     Requires the `(` to follow the identifier directly, so docblock tags
+    #     (`@param string $x`, `@see self::foo()`, `@return array<int,string>`)
+    #     and e-mail literals never match — in each of those a non-`(` character
+    #     follows the tag name. Caught post-hoc by review on this very commit
+    #     (an `@exec()` in a new test), which is why it is mechanized here.
+    hits=$(printf '%s\n' "$added" | grep -E '@[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*\(' || true)
+    [ -n "$hits" ] && report "error-suppressed call @foo() — handle the failure explicitly instead" "$hits"
+
     # JSON_UNESCAPED_SLASHES sniff (previously rule 10) was removed:
     # the </script> breakout concern only applies inside HTML <script>
     # contexts, and the repo legitimately uses the flag elsewhere

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -170,12 +170,16 @@ if [ -n "$added" ]; then
 
     # 15. Error-suppressed call — @foo(...). Suppression hides the failure
     #     instead of handling it; use an explicit guard or try/catch(\Throwable).
-    #     Requires the `(` to follow the identifier directly, so docblock tags
-    #     (`@param string $x`, `@see self::foo()`, `@return array<int,string>`)
-    #     and e-mail literals never match — in each of those a non-`(` character
-    #     follows the tag name. Caught post-hoc by review on this very commit
-    #     (an `@exec()` in a new test), which is why it is mechanized here.
-    hits=$(printf '%s\n' "$added" | grep -E '@[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*\(' || true)
+    #     The `(` must follow the identifier directly, with no whitespace, so
+    #     docblock tags never match: `@param string $x`, `@see self::foo()`,
+    #     `@return array<int,string>`, and the parenthesised-union form
+    #     `@param (int|string) $x` all put a non-`(` character (or a space)
+    #     after the tag name. That last one is why the space is not tolerated
+    #     here — allowing it would flag valid PHPStan syntax. The cost is that
+    #     the `@ foo()` spelling slips through, which no formatter emits.
+    #     Caught post-hoc by review on this very commit (an `@exec()` in a new
+    #     test), which is why it is mechanized here.
+    hits=$(printf '%s\n' "$added" | grep -E '@[a-zA-Z_][a-zA-Z0-9_]*\(' || true)
     [ -n "$hits" ] && report "error-suppressed call @foo() — handle the failure explicitly instead" "$hits"
 
     # JSON_UNESCAPED_SLASHES sniff (previously rule 10) was removed:

--- a/htdocs/class/criteria.php
+++ b/htdocs/class/criteria.php
@@ -370,6 +370,38 @@ class Criteria extends CriteriaElement
     }
 
     /**
+     * Predicate for an empty IN / NOT IN list.
+     *
+     * MySQL rejects the literal `IN ()` with a syntax error, so an empty set
+     * renders as a constant instead: nothing is a member of the empty set, and
+     * everything is outside it.
+     *
+     * @param string $op uppercased operator, 'IN' or 'NOT IN'
+     * @return string constant predicate
+     */
+    private static function emptyInPredicate(string $op): string
+    {
+        return $op === 'IN' ? '1=0' : '1=1';
+    }
+
+    /**
+     * Render a validated legacy (preformatted string) IN list.
+     *
+     * @param string $clause rendered column reference
+     * @param string $op     uppercased operator, 'IN' or 'NOT IN'
+     * @param string $legacy validated legacy list, e.g. "(1,2,3)"
+     * @return string SQL fragment
+     */
+    private static function renderLegacyInList(string $clause, string $op, string $legacy): string
+    {
+        if (preg_match('/^\(\s*\)$/', trim($legacy))) {
+            return self::emptyInPredicate($op);
+        }
+
+        return $clause . ' ' . $op . ' ' . $legacy;
+    }
+
+    /**
      * Set the global default for allowing inner wildcards in LIKE patterns.
      * Useful during migrations of legacy modules that intentionally use inner wildcards.
      *
@@ -505,14 +537,25 @@ class Criteria extends CriteriaElement
             if (is_array($this->value)) {
                 $parts = [];
                 foreach ($this->value as $v) {
-                    if (is_int($v) || (is_string($v) && preg_match('/^-?\d+$/', $v))) {
-                        $parts[] = (string)(int)$v;
+                    // Preserve the caller's PHP type: an int becomes an SQL
+                    // integer, anything else an SQL string literal. Casting
+                    // numeric-looking strings would turn a text-column search
+                    // for '001' into `IN (1)`, which MySQL then evaluates
+                    // numerically and matches against '1', '01' and ' 1' too.
+                    // Callers holding IDs cast with (int)/array_map('intval').
+                    if (is_int($v)) {
+                        $parts[] = (string)$v;
                     } else {
                         $parts[] = $db->quote((string)$v);
                     }
                 }
-            return $clause . ' ' . $op . ' (' . implode(',', $parts) . ')';
-        }
+
+                if ($parts === []) {
+                    return self::emptyInPredicate($op);
+                }
+
+                return $clause . ' ' . $op . ' (' . implode(',', $parts) . ')';
+            }
 
             // Legacy format: preformatted string in parentheses
             $legacy = (string)$this->value;
@@ -525,8 +568,8 @@ class Criteria extends CriteriaElement
 
             // If legacy logging is not enabled, just pass through
             if (!self::isLegacyLogEnabled()) {
-                return $clause . ' ' . $op . ' ' . $legacy;
-        }
+                return self::renderLegacyInList($clause, $op, $legacy);
+            }
 
             // Build log message
             $message = sprintf(
@@ -547,15 +590,15 @@ class Criteria extends CriteriaElement
             if (class_exists('XoopsLogger')) {
                 \XoopsLogger::getInstance()
                             ->addExtra('CriteriaLegacyIN', $message);
-        } else {
+            } else {
                 error_log($message);
-        }
+            }
 
             if (defined('XOOPS_DEBUG') && XOOPS_DEBUG) {
                 trigger_error($message, E_USER_DEPRECATED);
             }
 
-            return $clause . ' ' . $op . ' ' . $legacy;
+            return self::renderLegacyInList($clause, $op, $legacy);
         }
 
         // NOW it's safe to cast to string for other operators

--- a/htdocs/class/xoopsform/formselectuser.php
+++ b/htdocs/class/xoopsform/formselectuser.php
@@ -123,7 +123,7 @@ class XoopsFormSelectUser extends XoopsFormElementTray
         }
         $allowedUids = $memberHandler->getUsersByGroupLink(
             $allowedGroups,
-            new Criteria('uid', '(' . implode(',', array_keys($selectedUsers)) . ')', 'IN'),
+            new Criteria('uid', array_map('intval', array_keys($selectedUsers)), 'IN'),
             false
         );
 
@@ -171,7 +171,7 @@ class XoopsFormSelectUser extends XoopsFormElementTray
         $value          = is_array($value) ? $value : (empty($value) ? [] : [$value]);
         $selectedUsers = [];
         if (count($value) > 0) {
-            $criteria = new Criteria('uid', '(' . implode(',', $value) . ')', 'IN');
+            $criteria = new Criteria('uid', array_map('intval', $value), 'IN');
             $criteria->setSort('uname');
             $criteria->setOrder('ASC');
             $selectedUsers = $member_handler->getUserList($criteria);

--- a/htdocs/include/findusers.php
+++ b/htdocs/include/findusers.php
@@ -590,9 +590,9 @@ if (!Request::hasVar('user_submit', 'POST')) {
     }
     if (Request::hasVar('user_avatar', 'POST')) {
         if (Request::getString('user_avatar', '', 'POST') === 'y') {
-            $criteria->add(new Criteria('user_avatar', "('', 'blank.gif')", 'NOT IN'));
+            $criteria->add(new Criteria('user_avatar', ['', 'blank.gif'], 'NOT IN'));
         } elseif (Request::getString('user_avatar', '', 'POST') === 'n') {
-            $criteria->add(new Criteria('user_avatar', "('', 'blank.gif')", 'IN'));
+            $criteria->add(new Criteria('user_avatar', ['', 'blank.gif'], 'IN'));
         }
     }
     if (Request::hasVar('level', 'POST')) {

--- a/htdocs/include/searchform.php
+++ b/htdocs/include/searchform.php
@@ -43,7 +43,7 @@ if (empty($modules)) {
     $criteria->add(new Criteria('isactive', 1));
     $criteria->add(new Criteria('dirname', 'system', '<>'));
     if (!empty($available_modules)) {
-        $criteria->add(new Criteria('mid', '(' . implode(',', $available_modules) . ')', 'IN'));
+        $criteria->add(new Criteria('mid', array_map('intval', $available_modules), 'IN'));
     }
     /** @var XoopsModuleHandler $module_handler */
     $module_handler = xoops_getHandler('module');

--- a/htdocs/kernel/member.php
+++ b/htdocs/kernel/member.php
@@ -276,7 +276,7 @@ class XoopsMemberHandler
             foreach ($batches as $batch) {
                 $criteria = new CriteriaCompo();
                 $criteria->add(new Criteria('groupid', (int)$group_id));
-                $criteria->add(new Criteria('uid', '(' . implode(',', $batch) . ')', 'IN'));
+                $criteria->add(new Criteria('uid', $batch, 'IN'));
                 if (!$this->membershipHandler->deleteAll($criteria)) {
                     return false;
                 }
@@ -286,7 +286,7 @@ class XoopsMemberHandler
 
         $criteria = new CriteriaCompo();
         $criteria->add(new Criteria('groupid', (int)$group_id));
-        $criteria->add(new Criteria('uid', '(' . implode(',', $ids) . ')', 'IN'));
+        $criteria->add(new Criteria('uid', $ids, 'IN'));
         return $this->membershipHandler->deleteAll($criteria);
     }
 
@@ -306,7 +306,7 @@ class XoopsMemberHandler
         }
 
         // Batch fetch users for better performance
-        $criteria = new Criteria('uid', '(' . implode(',', array_map('intval', $user_ids)) . ')', 'IN');
+        $criteria = new Criteria('uid', array_map('intval', $user_ids), 'IN');
         $users = $this->userHandler->getObjects($criteria, true);
 
         $ret = [];
@@ -332,7 +332,7 @@ class XoopsMemberHandler
         }
 
         // Batch fetch groups for better performance
-        $criteria = new Criteria('groupid', '(' . implode(',', array_map('intval', $group_ids)) . ')', 'IN');
+        $criteria = new Criteria('groupid', array_map('intval', $group_ids), 'IN');
         $groups = $this->groupHandler->getObjects($criteria, true);
 
         $ret = [];
@@ -659,8 +659,8 @@ class XoopsMemberHandler
     private function createSafeInCriteria($field, $value)
     {
         $ids = $this->sanitizeIds((array)$value);
-        $inClause = !empty($ids) ? '(' . implode(',', $ids) . ')' : '(0)';
-        return new Criteria($field, $inClause, 'IN');
+        // An empty list renders as a constant false predicate, so no '(0)' sentinel is needed.
+        return new Criteria($field, $ids, 'IN');
     }
 
     /**

--- a/htdocs/modules/pm/viewpmsg.php
+++ b/htdocs/modules/pm/viewpmsg.php
@@ -51,7 +51,7 @@ if (Request::hasVar('delete_messages', 'POST') && (Request::hasVar('msg_id', 'PO
         $confirmMsg = _MD_PM_SURE_TO_DELETE;
         $allowedIds = [];
         if (!empty($postedIds)) {
-            $criteria = new Criteria('msg_id', '(' . implode(',', $postedIds) . ')', 'IN');
+            $criteria = new Criteria('msg_id', $postedIds, 'IN');
             $pmObjects = $pm_handler->getObjects($criteria, true);
             $confirmMsg .= '<ul>';
             foreach ($postedIds as $delId) {
@@ -260,7 +260,9 @@ if (count($pm_arr) > 0) {
     }
     /** @var XoopsMemberHandler $member_handler */
     $member_handler = xoops_getHandler('member');
-    $senders        = $member_handler->getUserList(new Criteria('uid', '(' . implode(', ', array_unique($uids)) . ')', 'IN'));
+    $senders        = $member_handler->getUserList(
+        new Criteria('uid', array_values(array_unique(array_map('intval', $uids))), 'IN')
+    );
     foreach (array_keys($pm_arr) as $i) {
         $message              = $pm_arr[$i];
         // Pass the raw filename — the template applies `|escape:'url'` since

--- a/htdocs/modules/profile/admin/field.php
+++ b/htdocs/modules/profile/admin/field.php
@@ -161,7 +161,7 @@ switch ($op) {
                 //if there are changed fields, fetch the fieldcategory objects
                 /** @var XoopsModuleHandler $field_handler */
                 $field_handler = xoops_getModuleHandler('field');
-                $fields        = $field_handler->getObjects(new Criteria('field_id', '(' . implode(',', $ids) . ')', 'IN'), true);
+                $fields        = $field_handler->getObjects(new Criteria('field_id', $ids, 'IN'), true);
                 foreach ($ids as $i) {
                     $fields[$i]->setVar('field_weight', (int) $weight[$i]);
                     $fields[$i]->setVar('cat_id', (int) $category[$i]);
@@ -299,7 +299,7 @@ switch ($op) {
                         }
                         $removed_groups = array_diff(array_keys($groups), $permGroups);
                         if (count($removed_groups) > 0) {
-                            $criteria->add(new Criteria('gperm_groupid', '(' . implode(',', $removed_groups) . ')', 'IN'));
+                            $criteria->add(new Criteria('gperm_groupid', array_map('intval', $removed_groups), 'IN'));
                             $groupperm_handler->deleteAll($criteria);
                         }
                         unset($groups);

--- a/htdocs/modules/profile/include/update.php
+++ b/htdocs/modules/profile/include/update.php
@@ -160,7 +160,7 @@ function xoops_module_update_profile(XoopsModule $module, $oldversion = null)
     $profile_handler->cleanOrphan($GLOBALS['xoopsDB']->prefix('users'), 'uid', 'profile_id');
     $field_handler = xoops_getModuleHandler('field', $module->getVar('dirname', 'n'));
     $user_fields   = $field_handler->getUserVars();
-    $criteria      = new Criteria('field_name', "('" . implode("', '", $user_fields) . "')", 'IN');
+    $criteria      = new Criteria('field_name', array_values($user_fields), 'IN');
     $field_handler->updateAll('field_config', 0, $criteria);
 
     return true;

--- a/htdocs/modules/profile/search.php
+++ b/htdocs/modules/profile/search.php
@@ -262,15 +262,15 @@ switch ($op) {
                     case XOBJ_DTYPE_INT:
                         $value        = array_map('intval', $fieldValues);
                         $searchvars[] = $fieldname;
-                        $criteria->add(new Criteria($fieldname, '(' . implode(',', $value) . ')', 'IN'));
+                        $criteria->add(new Criteria($fieldname, $value, 'IN'));
                         break;
 
                     case XOBJ_DTYPE_URL:
                     case XOBJ_DTYPE_TXTBOX:
                     case XOBJ_DTYPE_TXTAREA:
-                        $value        = array_map([$GLOBALS['xoopsDB'], 'quoteString'], $fieldValues);
                         $searchvars[] = $fieldname;
-                        $criteria->add(new Criteria($fieldname, '(' . implode(',', $value) . ')', 'IN'));
+                        // Pass raw values — Criteria quotes each element; pre-quoting would double-escape.
+                        $criteria->add(new Criteria($fieldname, array_values($fieldValues), 'IN'));
                         break;
                 }
                 foreach ($fieldValues as $value) {
@@ -334,7 +334,7 @@ switch ($op) {
                                 foreach ($value as $thisvalue) {
                                     $search_url[] = $fieldname . '[]=' . $thisvalue;
                                 }
-                                $criteria->add(new Criteria($fieldname, '(' . implode(',', $value) . ')', 'IN'));
+                                $criteria->add(new Criteria($fieldname, $value, 'IN'));
                             }
 
                             $searchvars[] = $fieldname;

--- a/htdocs/modules/system/admin/users/main.php
+++ b/htdocs/modules/system/admin/users/main.php
@@ -346,7 +346,7 @@ case 'users_save':
         }
 
         if (!empty($groups_failed)) {
-            $group_names = $member_handler->getGroupList(new Criteria('groupid', '(' . implode(', ', $groups_failed) . ')', 'IN'));
+            $group_names = $member_handler->getGroupList(new Criteria('groupid', array_map('intval', $groups_failed), 'IN'));
             xoops_error(sprintf(_AM_SYSTEM_USERS_CNRNU2, implode(', ', $group_names)));
             break;
         }
@@ -931,7 +931,7 @@ case 'users_save':
                 $groups_map = [];
                 if (!empty($all_group_ids_on_page)) {
                     $groupHandler   = xoops_getHandler('group');
-                    $group_criteria = new \Criteria('groupid', '(' . implode(',', array_keys($all_group_ids_on_page)) . ')', 'IN');
+                    $group_criteria = new \Criteria('groupid', array_map('intval', array_keys($all_group_ids_on_page)), 'IN');
                     $groups_map     = $groupHandler->getObjects($group_criteria, true);
                 }
 

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -448,7 +448,7 @@ function b_system_comments_show($options)
     $moduleperm_handler = xoops_getHandler('groupperm');
     $gperm_groupid      = is_object($xoopsUser) ? $xoopsUser->getGroups() : [XOOPS_GROUP_ANONYMOUS];
     $criteria1          = new CriteriaCompo(new Criteria('gperm_name', 'module_read', '='));
-    $criteria1->add(new Criteria('gperm_groupid', '(' . implode(',', $gperm_groupid) . ')', 'IN'));
+    $criteria1->add(new Criteria('gperm_groupid', array_map('intval', $gperm_groupid), 'IN'));
     $perms  = $moduleperm_handler->getObjects($criteria1, true);
     $modIds = [];
     foreach ($perms as $item) {
@@ -456,7 +456,7 @@ function b_system_comments_show($options)
     }
     if (count($modIds) > 0) {
         $modIds = array_unique($modIds);
-        $criteria->add(new Criteria('com_modid', '(' . implode(',', $modIds) . ')', 'IN'));
+        $criteria->add(new Criteria('com_modid', array_map('intval', $modIds), 'IN'));
     }
     // Check modules permissions
 

--- a/htdocs/modules/system/class/group.php
+++ b/htdocs/modules/system/class/group.php
@@ -143,7 +143,7 @@ class SystemGroup extends XoopsGroup
         $module_list[0] = _AM_SYSTEM_GROUPS_CUSTOMBLOCK;
         /** @var XoopsBlockHandler $block_handler */
         $block_handler = xoops_getHandler('block');
-        $blocks_obj    = $block_handler->getObjects(new Criteria('mid', "('" . implode("', '", array_keys($module_list)) . "')", 'IN'), true);
+        $blocks_obj    = $block_handler->getObjects(new Criteria('mid', array_map('intval', array_keys($module_list)), 'IN'), true);
 
         $blocks_module = [];
         foreach (array_keys($blocks_obj) as $bid) {

--- a/htdocs/modules/system/include/update.php
+++ b/htdocs/modules/system/include/update.php
@@ -165,7 +165,7 @@ function update_system_v211($module)
     }
     if (count($tplids) > 0) {
         $tplfile_handler = xoops_getHandler('tplfile');
-        $duplicate_files = $tplfile_handler->getObjects(new Criteria('tpl_id', '(' . implode(',', $tplids) . ')', 'IN'));
+        $duplicate_files = $tplfile_handler->getObjects(new Criteria('tpl_id', array_map('intval', $tplids), 'IN'));
 
         if (count($duplicate_files) > 0) {
             foreach (array_keys($duplicate_files) as $i) {

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -180,7 +180,7 @@ switch ($action) {
         $module_handler = xoops_getHandler('module');
         $criteria       = new CriteriaCompo(new Criteria('hassearch', 1));
         $criteria->add(new Criteria('isactive', 1));
-        $criteria->add(new Criteria('mid', '(' . implode(',', $available_modules) . ')', 'IN'));
+        $criteria->add(new Criteria('mid', array_map('intval', $available_modules), 'IN'));
         $modules = $module_handler->getObjects($criteria, true);
         $mids    = Request::hasVar('mids', 'POST') ? Request::getArray('mids', [], 'POST') : Request::getArray('mids', [], 'GET');
         if (empty($mids) || !is_array($mids)) {

--- a/tests/unit/htdocs/class/CriteriaLegacyInUsageTest.php
+++ b/tests/unit/htdocs/class/CriteriaLegacyInUsageTest.php
@@ -76,14 +76,34 @@ final class CriteriaLegacyInUsageTest extends TestCase
         'htdocs/class/xoopseditor/',
     ];
 
+    /** Must always be in the scan set; its absence means the scan is not seeing core. */
+    private const SENTINEL_FILE = 'htdocs/class/criteria.php';
+
     #[Test]
     public function noCoreSourceUsesTheLegacyCriteriaInFormat(): void
     {
-        $offenders = [];
+        $root  = dirname(__DIR__, 4);
+        $files = self::coreSourceFiles();
 
-        foreach (self::coreSourceFiles() as $file) {
-            $lines = file(dirname(__DIR__, 4) . '/' . $file, FILE_IGNORE_NEW_LINES);
+        // A guard test that scans nothing passes vacuously, which is worse than
+        // no test at all: it reports success while protecting nothing. Both ways
+        // of ending up with an empty scan — a wrong root, or git failing so the
+        // fallback walks directories that are not there — are caught here.
+        $this->assertContains(
+            self::SENTINEL_FILE,
+            $files,
+            'Scan set does not contain ' . self::SENTINEL_FILE . ', so the scan is not '
+            . 'running over core source. Check the repository root resolution.'
+        );
+
+        $offenders  = [];
+        $unreadable = [];
+
+        foreach ($files as $file) {
+            $lines = file($root . '/' . $file, FILE_IGNORE_NEW_LINES);
             if (false === $lines) {
+                // Never skip silently — an unread file is an unscanned file.
+                $unreadable[] = $file;
                 continue;
             }
             $source = implode("\n", $lines);
@@ -104,6 +124,13 @@ final class CriteriaLegacyInUsageTest extends TestCase
                 }
             }
         }
+
+        $this->assertSame(
+            [],
+            $unreadable,
+            "Core source files could not be read, so the scan is incomplete:\n"
+            . implode("\n", $unreadable)
+        );
 
         $this->assertSame(
             [],

--- a/tests/unit/htdocs/class/CriteriaLegacyInUsageTest.php
+++ b/tests/unit/htdocs/class/CriteriaLegacyInUsageTest.php
@@ -194,9 +194,13 @@ final class CriteriaLegacyInUsageTest extends TestCase
             return null;
         }
 
+        // No 2>&1: exec() collects stdout into $output, and merging stderr in
+        // would let a git warning become an entry in the file list. A non-zero
+        // status is already the signal that there is no usable repository, and
+        // a bogus entry would now surface as an unreadable-file failure.
         $output = [];
         $status = 1;
-        exec(sprintf('git -C %s ls-files -- "*.php" 2>&1', escapeshellarg($root)), $output, $status);
+        exec(sprintf('git -C %s ls-files -- "*.php"', escapeshellarg($root)), $output, $status);
 
         if (0 !== $status || [] === $output) {
             return null;

--- a/tests/unit/htdocs/class/CriteriaLegacyInUsageTest.php
+++ b/tests/unit/htdocs/class/CriteriaLegacyInUsageTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Source-level guard against the legacy Criteria IN format.
+ *
+ * You may not change or alter any portion of this comment or credits
+ * of supporting developers from this source code or any supporting source code
+ * which is considered copyrighted (c) material of the original comment or credit authors.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * @category        Tests
+ * @package         kernel
+ * @author          XOOPS Development Team
+ * @copyright       (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license         GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @link            https://xoops.org
+ */
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Criteria` accepts two shapes for IN / NOT IN:
+ *
+ *   new Criteria('uid', [1, 2, 3], 'IN');                          // modern, escaped per element
+ *   new Criteria('uid', '(' . implode(',', $ids) . ')', 'IN');     // legacy, preformatted string
+ *
+ * The legacy shape is retained in `Criteria::render()` for third-party modules,
+ * where it emits an E_USER_DEPRECATED notice under XOOPS_DEBUG. Core itself must
+ * not use it: the caller hand-builds the SQL list, so escaping depends on every
+ * caller remembering to cast, and a value that fails validation silently collapses
+ * to a single quoted literal that matches nothing.
+ *
+ * Unit tests cannot catch this — each individual call site renders valid SQL. Only
+ * a source-level scan finds them all, which is what this test does. It is mirrored
+ * by the `.githooks/pre-commit` sniff so offenders are caught before they land.
+ */
+#[CoversNothing]
+final class CriteriaLegacyInUsageTest extends TestCase
+{
+    /**
+     * A Criteria construction whose value argument is a literal string opening
+     * with a parenthesis, on a line that also names the IN / NOT IN operator.
+     *
+     * Catches: new Criteria('user_avatar', "('', 'blank.gif')", 'IN')
+     */
+    private const LEGACY_CRITERIA_ARG = '/Criteria\s*\(.*,\s*[\'"]\(.*[\'"](NOT )?IN[\'"]/i';
+
+    /**
+     * A variable assigned a parenthesised list built by string concatenation.
+     *
+     * On its own this is legitimate — raw-SQL EXISTS subqueries in member.php and
+     * the Tailwind renderer's JS argument builder both do it. It only counts as an
+     * offence when the same variable is then handed to a Criteria as an IN value,
+     * which #INDIRECT_CRITERIA_USE checks for.
+     *
+     * Catches: $in = '(' . implode(',', $ids) . ')'   and   $in = "('" . implode("', '", $x) . "')"
+     */
+    private const HANDBUILT_LIST_ASSIGNMENT = '/(\$\w+)\s*=\s*[^;]*[\'"]\(.{0,3}\s*\.\s*implode\s*\(/';
+
+    /** Consumes a hand-built list variable as a Criteria IN value. Sprintf slot: the variable. */
+    private const INDIRECT_CRITERIA_USE = '/Criteria\s*\([^;]*%s[^;]*[\'"](NOT )?IN[\'"]/i';
+
+    /** Source roots that ship as core. */
+    private const SOURCE_ROOTS = ['htdocs', 'upgrade'];
+
+    /** Bundled third-party code we neither own nor convert. */
+    private const EXCLUDED_PATTERNS = [
+        'htdocs/xoops_lib/vendor/',
+        'htdocs/class/libraries/vendor/',
+        'htdocs/class/xoopseditor/',
+    ];
+
+    #[Test]
+    public function noCoreSourceUsesTheLegacyCriteriaInFormat(): void
+    {
+        $offenders = [];
+
+        foreach (self::coreSourceFiles() as $file) {
+            $lines = file(dirname(__DIR__, 4) . '/' . $file, FILE_IGNORE_NEW_LINES);
+            if (false === $lines) {
+                continue;
+            }
+            $source = implode("\n", $lines);
+
+            foreach ($lines as $index => $line) {
+                if (preg_match(self::LEGACY_CRITERIA_ARG, $line)) {
+                    $offenders[] = sprintf('%s:%d  %s', $file, $index + 1, trim($line));
+                    continue;
+                }
+
+                if (!preg_match(self::HANDBUILT_LIST_ASSIGNMENT, $line, $matches)) {
+                    continue;
+                }
+
+                $consumed = sprintf(self::INDIRECT_CRITERIA_USE, preg_quote($matches[1], '/'));
+                if (preg_match($consumed, $source)) {
+                    $offenders[] = sprintf('%s:%d  %s', $file, $index + 1, trim($line));
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            sprintf(
+                "%d core source line(s) build an IN list by hand. Pass an array instead —\n"
+                . "  new Criteria('uid', \$ids, 'IN')  — and let Criteria quote each element:\n\n%s\n",
+                count($offenders),
+                implode("\n", $offenders)
+            )
+        );
+    }
+
+    /**
+     * Every core PHP source file, relative to the repository root.
+     *
+     * Prefers git's index so untracked working copies (a locally extracted
+     * upgrade tree, scratch files) are never scanned; falls back to a directory
+     * walk when the tests run from an exported tarball with no git.
+     *
+     * @return list<string> repo-relative paths
+     */
+    private static function coreSourceFiles(): array
+    {
+        $root  = dirname(__DIR__, 4);
+        $files = self::gitTrackedFiles($root) ?? self::walkSourceRoots($root);
+
+        return array_values(array_filter($files, static function (string $path): bool {
+            if (!str_ends_with($path, '.php')) {
+                return false;
+            }
+            foreach (self::EXCLUDED_PATTERNS as $excluded) {
+                if (str_contains($path, $excluded)) {
+                    return false;
+                }
+            }
+            foreach (self::SOURCE_ROOTS as $sourceRoot) {
+                if (str_starts_with($path, $sourceRoot . '/')) {
+                    return true;
+                }
+            }
+
+            return false;
+        }));
+    }
+
+    /**
+     * @param  string $root repository root
+     * @return list<string>|null repo-relative paths, or null when git is unavailable
+     */
+    private static function gitTrackedFiles(string $root): ?array
+    {
+        // Do NOT probe for a .git *directory*: in a linked worktree (git worktree
+        // add) .git is a FILE pointing at the real gitdir, so that check would
+        // silently downgrade this test to a filesystem walk and start scanning
+        // untracked files. Just ask git — a non-zero status is the reliable
+        // signal that there is no usable repository here.
+        // function_exists() returns false when exec is in disabled_functions,
+        // which is why no error suppression is needed on the call itself.
+        if (!function_exists('exec')) {
+            return null;
+        }
+
+        $output = [];
+        $status = 1;
+        exec(sprintf('git -C %s ls-files -- "*.php" 2>&1', escapeshellarg($root)), $output, $status);
+
+        if (0 !== $status || [] === $output) {
+            return null;
+        }
+
+        return array_values($output);
+    }
+
+    /**
+     * @param  string $root repository root
+     * @return list<string> repo-relative paths
+     */
+    private static function walkSourceRoots(string $root): array
+    {
+        $files = [];
+
+        foreach (self::SOURCE_ROOTS as $sourceRoot) {
+            $directory = $root . '/' . $sourceRoot;
+            if (!is_dir($directory)) {
+                continue;
+            }
+
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS)
+            );
+            foreach ($iterator as $fileInfo) {
+                /** @var SplFileInfo $fileInfo */
+                $files[] = str_replace('\\', '/', substr($fileInfo->getPathname(), strlen($root) + 1));
+            }
+        }
+
+        return $files;
+    }
+}

--- a/tests/unit/htdocs/class/CriteriaTest.php
+++ b/tests/unit/htdocs/class/CriteriaTest.php
@@ -642,7 +642,26 @@ class CriteriaTest extends TestCase
     {
         $c = new Criteria('uid', [], 'IN');
 
-        $this->assertSame('`uid` IN ()', $c->render($this->db));
+        // MySQL rejects the literal `IN ()`; nothing is a member of the empty set
+        $this->assertSame('1=0', $c->render($this->db));
+    }
+
+    public function testRenderNotInWithEmptyArray(): void
+    {
+        $c = new Criteria('uid', [], 'NOT IN');
+
+        // Everything is outside the empty set
+        $this->assertSame('1=1', $c->render($this->db));
+    }
+
+    public function testRenderInWithEmptyArrayIsNotDroppedByCriteriaCompo(): void
+    {
+        // Regression: an empty IN must narrow to no rows, never vanish from the
+        // WHERE clause — CriteriaCompo silently drops fragments that render ''.
+        $compo = new CriteriaCompo(new Criteria('isactive', 1));
+        $compo->add(new Criteria('uid', [], 'IN'));
+
+        $this->assertSame('(`isactive` = 1 AND 1=0)', $compo->render($this->db));
     }
 
     public function testRenderInWithSingleElementArray(): void
@@ -656,8 +675,27 @@ class CriteriaTest extends TestCase
     {
         $c = new Criteria('uid', ['1', '2', '3'], 'IN');
 
-        // Numeric strings are cast to int
+        // Numeric STRINGS stay strings — the caller's PHP type is the intent.
+        // MySQL folds these constants for an integer column and still uses the
+        // index; casting them would break text columns, where a search for
+        // '001' must not become IN (1) and start matching '1' and ' 1'.
+        $this->assertSame("`uid` IN ('1','2','3')", $c->render($this->db));
+    }
+
+    public function testRenderInWithIntsInArrayStaysUnquoted(): void
+    {
+        $c = new Criteria('uid', [1, 2, 3], 'IN');
+
         $this->assertSame('`uid` IN (1,2,3)', $c->render($this->db));
+    }
+
+    public function testRenderInPreservesLeadingZeroStrings(): void
+    {
+        // Regression: '001' and '1' are distinct text values and must not both
+        // collapse to the integer 1.
+        $c = new Criteria('field_value', ['001', '1'], 'IN');
+
+        $this->assertSame("`field_value` IN ('001','1')", $c->render($this->db));
     }
 
     // =========================================================================
@@ -682,7 +720,26 @@ class CriteriaTest extends TestCase
     {
         $c = new Criteria('uid', '()', 'IN');
 
-        $this->assertSame('`uid` IN ()', $c->render($this->db));
+        // Same contract as the modern empty array
+        $this->assertSame('1=0', $c->render($this->db));
+    }
+
+    public function testRenderNotInWithSafeLegacyEmptyParens(): void
+    {
+        $c = new Criteria('uid', '()', 'NOT IN');
+
+        $this->assertSame('1=1', $c->render($this->db));
+    }
+
+    public function testRenderInWithWhitespaceOnlyParensIsTreatedAsMalformed(): void
+    {
+        $c = new Criteria('uid', '( )', 'IN');
+
+        // '( )' is not a recognised legacy list — only the exact '()' is. It takes
+        // the malformed path and is quoted as a single literal rather than being
+        // trusted as an empty set. Hand-built lists always produce '()' because
+        // implode() of an empty array is '', so this shape cannot arise in practice.
+        $this->assertSame("`uid` IN ('( )')", $c->render($this->db));
     }
 
     public function testRenderInWithUnsafeLegacyStringQuotesSafely(): void
@@ -1486,10 +1543,11 @@ class CriteriaTest extends TestCase
             'string list'    => ['name', ['a', 'b'], 'IN', "`name` IN ('a','b')"],
             'mixed list'     => ['val', [1, 'x', 3], 'IN', "`val` IN (1,'x',3)"],
             'single int'     => ['uid', [42], 'IN', '`uid` IN (42)'],
-            'empty list'     => ['uid', [], 'IN', '`uid` IN ()'],
+            'empty list'     => ['uid', [], 'IN', '1=0'],
+            'empty not in'   => ['uid', [], 'NOT IN', '1=1'],
             'not in ints'    => ['uid', [4, 5], 'NOT IN', '`uid` NOT IN (4,5)'],
             'not in strings' => ['s', ['a', 'b'], 'NOT IN', "`s` NOT IN ('a','b')"],
-            'numeric strings'=> ['uid', ['1', '2'], 'IN', '`uid` IN (1,2)'],
+            'numeric strings'=> ['uid', ['1', '2'], 'IN', "`uid` IN ('1','2')"],
             'negative ints'  => ['uid', [-1, -2], 'IN', '`uid` IN (-1,-2)'],
         ];
     }
@@ -1817,7 +1875,9 @@ class CriteriaTest extends TestCase
     {
         $c = new Criteria('offset', ['-10', '-20'], 'IN');
 
-        $this->assertSame('`offset` IN (-10,-20)', $c->render($this->db));
+        // Strings stay quoted; only real ints render bare (see the -10/-20/5
+        // int case above, which is unchanged).
+        $this->assertSame("`offset` IN ('-10','-20')", $c->render($this->db));
     }
 
     // =========================================================================

--- a/upgrade/cnt-2.2.x-to-2.3.0/index.php
+++ b/upgrade/cnt-2.2.x-to-2.3.0/index.php
@@ -188,7 +188,7 @@ class Upgrade_220 extends XoopsUpgrade
         }
 
         //Rebuild user configuration options
-        $criteria = new CriteriaCompo(new Criteria('conf_name', "('activation_type', 'uname_test_level')", 'IN'));
+        $criteria = new CriteriaCompo(new Criteria('conf_name', ['activation_type', 'uname_test_level'], 'IN'));
         $criteria->add(new Criteria('conf_modid', 0));
         $criteria->setSort('conf_name');
         $criteria->setOrder('ASC');


### PR DESCRIPTION
## Problem

A live site logged `Legacy Criteria IN format used for column "uid" with value "(1)"`
from `pm/viewpmsg.php`. Auditing that path turned up 24 core call sites still building
IN lists by hand, plus two real defects underneath.

`Criteria::render()` emitted the literal `IN ()` for an empty list, which MySQL rejects
as a syntax error. `search.php` hit this in production: it always added `mid IN (...)`,
even when the module-read permission list was empty.

## Changes

**Empty lists.** An empty set now renders `1=0` for IN and `1=1` for NOT IN. Returning
an empty fragment would be worse — `CriteriaCompo` drops empty fragments, so the
predicate would vanish and the query would widen to match every row.

**Array element typing.** An IN array now preserves the caller's PHP type: an int
renders as an SQL integer, anything else as a quoted string. Previously a
numeric-looking string was cast, so a text-column search for `'001'` rendered `IN (1)`
— which MySQL evaluates numerically and matches against `'1'`, `'01'` and `' 1'` — and
`['001','1']` collapsed to `IN (1,1)`. Integer columns are unaffected in practice:
MySQL folds the constants and still uses the index, and every core caller holding IDs
casts explicitly.

**24 call sites across 13 files** converted from the preformatted-string form to arrays.
Two carried defects beyond the deprecation notice: the profile search pre-quoted with
the deprecated `quoteString()` (which would double-escape once the array path quotes
again), and the user selector passed a caller-supplied value that was never cast to int.
`createSafeInCriteria()` drops its `'(0)'` sentinel, which also covers `deleteGroup`
and `deleteUser`.

## Why six test expectations changed

Three assertions expected `` `uid` IN () `` — they were pinning a query that MySQL
rejects. Three expected numeric strings to render as bare integers. Both sets are the
contract changes above, not assertions relaxed to fit the code.

## Deliberately not changed

- The legacy string path and its deprecation notice stay, for third-party modules.
- The scalar comparison path (`=`, `<`, `>`) still casts numeric strings. Same coercion,
  but changing it would alter the rendered SQL of nearly every `Criteria` in core and in
  third-party modules — it belongs in its own change.
- `member.php:531`/`:619` still build lists by hand: those are raw-SQL `EXISTS`
  subqueries, not `Criteria`.

## Regression prevention

Unit tests can't catch this class of problem — each call site renders valid SQL on its
own. `CriteriaLegacyInUsageTest` scans tracked sources for both the direct shape and the
indirect one (a hand-built list reaching a `Criteria` via a variable). It asks git for
the file list rather than probing for a `.git` directory, since `.git` is a file in a
linked worktree. Pre-commit rule 14 mirrors the direct pattern; rule 15 bans
error-suppressed `@foo()` calls.

## Testing

- Core suite: 6421 tests. The only failures are pre-existing and unrelated (two TinyMCE
  cases that reproduce identically on a clean `master` checkout).
- Upgrade tool suite: 32 tests, green.
- `php -l` clean on all changed files.
- PHPStan was not run — this repo has no root `composer.json` and CI doesn't run it, so
  no static-analysis claim is made either way.

## Summary by Sourcery

Normalize Criteria IN/NOT IN handling by rendering empty sets as constant predicates, preserving caller value types, and converting core code to array-based IN usage, backed by new tests and hooks that guard against legacy hand-built IN lists.

New Features:
- Treat empty IN and NOT IN criteria as constant true/false predicates so queries remain valid and predictable.
- Add a source-level guard test to enforce use of array-based IN/NOT IN Criteria values in core code.

Bug Fixes:
- Prevent MySQL syntax errors and unintended wide queries by avoiding literal IN () and ensuring empty IN lists narrow results to no rows.
- Fix text-column IN searches so numeric-looking strings and values with leading zeros are preserved and not collapsed via integer casting.
- Correct legacy IN list handling to safely treat validated empty lists and malformed variants without breaking escaping.
- Eliminate unsafe caller-supplied values and pre-quoting in various IN usages by passing typed arrays into Criteria.

Enhancements:
- Refine Criteria::render() to distinguish integers from strings in IN arrays and to centralize legacy IN list rendering.
- Convert multiple core call sites from hand-built IN list strings to array-based Criteria values, with explicit int casting where appropriate.

CI:
- Update the pre-commit hook configuration to mirror the legacy IN usage patterns checked by the new test and to ban error-suppressed calls.

Tests:
- Extend Criteria unit tests to cover empty IN/NOT IN behavior, CriteriaCompo interaction, and preservation of numeric string values.
- Add a dedicated CriteriaLegacyInUsageTest that scans core PHP sources (via git or filesystem) for legacy IN list patterns and indirect usages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `IN` and `NOT IN` filtering for empty lists, numeric strings, and negative values.
  * Updated user, profile, search, messaging, and administration filters to handle ID lists more reliably.
  * Preserved correct SQL behavior for empty criteria and leading-zero values.

* **Tests**
  * Added coverage to detect legacy list formatting and error-suppressed calls.
  * Expanded criteria rendering tests for empty, numeric, and malformed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->