### PR TITLE
fix(system): guard getByDirname() on the uninstall and update confirm screens

### DIFF
--- a/htdocs/modules/system/admin/modulesadmin/main.php
+++ b/htdocs/modules/system/admin/modulesadmin/main.php
@@ -381,6 +381,9 @@ switch ($op) {
         /** @var XoopsModuleHandler $module_handler */
         $module_handler = xoops_getHandler('module');
         $mod            = $module_handler->getByDirname($module);
+        if (!is_object($mod)) {
+            redirect_header('admin.php?fct=modulesadmin', 3, sprintf(_AM_SYSTEM_MODULES_DELETE_ERROR, $module));
+        }
         // Construct message
         if (is_string($mod->getInfo('image')) && trim($mod->getInfo('image')) != '') {
             $msgs = '<img src="' . XOOPS_URL . '/modules/' . htmlspecialchars((string) $mod->getVar('dirname', 'n'), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '/' . htmlspecialchars(trim($mod->getInfo('image')), ENT_QUOTES | ENT_HTML5, 'UTF-8') . '" alt="" />';
@@ -442,6 +445,9 @@ switch ($op) {
         /** @var XoopsModuleHandler $module_handler */
         $module_handler = xoops_getHandler('module');
         $mod            = $module_handler->getByDirname($module);
+        if (!is_object($mod)) {
+            redirect_header('admin.php?fct=modulesadmin', 3, sprintf(_AM_SYSTEM_MODULES_UPDATE_ERROR, $module));
+        }
         $msgs = '';
         // Construct message
         if (is_string($mod->getInfo('image')) && trim($mod->getInfo('image')) != '') {


### PR DESCRIPTION
## Summary
The uninstall and update confirmation screens in the modules admin
(`system/admin/modulesadmin/main.php`) resolve the target module with
`getByDirname()` and then dereference the result to build the confirmation
message. When the dirname names no installed module, `getByDirname()` returns
`false`, so a crafted request fataled on the following `getInfo()` call.

## Motivation
`admin.php?fct=modulesadmin&op=uninstall&module=<not-installed>` (and the same
for `op=update`) produced a fatal error instead of a graceful message. The
corresponding action paths (`uninstall_ok`, `update_ok`) already guard the same
lookup; only the confirm screens were missing it.

## Approach
Add `if (!is_object($mod)) { redirect_header(..., sprintf(_AM_SYSTEM_MODULES_*_ERROR, $module)); }`
immediately after each `getByDirname()`, mirroring the existing `_ok` guards
verbatim (same redirect target and language constants).

## Testing
- `php -l` clean on 8.2
- MainControllerTest: 55/55 green on PHP 8.4
- Admin-only path behind CSRF; no behavioural change for valid modules

## Summary by Sourcery

Guard module resolution failures on the uninstall and update confirmation screens in the system modules admin to prevent fatals when a non-installed module dirname is requested.

Bug Fixes:
- Handle missing modules on uninstall confirmation by redirecting with an error message instead of fataling when getByDirname() returns false.
- Handle missing modules on update confirmation by redirecting with an error message instead of fataling when getByDirname() returns false.