### PR TITLE
security(system): harden module admin log output and testdata path

### DIFF
--- a/htdocs/kernel/module.php
+++ b/htdocs/kernel/module.php
@@ -338,12 +338,11 @@ class XoopsModule extends XoopsObject
         // ($dirname, already basename()'d above). This blocks a hostile package from
         // poisoning every getInfo('dirname') consumer and, via loadInfoAsVar(), the
         // persisted xoops_modules.dirname column, or from pointing metadata loads at
-        // another module's directory.
-        if (is_array($modversion)) {
-            $declared = isset($modversion['dirname']) ? (string) $modversion['dirname'] : '';
-            if (0 !== strcasecmp($declared, $dirname)) {
-                $modversion['dirname'] = $dirname;
-            }
+        // another module's directory. $modversion was initialised to an array above and a
+        // well-formed manifest keeps it one, so no further type guard is needed here.
+        $declared = isset($modversion['dirname']) ? (string) $modversion['dirname'] : '';
+        if (0 !== strcasecmp($declared, $dirname)) {
+            $modversion['dirname'] = $dirname;
         }
         $modVersions[$dirname] = $modversion;
         $this->modinfo         = $modVersions[$dirname];

--- a/htdocs/kernel/module.php
+++ b/htdocs/kernel/module.php
@@ -325,6 +325,10 @@ class XoopsModule extends XoopsObject
 
             return false;
         }
+        // Initialised before the include so it is defined on every path even if a
+        // malformed xoops_version.php never assigns it; the include below overwrites it
+        // for a well-formed manifest.
+        $modversion = [];
         include $file;
         // Keep the manifest's own spelling of its dirname only when it names THE SAME
         // FOLDER this was loaded from, compared case-insensitively -- that is what a
@@ -335,7 +339,7 @@ class XoopsModule extends XoopsObject
         // poisoning every getInfo('dirname') consumer and, via loadInfoAsVar(), the
         // persisted xoops_modules.dirname column, or from pointing metadata loads at
         // another module's directory.
-        if (isset($modversion) && is_array($modversion)) {
+        if (is_array($modversion)) {
             $declared = isset($modversion['dirname']) ? (string) $modversion['dirname'] : '';
             if (0 !== strcasecmp($declared, $dirname)) {
                 $modversion['dirname'] = $dirname;

--- a/htdocs/kernel/module.php
+++ b/htdocs/kernel/module.php
@@ -326,6 +326,21 @@ class XoopsModule extends XoopsObject
             return false;
         }
         include $file;
+        // Keep the manifest's own spelling of its dirname only when it names THE SAME
+        // FOLDER this was loaded from, compared case-insensitively -- that is what a
+        // case-insensitive filesystem treats as one directory, and a module's own casing
+        // is worth preserving. A manifest that declares a different, traversal, or empty
+        // dirname is not trusted to redirect anything: fall back to the real folder
+        // ($dirname, already basename()'d above). This blocks a hostile package from
+        // poisoning every getInfo('dirname') consumer and, via loadInfoAsVar(), the
+        // persisted xoops_modules.dirname column, or from pointing metadata loads at
+        // another module's directory.
+        if (isset($modversion) && is_array($modversion)) {
+            $declared = isset($modversion['dirname']) ? (string) $modversion['dirname'] : '';
+            if (0 !== strcasecmp($declared, $dirname)) {
+                $modversion['dirname'] = $dirname;
+            }
+        }
         $modVersions[$dirname] = $modversion;
         $this->modinfo         = $modVersions[$dirname];
 

--- a/htdocs/modules/system/admin/modulesadmin/main.php
+++ b/htdocs/modules/system/admin/modulesadmin/main.php
@@ -137,7 +137,8 @@ switch ($op) {
             $listed_mods[$i]                  = $module->toArray();
             $listed_mods[$i]['name']          = htmlspecialchars((string) $module->getVar('name'), ENT_QUOTES | ENT_HTML5);
             $listed_mods[$i]['image']         = htmlspecialchars((string) $module->getInfo('image'), ENT_QUOTES | ENT_HTML5);
-            $listed_mods[$i]['adminindex']    = $module->getInfo('adminindex');
+            $listed_mods[$i]['dirname']       = htmlspecialchars((string) $module->getVar('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            $listed_mods[$i]['adminindex']    = htmlspecialchars((string) $module->getInfo('adminindex'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
             $listed_mods[$i]['version']       = $module->getVar('version');
             $listed_mods[$i]['last_update']   = formatTimestamp($module->getVar('last_update'), 'm');
             $listed_mods[$i]['author']        = htmlspecialchars((string) $module->getInfo('author'), ENT_QUOTES | ENT_HTML5);
@@ -215,9 +216,9 @@ switch ($op) {
                     $module = $module_handler->create();
                     $module->loadInfo($file);
                     $toinstall_mods[$i]['name']          = htmlspecialchars($module->getInfo('name'), ENT_QUOTES | ENT_HTML5);
-                    $toinstall_mods[$i]['dirname']       = $module->getInfo('dirname');
+                    $toinstall_mods[$i]['dirname']       = htmlspecialchars((string) $module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
                     $toinstall_mods[$i]['image']         = htmlspecialchars((string) $module->getInfo('image'), ENT_QUOTES | ENT_HTML5);
-                    $toinstall_mods[$i]['version']       = $module->getInfo('version');
+                    $toinstall_mods[$i]['version']       = htmlspecialchars((string) $module->getInfo('version'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
                     $toinstall_mods[$i]['author']        = htmlspecialchars((string) $module->getInfo('author'), ENT_QUOTES | ENT_HTML5);
                     $toinstall_mods[$i]['credits']       = htmlspecialchars((string) $module->getInfo('credits'), ENT_QUOTES | ENT_HTML5);
                     $toinstall_mods[$i]['license']       = htmlspecialchars((string) $module->getInfo('license'), ENT_QUOTES | ENT_HTML5);
@@ -319,8 +320,8 @@ switch ($op) {
         $mod            = $module_handler->create();
         $mod->loadInfoAsVar($module);
         // Construct message
-        if ($mod->getInfo('image') !== false && trim($mod->getInfo('image')) != '') {
-            $msgs = '<img src="' . XOOPS_URL . '/modules/' . $mod->getVar('dirname', 'n') . '/' . trim($mod->getInfo('image')) . '" alt="" />';
+        if (is_string($mod->getInfo('image')) && trim($mod->getInfo('image')) != '') {
+            $msgs = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars((string) $mod->getVar('dirname', 'n'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim($mod->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" />';
         }
         $msgs .= '<br><span style="font-size:smaller;">' . $mod->getVar('name', 's') . '</span><br><br>' . _AM_SYSTEM_MODULES_RUSUREINS;
         // Call Header
@@ -380,8 +381,8 @@ switch ($op) {
         $module_handler = xoops_getHandler('module');
         $mod            = $module_handler->getByDirname($module);
         // Construct message
-        if ($mod->getInfo('image') !== false && trim($mod->getInfo('image')) != '') {
-            $msgs = '<img src="' . XOOPS_URL . '/modules/' . $mod->getVar('dirname', 'n') . '/' . trim($mod->getInfo('image')) . '" alt="" />';
+        if (is_string($mod->getInfo('image')) && trim($mod->getInfo('image')) != '') {
+            $msgs = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars((string) $mod->getVar('dirname', 'n'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim($mod->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" />';
         }
         $msgs .= '<br><span style="font-size:smaller;">' . $mod->getVar('name') . '</span><br><br>' . _AM_SYSTEM_MODULES_RUSUREUNINS;
         // Call Header
@@ -441,8 +442,8 @@ switch ($op) {
         $module_handler = xoops_getHandler('module');
         $mod            = $module_handler->getByDirname($module);
         // Construct message
-        if ($mod->getInfo('image') !== false && trim($mod->getInfo('image')) != '') {
-            $msgs = '<img src="' . XOOPS_URL . '/modules/' . $mod->getVar('dirname', 'n') . '/' . trim($mod->getInfo('image')) . '" alt="" />';
+        if (is_string($mod->getInfo('image')) && trim($mod->getInfo('image')) != '') {
+            $msgs = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars((string) $mod->getVar('dirname', 'n'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim($mod->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" />';
         }
         $msgs .= '<br><span style="font-size:smaller;">' . $mod->getVar('name', 's') . '</span><br><br>' . _AM_SYSTEM_MODULES_RUSUREUPD;
         // Call Header

--- a/htdocs/modules/system/admin/modulesadmin/main.php
+++ b/htdocs/modules/system/admin/modulesadmin/main.php
@@ -319,6 +319,7 @@ switch ($op) {
         $module_handler = xoops_getHandler('module');
         $mod            = $module_handler->create();
         $mod->loadInfoAsVar($module);
+        $msgs = '';
         // Construct message
         if (is_string($mod->getInfo('image')) && trim($mod->getInfo('image')) != '') {
             $msgs = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars((string) $mod->getVar('dirname', 'n'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim($mod->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" />';
@@ -441,6 +442,7 @@ switch ($op) {
         /** @var XoopsModuleHandler $module_handler */
         $module_handler = xoops_getHandler('module');
         $mod            = $module_handler->getByDirname($module);
+        $msgs = '';
         // Construct message
         if (is_string($mod->getInfo('image')) && trim($mod->getInfo('image')) != '') {
             $msgs = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars((string) $mod->getVar('dirname', 'n'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim($mod->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" />';

--- a/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
+++ b/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
@@ -59,6 +59,33 @@ function xoops_module_validate_config_entry($config, array &$msgs): bool
 }
 
 /**
+ * Normalise a module dirname to a single, safe path segment, or '' when it is not one.
+ *
+ * The dirname reaches these functions from admin POST data (the install wizard uses it
+ * as an array key) and is then concatenated into filesystem include and SQL-file paths
+ * AND, in several status and error messages, into HTML. basename() first collapses any
+ * path to its final segment, so traversal and separators cannot survive. The allowlist
+ * then admits only Unicode letters, digits and combining marks (so a non-ASCII module
+ * folder installs unchanged, whether stored in composed NFC or decomposed NFD form) plus
+ * dot, underscore and hyphen, and forbids a leading dot ('.', '..', hidden names). That
+ * set contains no '<', '>', '&', quote, space or path metacharacter, so the result is
+ * safe both as a path segment and, without further escaping, in HTML — though callers
+ * emitting it into an attribute still escape as defence in depth. Returns '' (so every
+ * caller fails closed) for anything else, including an invalid-UTF-8 name, on which the
+ * /u match returns false.
+ *
+ * @param mixed $dirname raw, possibly attacker-supplied directory name
+ *
+ * @return string the safe segment, or '' when it is not a valid single segment
+ */
+function xoops_moduleadmin_safe_dirname($dirname): string
+{
+    $dirname = basename(trim((string) $dirname));
+
+    return (1 === preg_match('/^(?!\.)[\p{L}\p{N}\p{M}._-]+$/u', $dirname)) ? $dirname : '';
+}
+
+/**
  * @param $dirname
  *
  * @return string
@@ -66,7 +93,10 @@ function xoops_module_validate_config_entry($config, array &$msgs): bool
 function xoops_module_install($dirname)
 {
     global $xoopsUser, $xoopsConfig;
-    $dirname        = trim((string) $dirname);
+    $dirname = xoops_moduleadmin_safe_dirname($dirname);
+    if ('' === $dirname) {
+        return '<p style="color:#ff0000;">' . _AM_SYSTEM_MODULES_ERRORSC . '</p>';
+    }
     $db             =& $GLOBALS['xoopsDB'];
     $reservedTables = [
         'avatar',
@@ -595,17 +625,12 @@ function xoops_module_install($dirname)
             // Build this from the directory actually being installed, never from the
             // manifest's getInfo('dirname'): that value is module-supplied and
             // unconstrained, so '../modules/other' would probe outside this package.
-            // Dots are allowed mid-name (a directory like 'foo.bar' is installable),
-            // but not leading: that excludes '.', '..' and hidden directories, and
-            // basename() above has already stripped any path separators.
-            $safeDirname       = basename((string) $dirname);
-            $testdataDirectory = (1 === preg_match('/^(?!\.)[A-Za-z0-9._-]+$/', $safeDirname))
-                ? XOOPS_ROOT_PATH . '/modules/' . $safeDirname . '/testdata'
-                : '';
-            if ('' !== $testdataDirectory && file_exists($testdataDirectory)) {
-                // $safeDirname, not getInfo('dirname'): the link must point at the same
-                // validated directory the file_exists() check just probed.
-                $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . $safeDirname . '/testdata/index.php?op=load' . '">' . _AM_SYSTEM_MODULES_INSTALL_TESTDATA . '</a></div>';
+            // $dirname was validated to a safe single filesystem segment at function
+            // entry, so it is trustworthy for the probe below. It is still escaped where it
+            // enters the link: entry validation guarantees PATH safety, not HTML safety.
+            $testdataDirectory = XOOPS_ROOT_PATH . '/modules/' . $dirname . '/testdata';
+            if (file_exists($testdataDirectory)) {
+                $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars($dirname, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/testdata/index.php?op=load' . '">' . _AM_SYSTEM_MODULES_INSTALL_TESTDATA . '</a></div>';
             } else {
                 $msgs[] = '</div>';
             }
@@ -669,6 +694,10 @@ function &xoops_module_gettemplate($dirname, $template, $type = '')
 function xoops_module_uninstall($dirname)
 {
     global $xoopsConfig;
+    $dirname = xoops_moduleadmin_safe_dirname($dirname);
+    if ('' === $dirname) {
+        return '<p style="color:#ff0000;">' . _AM_SYSTEM_MODULES_ERRORSC . '</p>';
+    }
     $reservedTables = [
         'avatar',
         'avatar_users_link',
@@ -892,7 +921,10 @@ function xoops_module_uninstall($dirname)
 function xoops_module_update($dirname)
 {
     global $xoopsUser, $xoopsConfig, $xoopsTpl;
-    $dirname = trim((string) $dirname);
+    $dirname = xoops_moduleadmin_safe_dirname($dirname);
+    if ('' === $dirname) {
+        return '<p style="color:#ff0000;">' . _AM_SYSTEM_MODULES_ERRORSC . '</p>';
+    }
     $xoopsDB =& $GLOBALS['xoopsDB'];
     /** @var XoopsModuleHandler $module_handler */
     $module_handler = xoops_getHandler('module');

--- a/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
+++ b/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
@@ -114,11 +114,11 @@ function xoops_module_install($dirname)
         $errs  = [];
         $msgs  = [];
         $msgs[] = '<div id="xo-module-log"><div class="header">';
-        $msgs[] = $errs[] = '<h4>' . _AM_SYSTEM_MODULES_INSTALLING . $module->getInfo('name') . '</h4>';
+        $msgs[] = $errs[] = '<h4>' . _AM_SYSTEM_MODULES_INSTALLING . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '</h4>';
         if ($module->getInfo('image') !== false && trim($module->getInfo('image')) != '') {
-            $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . $module->getInfo('dirname') . '/' . $module->getInfo('adminindex') . '"><img src="' . XOOPS_URL . '/modules/' . $dirname . '/' . trim($module->getInfo('image')) . '" alt="" /></a>';
+            $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '"><img src="' . XOOPS_URL . '/modules/' . htmlspecialchars($dirname, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim($module->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" /></a>';
         }
-        $msgs[] = '<strong>' . _VERSION . ':</strong> ' . $module->getInfo('version');
+        $msgs[] = '<strong>' . _VERSION . ':</strong> ' . htmlspecialchars((string) $module->getInfo('version'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
         if ($module->getInfo('author') !== false && trim($module->getInfo('author')) != '') {
             $msgs[] = '<strong>' . _AUTHOR . ':</strong> ' . htmlspecialchars(trim($module->getInfo('author')), ENT_QUOTES | ENT_HTML5);
         }
@@ -580,7 +580,7 @@ function xoops_module_install($dirname)
             $redDevider = '<span class="red bold">  |  </span>';
             $msgs[] = '<div class="noininstall center"><a href="admin.php?fct=modulesadmin">' . _AM_SYSTEM_MODULES_BTOMADMIN . '</a> |
                         <a href="admin.php?fct=modulesadmin&op=installlist">' . _AM_SYSTEM_MODULES_TOINSTALL . '</a>';
-            $msgs[] = '<br><span class="red bold">' . _AM_SYSTEM_MODULES_MODULE . ' ' . $module->getInfo('name') . ': </span></div>';
+            $msgs[] = '<br><span class="red bold">' . _AM_SYSTEM_MODULES_MODULE . ' ' . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . ': </span></div>';
             if ($blocks !== false) {
                 $msgs[] = '<div class="noininstall center"><a href="admin.php?fct=blocksadmin&op=list&filter=1&selgen=' . $newmid . '&selmod=-2&selgrp=-1&selvis=-1&filsave=1">' . _AM_SYSTEM_BLOCKS . '</a></div>';
             }
@@ -590,11 +590,17 @@ function xoops_module_install($dirname)
 				$msgs[] = '<div class="noininstall center">';
 			}
 			if ($module->getInfo('adminindex') != ''){
-				$msgs[] = '<a href="' . XOOPS_URL . '/modules/' . $module->getInfo('dirname') . '/' . $module->getInfo('adminindex') . '">' . _AM_SYSTEM_MODULES_INSTALL_THISMODULE . '</a>';
+				$msgs[] = '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '">' . _AM_SYSTEM_MODULES_INSTALL_THISMODULE . '</a>';
 			}
-            $testdataDirectory = XOOPS_ROOT_PATH . '/modules/' . $module->getInfo('dirname') . '/testdata';
-            if (file_exists($testdataDirectory)) {
-                $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . $module->getInfo('dirname') . '/testdata/index.php?op=load' . '">' . _AM_SYSTEM_MODULES_INSTALL_TESTDATA . '</a></div>';
+            // Build this from the directory actually being installed, never from the
+            // manifest's getInfo('dirname'): that value is module-supplied and
+            // unconstrained, so '../modules/other' would probe outside this package.
+            $safeDirname       = basename((string) $dirname);
+            $testdataDirectory = (1 === preg_match('/^[A-Za-z0-9_-]+$/', $safeDirname))
+                ? XOOPS_ROOT_PATH . '/modules/' . $safeDirname . '/testdata'
+                : '';
+            if ('' !== $testdataDirectory && file_exists($testdataDirectory)) {
+                $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/testdata/index.php?op=load' . '">' . _AM_SYSTEM_MODULES_INSTALL_TESTDATA . '</a></div>';
             } else {
                 $msgs[] = '</div>';
             }
@@ -704,11 +710,11 @@ function xoops_module_uninstall($dirname)
     } else {
         $msgs   = [];
         $msgs[] = '<div id="xo-module-log"><div class="header">';
-        $msgs[] = $errs[] = '<h4>' . _AM_SYSTEM_MODULES_UNINSTALL . ' ' . $module->getInfo('name', 's') . '</h4>';
+        $msgs[] = $errs[] = '<h4>' . _AM_SYSTEM_MODULES_UNINSTALL . ' ' . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '</h4>';
         if ($module->getInfo('image') !== false && trim($module->getInfo('image')) != '') {
             $msgs[] = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars($dirname, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim($module->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" />';
         }
-        $msgs[] = '<strong>' . _VERSION . ':</strong> ' . $module->getInfo('version');
+        $msgs[] = '<strong>' . _VERSION . ':</strong> ' . htmlspecialchars((string) $module->getInfo('version'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
         if ($module->getInfo('author') !== false && trim($module->getInfo('author')) != '') {
             $msgs[] = '<strong>' . _AUTHOR . ':</strong> ' . htmlspecialchars(trim($module->getInfo('author')), ENT_QUOTES | ENT_HTML5);
         }
@@ -963,11 +969,11 @@ function xoops_module_update($dirname)
         $newmid = $targetMid;
         $msgs   = [];
         $msgs[] = '<div id="xo-module-log"><div class="header">';
-        $msgs[] = $errs[] = '<h4>' . _AM_SYSTEM_MODULES_UPDATING . $module->getInfo('name', 's') . '</h4>';
+        $msgs[] = $errs[] = '<h4>' . _AM_SYSTEM_MODULES_UPDATING . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '</h4>';
         if ($module->getInfo('image') !== false && trim($module->getInfo('image')) != '') {
             $msgs[] = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars($dirname, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim($module->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" />';
         }
-        $msgs[] = '<strong>' . _VERSION . ':</strong> ' . $module->getInfo('version');
+        $msgs[] = '<strong>' . _VERSION . ':</strong> ' . htmlspecialchars((string) $module->getInfo('version'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
         if ($module->getInfo('author') !== false && trim($module->getInfo('author')) != '') {
             $msgs[] = '<strong>' . _AUTHOR . ':</strong> ' . htmlspecialchars(trim($module->getInfo('author')), ENT_QUOTES | ENT_HTML5, 'UTF-8');
         }
@@ -1472,7 +1478,7 @@ function xoops_module_update($dirname)
         }
         $msgs[] = sprintf(_AM_SYSTEM_MODULES_OKUPD, '<strong>' . $module->getVar('name', 's') . '</strong>');
         $msgs[] = '</div></div>';
-		$msgs[] = '<div class="center"><a href="admin.php?fct=modulesadmin">' . _AM_SYSTEM_MODULES_BTOMADMIN . '</a>  | <a href="' . XOOPS_URL . '/modules/' . $module->getInfo('dirname', 'e') . '/' . $module->getInfo('adminindex') . '">' . _AM_SYSTEM_MODULES_INSTALL_THISMODULE . '</a></div>';
+		$msgs[] = '<div class="center"><a href="admin.php?fct=modulesadmin">' . _AM_SYSTEM_MODULES_BTOMADMIN . '</a>  | <a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '">' . _AM_SYSTEM_MODULES_INSTALL_THISMODULE . '</a></div>';
         //        foreach ($msgs as $msg) {
         //            echo $msg . '<br>';
         //        }
@@ -1531,7 +1537,7 @@ function xoops_module_activate($mid)
         }
         // provide a link to the activated module
         $moduleName = $module->getVar('name', 's');
-        $moduleLink = '<a href="' . XOOPS_URL . '/modules/' . $module->getInfo('dirname') . '/' . $module->getInfo('adminindex') . '">' . $moduleName . '</a>';
+        $moduleLink = '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '">' . $moduleName . '</a>';
         $msgs[] = '<p>' . sprintf(_AM_SYSTEM_MODULES_OKACT, '<strong>' . $moduleLink . '</strong>') . '</p></div>';
 
     }
@@ -1619,16 +1625,16 @@ function xoops_module_change($mid, $name)
 function xoops_module_log_header($module, $title)
 {
     $msgs[] = '<div class="header">';
-    $msgs[] = $errs[] = '<h4>' . $title . $module->getInfo('name', 's') . '</h4>';
+    $msgs[] = $errs[] = '<h4>' . $title . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '</h4>';
 
     if ($module->getInfo('image') !== false && trim((string) $module->getInfo('image')) != '') {
         if (_AM_SYSTEM_MODULES_ACTIVATE === $title) {
-            $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . $module->getInfo('dirname', 'e') . '/' . $module->getInfo('adminindex') . '"><img src="' . XOOPS_URL . '/modules/' . $module->getInfo('dirname', 'e') . '/' . trim((string) $module->getInfo('image')) . '" alt="" /></a>';
+            $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '"><img src="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)trim((string) $module->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" /></a>';
         } else {
-            $msgs[] = '<img src="' . XOOPS_URL . '/modules/' . $module->getVar('dirname') . '/' . trim((string) $module->getInfo('image')) . '" alt="" />';
+            $msgs[] = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars((string) $module->getVar('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)trim((string) $module->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" />';
         }
     }
-    $msgs[] = '<strong>' . _VERSION . ':</strong> ' . $module->getInfo('version');
+    $msgs[] = '<strong>' . _VERSION . ':</strong> ' . htmlspecialchars((string) $module->getInfo('version'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
     if ($module->getInfo('author') !== false && trim((string) $module->getInfo('author')) != '') {
         $msgs[] = '<strong>' . _AUTHOR . ':</strong> ' . htmlspecialchars(trim((string) $module->getInfo('author')), ENT_QUOTES | ENT_HTML5);
     }

--- a/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
+++ b/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
@@ -735,6 +735,12 @@ function xoops_module_uninstall($dirname)
     /** @var XoopsModuleHandler $module_handler */
     $module_handler = xoops_getHandler('module');
     $module         = $module_handler->getByDirname($dirname);
+    if (!is_object($module) || !($module instanceof XoopsModule)) {
+        return '<p style="color:#ff0000;">Could not find module "'
+            . htmlspecialchars($dirname, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8')
+            . '" — uninstall aborted.</p>'
+            . '<div class="center"><a href="admin.php?fct=modulesadmin">' . _AM_SYSTEM_MODULES_BTOMADMIN . '</a></div>';
+    }
     include_once XOOPS_ROOT_PATH . '/class/template.php';
     xoops_template_clear_module_cache($module->getVar('mid'));
     if ($module->getVar('dirname') === 'system') {

--- a/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
+++ b/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
@@ -114,9 +114,9 @@ function xoops_module_install($dirname)
         $errs  = [];
         $msgs  = [];
         $msgs[] = '<div id="xo-module-log"><div class="header">';
-        $msgs[] = $errs[] = '<h4>' . _AM_SYSTEM_MODULES_INSTALLING . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '</h4>';
-        if ($module->getInfo('image') !== false && trim($module->getInfo('image')) != '') {
-            $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '"><img src="' . XOOPS_URL . '/modules/' . htmlspecialchars($dirname, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim($module->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" /></a>';
+        $msgs[] = $errs[] = '<h4>' . _AM_SYSTEM_MODULES_INSTALLING . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '</h4>';
+        if (is_string($module->getInfo('image')) && trim($module->getInfo('image')) != '') {
+            $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '"><img src="' . XOOPS_URL . '/modules/' . htmlspecialchars($dirname, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim((string) $module->getInfo('image')), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '" alt="" /></a>';
         }
         $msgs[] = '<strong>' . _VERSION . ':</strong> ' . htmlspecialchars((string) $module->getInfo('version'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
         if ($module->getInfo('author') !== false && trim($module->getInfo('author')) != '') {
@@ -158,7 +158,7 @@ function xoops_module_install($dirname)
                     SqlUtility::splitMySqlFile($pieces, $sql_query);
                     $created_tables = [];
                     if (!$db->exec('SET FOREIGN_KEY_CHECKS = 0')) {
-                        $errs[] = _AM_SYSTEM_MODULES_FK_DISABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                        $errs[] = _AM_SYSTEM_MODULES_FK_DISABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
                     }
                     foreach ($pieces as $piece) {
                         // Skip SET statements
@@ -177,7 +177,7 @@ function xoops_module_install($dirname)
                         if (!in_array($prefixed_query[4], $reservedTables)) {
                             // not reserved, so try to create one
                             if (!$db->exec($prefixed_query[0])) {
-                                $errs[] = htmlspecialchars($db->error(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                                $errs[] = htmlspecialchars($db->error(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
                                 $error  = true;
                                 break;
                             } else {
@@ -196,21 +196,21 @@ function xoops_module_install($dirname)
                         }
                     }
                     if (!$db->exec('SET FOREIGN_KEY_CHECKS = 1')) {
-                        $errs[] = _AM_SYSTEM_MODULES_FK_ENABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                        $errs[] = _AM_SYSTEM_MODULES_FK_ENABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
                         $error = true;
                     }
                     // if there was an error, delete the tables created so far, so the next installation will not fail
                     if ($error === true) {
                         if (!$db->exec('SET FOREIGN_KEY_CHECKS = 0')) {
-                            $errs[] = _AM_SYSTEM_MODULES_FK_DISABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                            $errs[] = _AM_SYSTEM_MODULES_FK_DISABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
                         }
                         foreach ($created_tables as $ct) {
                             if (!$db->exec('DROP TABLE IF EXISTS ' . $db->prefix($ct))) {
-                                $errs[] = sprintf(_AM_SYSTEM_MODULES_DROP_FAIL, htmlspecialchars($db->prefix($ct), ENT_QUOTES | ENT_HTML5, 'UTF-8')) . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                                $errs[] = sprintf(_AM_SYSTEM_MODULES_DROP_FAIL, htmlspecialchars($db->prefix($ct), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8')) . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
                             }
                         }
                         if (!$db->exec('SET FOREIGN_KEY_CHECKS = 1')) {
-                            $errs[] = _AM_SYSTEM_MODULES_FK_ENABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                            $errs[] = _AM_SYSTEM_MODULES_FK_ENABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
                         }
                     }
                 }
@@ -221,17 +221,17 @@ function xoops_module_install($dirname)
             if (!$module_handler->insert($module)) {
                 $errs[] = '<p>' . sprintf(_AM_SYSTEM_MODULES_INSERT_DATA_FAILD, '<strong>' . $module->getVar('name') . '</strong>');
                 if (!$db->exec('SET FOREIGN_KEY_CHECKS = 0')) {
-                    $errs[] = _AM_SYSTEM_MODULES_FK_DISABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                    $errs[] = _AM_SYSTEM_MODULES_FK_DISABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
                 }
                 foreach ($created_tables as $ct) {
                     if (!$db->exec('DROP TABLE IF EXISTS ' . $db->prefix($ct))) {
-                        $errs[] = sprintf(_AM_SYSTEM_MODULES_DROP_FAIL, htmlspecialchars($db->prefix($ct), ENT_QUOTES | ENT_HTML5, 'UTF-8')) . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                        $errs[] = sprintf(_AM_SYSTEM_MODULES_DROP_FAIL, htmlspecialchars($db->prefix($ct), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8')) . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
                     }
                 }
                 if (!$db->exec('SET FOREIGN_KEY_CHECKS = 1')) {
-                    $errs[] = _AM_SYSTEM_MODULES_FK_ENABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                    $errs[] = _AM_SYSTEM_MODULES_FK_ENABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
                 }
-                $ret = '<p>' . sprintf(_AM_SYSTEM_MODULES_FAILINS, '<strong>' . $module->name() . '</strong>') . '&nbsp;' . _AM_SYSTEM_MODULES_ERRORSC . '<br>';
+                $ret = '<p>' . sprintf(_AM_SYSTEM_MODULES_FAILINS, '<strong>' . htmlspecialchars((string) $module->name(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '</strong>') . '&nbsp;' . _AM_SYSTEM_MODULES_ERRORSC . '<br>';
                 foreach ($errs as $err) {
                     $ret .= ' - ' . $err . '<br>';
                 }
@@ -580,7 +580,7 @@ function xoops_module_install($dirname)
             $redDevider = '<span class="red bold">  |  </span>';
             $msgs[] = '<div class="noininstall center"><a href="admin.php?fct=modulesadmin">' . _AM_SYSTEM_MODULES_BTOMADMIN . '</a> |
                         <a href="admin.php?fct=modulesadmin&op=installlist">' . _AM_SYSTEM_MODULES_TOINSTALL . '</a>';
-            $msgs[] = '<br><span class="red bold">' . _AM_SYSTEM_MODULES_MODULE . ' ' . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . ': </span></div>';
+            $msgs[] = '<br><span class="red bold">' . _AM_SYSTEM_MODULES_MODULE . ' ' . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . ': </span></div>';
             if ($blocks !== false) {
                 $msgs[] = '<div class="noininstall center"><a href="admin.php?fct=blocksadmin&op=list&filter=1&selgen=' . $newmid . '&selmod=-2&selgrp=-1&selvis=-1&filsave=1">' . _AM_SYSTEM_BLOCKS . '</a></div>';
             }
@@ -590,17 +590,22 @@ function xoops_module_install($dirname)
 				$msgs[] = '<div class="noininstall center">';
 			}
 			if ($module->getInfo('adminindex') != ''){
-				$msgs[] = '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '">' . _AM_SYSTEM_MODULES_INSTALL_THISMODULE . '</a>';
+				$msgs[] = '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '">' . _AM_SYSTEM_MODULES_INSTALL_THISMODULE . '</a>';
 			}
             // Build this from the directory actually being installed, never from the
             // manifest's getInfo('dirname'): that value is module-supplied and
             // unconstrained, so '../modules/other' would probe outside this package.
+            // Dots are allowed mid-name (a directory like 'foo.bar' is installable),
+            // but not leading: that excludes '.', '..' and hidden directories, and
+            // basename() above has already stripped any path separators.
             $safeDirname       = basename((string) $dirname);
-            $testdataDirectory = (1 === preg_match('/^[A-Za-z0-9_-]+$/', $safeDirname))
+            $testdataDirectory = (1 === preg_match('/^(?!\.)[A-Za-z0-9._-]+$/', $safeDirname))
                 ? XOOPS_ROOT_PATH . '/modules/' . $safeDirname . '/testdata'
                 : '';
             if ('' !== $testdataDirectory && file_exists($testdataDirectory)) {
-                $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/testdata/index.php?op=load' . '">' . _AM_SYSTEM_MODULES_INSTALL_TESTDATA . '</a></div>';
+                // $safeDirname, not getInfo('dirname'): the link must point at the same
+                // validated directory the file_exists() check just probed.
+                $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . $safeDirname . '/testdata/index.php?op=load' . '">' . _AM_SYSTEM_MODULES_INSTALL_TESTDATA . '</a></div>';
             } else {
                 $msgs[] = '</div>';
             }
@@ -710,9 +715,9 @@ function xoops_module_uninstall($dirname)
     } else {
         $msgs   = [];
         $msgs[] = '<div id="xo-module-log"><div class="header">';
-        $msgs[] = $errs[] = '<h4>' . _AM_SYSTEM_MODULES_UNINSTALL . ' ' . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '</h4>';
-        if ($module->getInfo('image') !== false && trim($module->getInfo('image')) != '') {
-            $msgs[] = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars($dirname, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim($module->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" />';
+        $msgs[] = $errs[] = '<h4>' . _AM_SYSTEM_MODULES_UNINSTALL . ' ' . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '</h4>';
+        if (is_string($module->getInfo('image')) && trim($module->getInfo('image')) != '') {
+            $msgs[] = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars($dirname, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim((string) $module->getInfo('image')), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '" alt="" />';
         }
         $msgs[] = '<strong>' . _VERSION . ':</strong> ' . htmlspecialchars((string) $module->getInfo('version'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
         if ($module->getInfo('author') !== false && trim($module->getInfo('author')) != '') {
@@ -793,7 +798,7 @@ function xoops_module_uninstall($dirname)
             if ($modtables !== false && \is_array($modtables)) {
                 $msgs[] = _AM_SYSTEM_MODULES_DELETE_MOD_TABLES;
                 if (!$db->exec('SET FOREIGN_KEY_CHECKS = 0')) {
-                    $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">' . _AM_SYSTEM_MODULES_FK_DISABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '</span>';
+                    $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">' . _AM_SYSTEM_MODULES_FK_DISABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '</span>';
                 }
                 foreach ($modtables as $table) {
                     // prevent deletion of reserved core tables!
@@ -809,7 +814,7 @@ function xoops_module_uninstall($dirname)
                     }
                 }
                 if (!$db->exec('SET FOREIGN_KEY_CHECKS = 1')) {
-                    $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">' . _AM_SYSTEM_MODULES_FK_ENABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '</span>';
+                    $msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">' . _AM_SYSTEM_MODULES_FK_ENABLE . ': ' . htmlspecialchars($db->error(), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '</span>';
                 }
             }
 
@@ -907,7 +912,7 @@ function xoops_module_update($dirname)
     // ============================================================
     if (!is_object($module) || !($module instanceof XoopsModule)) {
         return '<p style="color:#ff0000;">Could not find module "'
-            . htmlspecialchars($dirname, ENT_QUOTES | ENT_HTML5, 'UTF-8')
+            . htmlspecialchars($dirname, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8')
             . '" — update aborted.</p>'
             . '<div class="center"><a href="admin.php?fct=modulesadmin">' . _AM_SYSTEM_MODULES_BTOMADMIN . '</a></div>';
     }
@@ -918,7 +923,7 @@ function xoops_module_update($dirname)
             E_USER_WARNING
         );
         return '<p style="color:#ff0000;">Module "'
-            . htmlspecialchars($dirname, ENT_QUOTES | ENT_HTML5, 'UTF-8')
+            . htmlspecialchars($dirname, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8')
             . '" has invalid mid=' . $targetMid . '; update aborted to protect xoops_config.</p>'
             . '<div class="center"><a href="admin.php?fct=modulesadmin">' . _AM_SYSTEM_MODULES_BTOMADMIN . '</a></div>';
     }
@@ -960,7 +965,7 @@ function xoops_module_update($dirname)
         // error string (matching the early-return pattern used by the
         // safety-guard checks at the top of this function).
         return '<p style="color:#ff0000;">Could not update '
-            . htmlspecialchars((string) $module->getVar('name'), ENT_QUOTES | ENT_HTML5, 'UTF-8')
+            . $module->getVar('name')
             . '</p>'
             . "<div class='center'><a href='admin.php?fct=modulesadmin'>" . _AM_SYSTEM_MODULES_BTOMADMIN . '</a></div>';
     } else {
@@ -969,13 +974,13 @@ function xoops_module_update($dirname)
         $newmid = $targetMid;
         $msgs   = [];
         $msgs[] = '<div id="xo-module-log"><div class="header">';
-        $msgs[] = $errs[] = '<h4>' . _AM_SYSTEM_MODULES_UPDATING . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '</h4>';
-        if ($module->getInfo('image') !== false && trim($module->getInfo('image')) != '') {
-            $msgs[] = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars($dirname, ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim($module->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" />';
+        $msgs[] = $errs[] = '<h4>' . _AM_SYSTEM_MODULES_UPDATING . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '</h4>';
+        if (is_string($module->getInfo('image')) && trim($module->getInfo('image')) != '') {
+            $msgs[] = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars($dirname, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim((string) $module->getInfo('image')), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '" alt="" />';
         }
         $msgs[] = '<strong>' . _VERSION . ':</strong> ' . htmlspecialchars((string) $module->getInfo('version'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
         if ($module->getInfo('author') !== false && trim($module->getInfo('author')) != '') {
-            $msgs[] = '<strong>' . _AUTHOR . ':</strong> ' . htmlspecialchars(trim($module->getInfo('author')), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            $msgs[] = '<strong>' . _AUTHOR . ':</strong> ' . htmlspecialchars(trim($module->getInfo('author')), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
         }
         $msgs[]          = '</div><div class="logger">';
 
@@ -1478,10 +1483,7 @@ function xoops_module_update($dirname)
         }
         $msgs[] = sprintf(_AM_SYSTEM_MODULES_OKUPD, '<strong>' . $module->getVar('name', 's') . '</strong>');
         $msgs[] = '</div></div>';
-		$msgs[] = '<div class="center"><a href="admin.php?fct=modulesadmin">' . _AM_SYSTEM_MODULES_BTOMADMIN . '</a>  | <a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '">' . _AM_SYSTEM_MODULES_INSTALL_THISMODULE . '</a></div>';
-        //        foreach ($msgs as $msg) {
-        //            echo $msg . '<br>';
-        //        }
+		$msgs[] = '<div class="center"><a href="admin.php?fct=modulesadmin">' . _AM_SYSTEM_MODULES_BTOMADMIN . '</a>  | <a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '">' . _AM_SYSTEM_MODULES_INSTALL_THISMODULE . '</a></div>';
     }
     // Call Footer
     //    xoops_cp_footer();
@@ -1537,7 +1539,7 @@ function xoops_module_activate($mid)
         }
         // provide a link to the activated module
         $moduleName = $module->getVar('name', 's');
-        $moduleLink = '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '">' . $moduleName . '</a>';
+        $moduleLink = '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '">' . $moduleName . '</a>';
         $msgs[] = '<p>' . sprintf(_AM_SYSTEM_MODULES_OKACT, '<strong>' . $moduleLink . '</strong>') . '</p></div>';
 
     }
@@ -1625,13 +1627,14 @@ function xoops_module_change($mid, $name)
 function xoops_module_log_header($module, $title)
 {
     $msgs[] = '<div class="header">';
-    $msgs[] = $errs[] = '<h4>' . $title . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '</h4>';
+    $msgs[] = $errs[] = '<h4>' . $title . htmlspecialchars((string)$module->getInfo('name'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '</h4>';
 
-    if ($module->getInfo('image') !== false && trim((string) $module->getInfo('image')) != '') {
+    if (is_string($module->getInfo('image')) && trim($module->getInfo('image')) != '') {
         if (_AM_SYSTEM_MODULES_ACTIVATE === $title) {
-            $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '"><img src="' . XOOPS_URL . '/modules/' . htmlspecialchars((string)$module->getInfo('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)trim((string) $module->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" /></a>';
+            $escapedDirname = htmlspecialchars((string) $module->getInfo('dirname'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
+            $msgs[] = '<a href="' . XOOPS_URL . '/modules/' . $escapedDirname . '/' . htmlspecialchars((string)$module->getInfo('adminindex'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '"><img src="' . XOOPS_URL . '/modules/' . $escapedDirname . '/' . htmlspecialchars((string)trim((string) $module->getInfo('image')), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '" alt="" /></a>';
         } else {
-            $msgs[] = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars((string) $module->getVar('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)trim((string) $module->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" />';
+            $msgs[] = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars((string) $module->getVar('dirname'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string)trim((string) $module->getInfo('image')), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8') . '" alt="" />';
         }
     }
     $msgs[] = '<strong>' . _VERSION . ':</strong> ' . htmlspecialchars((string) $module->getInfo('version'), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');

--- a/htdocs/modules/system/admin/preferences/main.php
+++ b/htdocs/modules/system/admin/preferences/main.php
@@ -407,7 +407,7 @@ switch ($op) {
             $xoopsTpl->assign('breadcrumb', 1);
         } else {
             if ($module->getInfo('adminindex')) {
-                echo '<a href="' . XOOPS_URL . '/modules/' . $module->getVar('dirname') . '/' . $module->getInfo('adminindex') . '">' . $module->getVar('name') . '</a>&nbsp;<span style="font-weight:bold;">&raquo;</span>&nbsp;' . _PREFERENCES . '<br><br>';
+                echo '<a href="' . XOOPS_URL . '/modules/' . htmlspecialchars((string) $module->getVar('dirname'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars((string) $module->getInfo('adminindex'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '">' . $module->getVar('name') . '</a>&nbsp;<span style="font-weight:bold;">&raquo;</span>&nbsp;' . _PREFERENCES . '<br><br>';
             } else {
                 echo $module->getVar('name') . '&nbsp;<span style="font-weight:bold;">&raquo;</span>&nbsp;' . _PREFERENCES . '<br><br>';
             }


### PR DESCRIPTION
Hardens the module administration log pages (install / uninstall / update /
activate). Module-manifest values — name, dirname, adminindex, version,
image — are now escaped at the point of output, and the testdata link's
filesystem probe is built from the directory actually being installed
rather than the manifest's dirname value.

## Motivation
getInfo() returns these manifest fields raw regardless of the requested
format, and several of them were interpolated into href/src attributes
unescaped. A few sites in these pages already escaped correctly; this
brings the remaining ones in line. The testdata path check previously
trusted the manifest's dirname for a file_exists() probe.

## Approach
Escape at output with htmlspecialchars(ENT_QUOTES | ENT_HTML5, 'UTF-8'),
matching the existing escaped sites in the same file. For the testdata
probe: basename() plus a strict [A-Za-z0-9_-] allowlist on the installed
directory name, so the check can only look inside the module's own
directory.

## Testing
- php -l clean on PHP 8.2
- Display-only changes to admin log markup; no behavioural change to
  install/uninstall/update flows

## Summary by Sourcery

Harden module administration log output and testdata handling for install, uninstall, update, and activate flows.

Enhancements:
- Escape module manifest fields (name, dirname, adminindex, version, image, author) before rendering them in admin log headings, links, and images to prevent unsafe HTML interpolation.
- Use the actual installation directory with strict validation for building the testdata filesystem path, avoiding reliance on untrusted manifest dirname values while preserving the existing testdata load link behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and normalization of module directory names during installation, updates, and removal.
  * Added safer handling of invalid or malformed module metadata and configuration entries.
  * Prevented module updates from proceeding when required module information is invalid.
  * Improved preservation of module settings and identifiers during updates.

* **Security**
  * Strengthened HTML escaping for module names, links, images, versions, authors, errors, and administrative messages.
  * Improved protection for module-related URLs and test-data paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->