### PR TITLE
File-based debug configuration, and the error-screen provider seam

### DIFF
--- a/htdocs/class/file/folder.php
+++ b/htdocs/class/file/folder.php
@@ -311,9 +311,25 @@ class XoopsFolderHandler
      */
     public function isAbsolute($path)
     {
-        $match = preg_match('/^\\//', $path) || preg_match('/^[A-Z]:\\//i', $path);
+        $path = (string) $path;
 
-        return $match;
+        // A drive letter is absolute with EITHER separator.
+        //
+        // This used to accept only 'C:/' and not 'C:\'. isWindowsPath() directly below
+        // recognises exactly the opposite spelling, so the two methods disagreed about the
+        // same path, and PHP hands out the backslash form freely: dirname() and realpath()
+        // both return it on Windows. A path like 'L:\xoops\htdocs\xoops_data' was
+        // therefore "not absolute", so cd() fell through to addPathElement() against an
+        // empty $this->path, built a path that does not exist, and left $path null --
+        // which is why the file cache engine failed to initialise on Windows with
+        // "Cache Engine file is not initialized", while working everywhere else.
+        //
+        // UNC paths (\\server\share) are absolute too, and were never matched at all.
+        $match = preg_match('#^/#', $path)
+            || preg_match('#^[A-Z]:[\\\\/]#i', $path)
+            || preg_match('#^\\\\\\\\#', $path);
+
+        return (bool) $match;
     }
 
     /**

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -87,9 +87,22 @@ $xoopsLogger->startTime('XOOPS Boot');
  * deprecations and SQL with no change to any producer. With no debug.php this is one
  * file_exists() and nothing more.
  */
-include_once XOOPS_ROOT_PATH . '/include/debugconfig.php';
-$xoopsDebugConfig = xoops_getDebugConfig();
-if ([] !== $xoopsDebugConfig) {
+// Guarded exactly as mainfile.php guards it, and for the same reason. Leaving this
+// unguarded made mainfile.php's care pointless: it survives the partial upgrade, then
+// common.php fatals fifteen lines later. include_once is a no-op when mainfile.php
+// already loaded the file, so on a healthy install this costs nothing.
+$xoopsDebugLoader = XOOPS_ROOT_PATH . '/include/debugconfig.php';
+if (is_readable($xoopsDebugLoader)) {
+    try {
+        require_once $xoopsDebugLoader;
+    } catch (\Throwable $e) {
+        // Fail closed; see xoops_getDebugConfigError().
+    }
+}
+unset($xoopsDebugLoader);
+
+$xoopsDebugConfig = function_exists('xoops_getDebugConfig') ? xoops_getDebugConfig() : [];
+if ([] !== $xoopsDebugConfig && function_exists('xoops_applyDebugConfig')) {
     // Applied HERE as well as further down. On an install whose mainfile.php predates
     // 2.7.3 nothing has raised error_reporting yet, so php.ini still governs -- and if
     // that is restrictive, handleError() discards the early errors before any logger sees
@@ -470,11 +483,12 @@ $xoopsPreload->triggerEvent('core.include.common.end');
  * the screen being overwritten, and is a genuinely unpleasant afternoon.
  *
  * Core registers nothing itself and knows no provider by name: it reads the owner
- * declared in xoops_data/data/debug.php, or recorded by the provider module that claimed
- * it at install, and triggers core.debug.errorscreen for whichever module that is.
- * Always defines XOOPS_ERROR_SCREEN_STATUS and XOOPS_ERROR_SCREEN_MESSAGE, whatever the
- * outcome, so a module can tell "no provider is installed" apart from "a provider is
- * installed and currently off". Costs one function call and a cached array read when no
- * debug.php exists.
+ * declared in xoops_data/data/debug.php and triggers core.debug.errorscreen, which the
+ * module owning that token answers. Always defines XOOPS_ERROR_SCREEN_STATUS and
+ * XOOPS_ERROR_SCREEN_MESSAGE, whatever the outcome, so a module can tell "no provider is
+ * installed" apart from "a provider is installed and currently off". Costs one function
+ * call and a cached array read when no debug.php exists.
  */
-xoops_activateErrorScreen();
+if (function_exists('xoops_activateErrorScreen')) {
+    xoops_activateErrorScreen();
+}

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -97,10 +97,13 @@ if ([] !== $xoopsDebugConfig) {
     // The call is idempotent and the config is cached, so repeating it costs nothing.
     xoops_applyDebugConfig();
 
-    if (!empty($xoopsDebugConfig['log']['enabled'])) {
+    // 'core_log' since 2.7.3; xoops_getDebugConfig() still publishes the older
+    // 'log' spelling as an alias pointing at the same array, so a debug.php
+    // written before the rename needs no edit.
+    if (!empty($xoopsDebugConfig['core_log']['enabled'])) {
         XoopsLoad::load('filelogger');
         if (class_exists('XoopsFileLogger', false)) {
-            $xoopsLogger->addLogger(new XoopsFileLogger((array) $xoopsDebugConfig['log']));
+            $xoopsLogger->addLogger(new XoopsFileLogger((array) $xoopsDebugConfig['core_log']));
         }
     }
 }
@@ -456,3 +459,22 @@ $xoopsLogger->stopTime('XOOPS Boot');
 $xoopsLogger->startTime('Module init');
 
 $xoopsPreload->triggerEvent('core.include.common.end');
+
+/**
+ * The error screen, last of all.
+ *
+ * Deliberately the final statement in this file. An error screen installs its own error
+ * and exception handlers, and so did XoopsLogger further up; whichever runs last owns
+ * them. Activating any earlier produces a screen that is quietly displaced before the
+ * first error ever happens -- which presents as the screen being broken rather than as
+ * the screen being overwritten, and is a genuinely unpleasant afternoon.
+ *
+ * Core registers nothing itself and knows no provider by name: it reads the owner
+ * declared in xoops_data/data/debug.php, or recorded by the provider module that claimed
+ * it at install, and triggers core.debug.errorscreen for whichever module that is.
+ * Always defines XOOPS_ERROR_SCREEN_STATUS and XOOPS_ERROR_SCREEN_MESSAGE, whatever the
+ * outcome, so a module can tell "no provider is installed" apart from "a provider is
+ * installed and currently off". Costs one function call and a cached array read when no
+ * debug.php exists.
+ */
+xoops_activateErrorScreen();

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -96,19 +96,32 @@ if (is_readable($xoopsDebugLoader)) {
     try {
         require_once $xoopsDebugLoader;
     } catch (\Throwable $e) {
-        // Fail closed; see xoops_getDebugConfigError().
+        // Fail closed, and deliberately silent: nothing has configured error display yet.
+        //
+        // Nothing is recorded here either. xoops_setDebugConfigError() lives in the file
+        // that just failed to parse, so in this exact case it does not exist to be called
+        // -- the recorder covers a broken debug.php, not a broken debugconfig.php. An
+        // earlier comment here pointed at it as though it applied.
     }
 }
 unset($xoopsDebugLoader);
 
 $xoopsDebugConfig = function_exists('xoops_getDebugConfig') ? xoops_getDebugConfig() : [];
-if ([] !== $xoopsDebugConfig && function_exists('xoops_applyDebugConfig')) {
+
+// Called unconditionally, not only when a debug.php exists. XOOPS_ENVIRONMENT, XOOPS_ENV
+// and RAY_ENABLED are defined at the top of this function precisely so they exist on every
+// request -- and guarding the call meant they were absent on exactly the sites that have no
+// debug.php, which is every production site. A consumer reading them bare then fatals in
+// production and nowhere else. With no config the call sets three constants and returns.
+if (function_exists('xoops_applyDebugConfig')) {
+    xoops_applyDebugConfig();
+}
+
+if ([] !== $xoopsDebugConfig) {
     // Applied HERE as well as further down. On an install whose mainfile.php predates
     // 2.7.3 nothing has raised error_reporting yet, so php.ini still governs -- and if
     // that is restrictive, handleError() discards the early errors before any logger sees
     // them. Attaching the logger early is pointless unless reporting is raised with it.
-    // The call is idempotent and the config is cached, so repeating it costs nothing.
-    xoops_applyDebugConfig();
 
     // 'core_log' since 2.7.3; xoops_getDebugConfig() still publishes the older
     // 'log' spelling as an alias pointing at the same array, so a debug.php
@@ -220,7 +233,11 @@ $xoops->gzipCompression();
  * install whose mainfile.php predates
  * 2.7.3 still get file logging, even though its XOOPS_DEBUG constant was fixed earlier.
  */
-$xoopsDebugConfig = xoops_getDebugConfig();
+// Guarded like the first read above, and for the identical reason. Guarding only the
+// earlier call site left this one to fatal on a truncated debugconfig.php a hundred lines
+// later -- the boot cleared every guard and then died anyway, which made the whole
+// fail-closed exercise decorative.
+$xoopsDebugConfig = function_exists('xoops_getDebugConfig') ? xoops_getDebugConfig() : [];
 
 if ($xoopsConfig['debug_mode'] == 1 || $xoopsConfig['debug_mode'] == 2) {
     xoops_loadLanguage('logger');
@@ -241,7 +258,9 @@ if ($xoopsConfig['debug_mode'] == 1 || $xoopsConfig['debug_mode'] == 2) {
     // addQuery/addBlock/addExtra/handleError, so the file logger still receives
     // everything.
     xoops_loadLanguage('logger');
-    xoops_applyDebugConfig();
+    if (function_exists('xoops_applyDebugConfig')) {
+        xoops_applyDebugConfig();
+    }
     $xoopsLogger->activated = false;
 } else {
     error_reporting(0);

--- a/htdocs/include/common.php
+++ b/htdocs/include/common.php
@@ -108,11 +108,11 @@ unset($xoopsDebugLoader);
 
 $xoopsDebugConfig = function_exists('xoops_getDebugConfig') ? xoops_getDebugConfig() : [];
 
-// Called unconditionally, not only when a debug.php exists. XOOPS_ENVIRONMENT, XOOPS_ENV
-// and RAY_ENABLED are defined at the top of this function precisely so they exist on every
+// Called unconditionally, not only when a debug.php exists. XOOPS_ENVIRONMENT and
+// XOOPS_ENV are defined at the top of this function precisely so they exist on every
 // request -- and guarding the call meant they were absent on exactly the sites that have no
 // debug.php, which is every production site. A consumer reading them bare then fatals in
-// production and nowhere else. With no config the call sets three constants and returns.
+// production and nowhere else. With no config the call sets both constants and returns.
 if (function_exists('xoops_applyDebugConfig')) {
     xoops_applyDebugConfig();
 }

--- a/htdocs/include/debugconfig.php
+++ b/htdocs/include/debugconfig.php
@@ -22,6 +22,47 @@ if (!defined('XOOPS_ROOT_PATH')) {
     die('Restricted access');
 }
 
+if (!function_exists('xoops_setDebugConfigError')) {
+    /**
+     * Record why debug.php could not be used, for later display.
+     *
+     * Split into a setter and a getter, both function_exists-guarded like everything else
+     * in this file, so the store survives whatever order the bootstrap loads things in.
+     * A static inside the getter is the whole implementation: this is per-request state,
+     * written at most once, read at most once, and it must not require a class to exist.
+     *
+     * @param string|null $message the reason, or null to read the current one
+     *
+     * @return string the recorded reason, '' when there is none
+     */
+    function xoops_setDebugConfigError($message = null)
+    {
+        static $stored = '';
+
+        if (null !== $message) {
+            $stored = (string) $message;
+        }
+
+        return $stored;
+    }
+}
+
+if (!function_exists('xoops_getDebugConfigError')) {
+    /**
+     * Why debug.php was ignored this request, or '' when it was not.
+     *
+     * Consumed by DebugBar's Diagnostics page. Deliberately NOT consumed during
+     * bootstrap: see the catch in xoops_getDebugConfig() for why saying this early is
+     * worse than saying it late.
+     *
+     * @return string
+     */
+    function xoops_getDebugConfigError()
+    {
+        return xoops_setDebugConfigError();
+    }
+}
+
 if (!function_exists('xoops_getDebugConfig')) {
     /**
      * Read xoops_data/data/debug.php, once per request.
@@ -64,10 +105,28 @@ if (!function_exists('xoops_getDebugConfig')) {
         try {
             $loaded = include $file;
         } catch (\Throwable $e) {
-            trigger_error(
-                'xoops_data/data/debug.php could not be loaded (' . get_class($e)
-                . '); continuing with debugging disabled.',
-                E_USER_WARNING
+            // RECORDED, not announced. This runs during bootstrap, before this very
+            // function has told PHP what to do with errors, so a trigger_error() here is
+            // emitted under php.ini's rules -- on a host with display_errors on, that is
+            // a file path printed to whoever happened to load the page. Silence is not
+            // the answer either: a developer whose debug.php has a typo would get no
+            // signal at all and conclude the feature is broken.
+            //
+            // So the reason is kept and published through xoops_getDebugConfigError(),
+            // which DebugBar's Diagnostics page reads once the request is known to belong
+            // to an authenticated administrator. The information survives; only the
+            // moment of delivery changes.
+            xoops_setDebugConfigError(
+                'xoops_data/data/debug.php could not be loaded (' . get_class($e) . ': '
+                . $e->getMessage() . '); continuing with debugging disabled.'
+            );
+
+            return $config;
+        }
+
+        if (!is_array($loaded)) {
+            xoops_setDebugConfigError(
+                'xoops_data/data/debug.php did not return an array; continuing with debugging disabled.'
             );
 
             return $config;
@@ -81,19 +140,331 @@ if (!function_exists('xoops_getDebugConfig')) {
 
         // Normalise the nested shapes now, so nothing downstream has to defend itself
         // against an object or a string where an array belongs.
-        $loaded['log']      = isset($loaded['log']) && is_array($loaded['log']) ? $loaded['log'] : [];
         $loaded['database'] = isset($loaded['database']) && is_array($loaded['database']) ? $loaded['database'] : [];
+        $loaded['ray']      = isset($loaded['ray']) && is_array($loaded['ray']) ? $loaded['ray'] : [];
+        $loaded['debugbar'] = isset($loaded['debugbar']) && is_array($loaded['debugbar']) ? $loaded['debugbar'] : [];
+
+        // Any OTHER key is passed through untouched. debug.php is a per-install file, so
+        // a site is free to keep a provider's settings in it -- but core does not know
+        // what those keys mean and must not pretend to. A provider normalises its own
+        // block, in its own repository, on the same terms as every other consumer.
+
+        // The core file log. Named 'core_log' from 2.7.3 on, matching the "core" source
+        // the DebugBar module lists on its Logs page and keeping it clearly distinct from
+        // database.legacy_log, which is a different switch entirely. The pre-2.7.3 spelling
+        // 'log' is still accepted so an existing debug.php keeps working; both keys are
+        // published below and point at the SAME normalised array, so a consumer written
+        // against either name reads identical settings.
+        $coreLog = null;
+        if (isset($loaded['core_log']) && is_array($loaded['core_log'])) {
+            $coreLog = $loaded['core_log'];
+        } elseif (isset($loaded['log']) && is_array($loaded['log'])) {
+            $coreLog = $loaded['log'];
+        }
+        $loaded['core_log'] = is_array($coreLog) ? $coreLog : [];
 
         // The nested switches need the same strict treatment as the top-level one.
         // Downstream reads them with !empty(), and the string 'false' is not empty, so
         // 'enabled' => 'false' switched logging ON -- precisely the trap closed above,
         // one level further down.
-        $loaded['log']['enabled']         = true === ($loaded['log']['enabled'] ?? false);
+        $loaded['core_log']['enabled']    = true === ($loaded['core_log']['enabled'] ?? false);
         $loaded['database']['legacy_log'] = true === ($loaded['database']['legacy_log'] ?? false);
+        $loaded['ray']['enabled']         = true === ($loaded['ray']['enabled'] ?? false);
+
+        // The DebugBar module reads this as a SECOND activation source, alongside the
+        // database-backed Admin -> Preferences -> Debug Mode. Normalised here rather than
+        // in the module so it gets the same strict treatment as every other switch: the
+        // module reads it with a truthiness test somewhere, and 'false' as a string is
+        // truthy, which is the exact trap closed above for the other three.
+        $loaded['debugbar']['enabled']    = true === ($loaded['debugbar']['enabled'] ?? false);
+
+        // Exactly one component may own PHP's error and exception handlers. The value is
+        // a free-form token naming that component, resolved by xoops_getErrorScreenOwner()
+        // and answered by whichever module claims it -- deliberately NOT an allowlist,
+        // because a closed list would mean no error screen could exist without a core
+        // release naming it first. Shape is validated, meaning is not: anything that is
+        // not a non-empty string falls back to 'core' rather than guessing, and a token
+        // no module answers for is reported as 'unclaimed' by xoops_activateErrorScreen()
+        // rather than silently handing the handlers to whichever module loads last.
+        // Absent means 'auto', NOT 'core': a site that installed exactly one error-screen
+        // module and never opened this file should get that module. An explicit 'core'
+        // still pins core, which is a different statement from saying nothing at all.
+        $screen = $loaded['error_screen'] ?? 'auto';
+        $loaded['error_screen'] = (is_string($screen) && '' !== trim($screen))
+            ? strtolower(trim($screen))
+            : 'auto';
+
+        // Alias, kept in step with core_log so pre-2.7.3 consumers see the same array.
+        $loaded['log'] = $loaded['core_log'];
 
         $config = $loaded;
 
         return $config;
+    }
+}
+
+if (!function_exists('xoops_getDebugEnvironment')) {
+    /**
+     * The declared deployment environment: development, staging or production.
+     *
+     * Anything unrecognised, and anything at all while debugging is off, resolves to
+     * 'production'. Failing towards the safe value matters because callers use this to
+     * decide whether to expose diagnostics.
+     *
+     * @return string
+     */
+    function xoops_getDebugEnvironment()
+    {
+        $config = xoops_getDebugConfig();
+        if ([] === $config) {
+            return 'production';
+        }
+
+        $environment = $config['environment'] ?? 'development';
+        if (!is_string($environment)) {
+            return 'production';
+        }
+
+        return in_array($environment, ['development', 'staging', 'production'], true)
+            ? $environment
+            : 'production';
+    }
+}
+
+if (!function_exists('xoops_getErrorScreenOwner')) {
+    /**
+     * Which component owns PHP's error and exception handlers this request.
+     *
+     * PHP has exactly one error handler and one exception handler, and set_error_handler()
+     * gives them to whoever calls last. XOOPS has more than one contender: XoopsLogger,
+     * registered unconditionally in its getInstance() and the source that feeds the
+     * DebugBar module, plus whatever error-screen modules a site has installed. Before
+     * this key existed the winner was decided by module weight and mid -- reinstalling an
+     * unrelated module could silently disable your error screen, or silently empty
+     * DebugBar's Messages tab, with no diagnostic anywhere pointing at the cause.
+     *
+     * Resolved in three steps, first answer wins:
+     *
+     *  1. 'error_screen' in debug.php, when it names something other than 'auto'. An
+     *     explicit choice is never overridden by anything below.
+     *  2. the owner recorded in debug-runtime.json, which the first provider module to be
+     *     installed writes for itself. This is what makes installing one module enough.
+     *  3. 'core' -- XoopsLogger keeps both handlers and DebugBar receives everything.
+     *
+     * The token is by convention the provider MODULE'S DIRNAME, so 'error_screen' names
+     * the directory to go and look in and no separate vocabulary has to be documented or
+     * kept unique. Core neither validates it against a list nor knows what any particular
+     * token means; a provider may additionally answer to legacy names of its own choosing,
+     * which is where a spelling like 'whoops' or 'tracy' is honoured -- in the module that
+     * owns the name, not here.
+     *
+     * Always 'core' when debugging is not enabled at all.
+     *
+     * @return string the owner token, 'core' when none applies
+     */
+    function xoops_getErrorScreenOwner()
+    {
+        $config = xoops_getDebugConfig();
+        if ([] === $config) {
+            return 'core';
+        }
+
+        $declared = (string) ($config['error_screen'] ?? 'auto');
+        if ('' !== $declared && 'auto' !== $declared) {
+            return $declared;
+        }
+
+        $recorded = xoops_getRecordedErrorScreenOwner();
+
+        return '' !== $recorded ? $recorded : 'core';
+    }
+}
+
+if (!function_exists('xoops_getErrorScreenOwnerSource')) {
+    /**
+     * WHERE the owner came from: config | recorded | default.
+     *
+     * Worth publishing because the recorded owner lives in a file nobody reads by hand.
+     * "Why is this module the owner?" must be answerable without knowing that
+     * debug-runtime.json exists, so an admin screen can say "recorded at install" rather
+     * than leaving a value with no visible cause.
+     *
+     * @return string config|recorded|default
+     */
+    function xoops_getErrorScreenOwnerSource()
+    {
+        $config = xoops_getDebugConfig();
+        if ([] === $config) {
+            return 'default';
+        }
+
+        $declared = (string) ($config['error_screen'] ?? 'auto');
+        if ('' !== $declared && 'auto' !== $declared) {
+            return 'config';
+        }
+
+        return '' !== xoops_getRecordedErrorScreenOwner() ? 'recorded' : 'default';
+    }
+}
+
+if (!function_exists('xoops_getRecordedErrorScreenOwner')) {
+    /**
+     * The owner recorded in debug-runtime.json, or '' when none is.
+     *
+     * @return string
+     */
+    function xoops_getRecordedErrorScreenOwner()
+    {
+        $override = xoops_readDebugRuntimeOverride();
+        $recorded = $override['error_screen_owner'] ?? '';
+
+        return is_string($recorded) ? trim($recorded) : '';
+    }
+}
+
+if (!function_exists('xoops_recordErrorScreenOwner')) {
+    /**
+     * Claim, or release, the recorded ownership of the error screen.
+     *
+     * Called by a provider module's install and uninstall routines, not at request time.
+     *
+     * The rule is first-installed-wins, and it is enforced HERE rather than trusted to
+     * each provider: a second provider installing must not be able to take a screen the
+     * first one is already showing, however it was written. Pass '' to release, which
+     * uninstalling should do -- and which deactivating deliberately should NOT, so that
+     * re-activating a module restores the setup the site already had.
+     *
+     * A released screen does not promote whatever else happens to be installed. Ownership
+     * changing without anybody asking for it is the surprise this whole mechanism exists
+     * to prevent, so the site falls back to 'core' and the other provider takes over only
+     * when it is next installed or updated -- a deliberate act, with a visible result.
+     *
+     * @param string $token the claiming module's dirname, or '' to release
+     * @param bool   $force take ownership even when another provider holds it
+     * @return bool true when the record now names $token
+     */
+    function xoops_recordErrorScreenOwner($token, $force = false)
+    {
+        $token = is_string($token) ? trim($token) : '';
+        $held  = xoops_getRecordedErrorScreenOwner();
+
+        if ('' === $token) {
+            // Release only what you hold. An uninstall must not clear somebody else's
+            // claim just because it ran later.
+            return true;
+        }
+
+        if ('' !== $held && $held !== $token && !$force) {
+            return false;
+        }
+
+        return xoops_writeDebugRuntimeOverride(['error_screen_owner' => $token]);
+    }
+}
+
+if (!function_exists('xoops_releaseErrorScreenOwner')) {
+    /**
+     * Release the recorded ownership, but only if $token currently holds it.
+     *
+     * @param string $token the releasing module's dirname
+     * @return bool true when the record no longer names $token
+     */
+    function xoops_releaseErrorScreenOwner($token)
+    {
+        $token = is_string($token) ? trim($token) : '';
+        if ('' === $token || xoops_getRecordedErrorScreenOwner() !== $token) {
+            return true;
+        }
+
+        return xoops_writeDebugRuntimeOverride(['error_screen_owner' => null]);
+    }
+}
+
+
+if (!function_exists('xoops_isDeveloperRequest')) {
+    /**
+     * May diagnostics be exposed to whoever is making THIS request?
+     *
+     * One answer to a question three components were each answering differently:
+     * DebugBar checked $xoopsUserIsAdmin plus the debug_mode preference, xwhoops checked
+     * the XOOPS_DEBUG constant plus isAdmin() plus its own group permission, and Tracy
+     * checked XOOPS_DEBUG and nothing else -- so the loosest of the three silently set the
+     * real exposure for the whole site. Tracy's bar and BlueScreen reveal source, paths
+     * and request data, and were rendering for anonymous visitors as a result.
+     *
+     * Two conditions, both required:
+     *  1. debugging is switched on by EITHER mechanism -- the XOOPS_DEBUG constant from
+     *     xoops_data/data/debug.php, or Admin -> Preferences -> Debug Mode. They are
+     *     documented as independent and either alone is a legitimate way to work;
+     *  2. the request belongs to an authenticated member of the webmaster group.
+     *
+     * Group membership is the test rather than XoopsUser::isAdmin(), which resolves
+     * against $GLOBALS['xoopsModule'] when called with no argument and therefore answers
+     * "admin of whatever module we happen to be inside" -- context-dependence being the
+     * exact property this function exists to remove.
+     *
+     * Safe to call at any point in the bootstrap: before the auth stage has run there is
+     * no user, and the answer is false.
+     *
+     * @param string|null $dirname optionally also require admin rights on this module
+     * @return bool
+     */
+    function xoops_isDeveloperRequest($dirname = null)
+    {
+        $debugMode = (int) ($GLOBALS['xoopsConfig']['debug_mode'] ?? 0);
+        $debugOn   = (defined('XOOPS_DEBUG') && XOOPS_DEBUG)
+            || in_array($debugMode, [1, 2], true);
+        if (!$debugOn) {
+            return false;
+        }
+
+        $user = $GLOBALS['xoopsUser'] ?? null;
+        if (!is_object($user) || !method_exists($user, 'getGroups')) {
+            return false;
+        }
+
+        $adminGroup = defined('XOOPS_GROUP_ADMIN') ? (int) constant('XOOPS_GROUP_ADMIN') : 1;
+        $groups     = $user->getGroups();
+        $groups     = is_array($groups) ? array_map('intval', $groups) : [];
+        if (!in_array($adminGroup, $groups, true)) {
+            return false;
+        }
+
+        if (null === $dirname || '' === $dirname) {
+            return true;
+        }
+
+        // Module-scoped rights. Resolved through xoops_getHandler() rather than
+        // \XoopsModule::getByDirname(), because 2.7.3 autoloads no kernel class and the
+        // static form only resolves when some earlier caller happened to load
+        // kernel/module.php first.
+        if (!function_exists('xoops_getHandler') || !method_exists($user, 'isAdmin')) {
+            return false;
+        }
+        $handler = xoops_getHandler('module');
+        if (!is_object($handler) || !method_exists($handler, 'getByDirname')) {
+            return false;
+        }
+        $module = $handler->getByDirname($dirname);
+
+        return is_object($module) && $user->isAdmin((int) $module->getVar('mid'));
+    }
+}
+
+if (!function_exists('xoops_mayRegisterErrorScreen')) {
+    /**
+     * May this component take over the error screen?
+     *
+     * The single question every contender asks before calling register()/enable().
+     * Callers should guard with function_exists() so they keep working on a core that
+     * predates this seam.
+     *
+     * @param string $component the caller's own owner token
+     * @return bool
+     */
+    function xoops_mayRegisterErrorScreen($component)
+    {
+        return is_string($component) && $component === xoops_getErrorScreenOwner();
     }
 }
 
@@ -104,11 +475,29 @@ if (!function_exists('xoops_applyDebugConfig')) {
      * Kept separate from xoops_getDebugConfig() so the configuration can be inspected
      * without side effects — the upgrade tooling and tests need to do exactly that.
      *
+     * Also publishes the constants that describe the environment. They are defined here
+     * rather than in mainfile.php because mainfile.php survives upgrades untouched, so
+     * anything placed there never reaches an existing site. Every define() is guarded:
+     * this function is called more than once per request by design, and mainfile.php may
+     * legitimately have set some of them already.
+     *
+     * XOOPS_DEBUG is NOT defined here. mainfile.php defines it unguarded straight after
+     * calling this function, and a second define() would be a fatal redeclaration.
+     *
      * @return bool true when debugging is enabled and was applied
      */
     function xoops_applyDebugConfig()
     {
         $config = xoops_getDebugConfig();
+
+        // Defined on EVERY request, enabled or not. A constant that exists only in
+        // development is worse than no constant: consuming code then has to branch on
+        // defined() and pick a fallback, and the fallbacks drift apart.
+        defined('XOOPS_ENVIRONMENT') || define('XOOPS_ENVIRONMENT', xoops_getDebugEnvironment());
+        defined('XOOPS_ENV') || define('XOOPS_ENV', XOOPS_ENVIRONMENT);
+        defined('RAY_ENABLED')
+            || define('RAY_ENABLED', [] !== $config && true === ($config['ray']['enabled'] ?? false));
+
         if ([] === $config) {
             return false;
         }
@@ -127,6 +516,311 @@ if (!function_exists('xoops_applyDebugConfig')) {
         // integer is honoured.
         $reporting = $config['error_reporting'] ?? null;
         error_reporting(is_int($reporting) ? $reporting : E_ALL);
+
+        return true;
+    }
+}
+
+if (!function_exists('xoops_findVendorDirectory')) {
+    /**
+     * Locate the Composer vendor directory for optional developer libraries.
+     *
+     * Installations disagree about where this lives — xoops_lib on a modern install,
+     * class/libraries on an older one, and XOOPS_PATH may or may not be defined by a
+     * mainfile.php written years ago. Each candidate is tested rather than assumed.
+     *
+     * @return string absolute path without trailing slash, or '' when none exists
+     */
+    function xoops_findVendorDirectory()
+    {
+        static $found = null;
+
+        if (null !== $found) {
+            return $found;
+        }
+        $found = '';
+
+        $candidates = [];
+        foreach (['XOOPS_LIB_PATH', 'XOOPS_PATH', 'XOOPS_TRUST_PATH'] as $constantName) {
+            if (defined($constantName)) {
+                $candidates[] = rtrim((string) constant($constantName), '/\\') . '/vendor';
+            }
+        }
+        $candidates[] = XOOPS_ROOT_PATH . '/xoops_lib/vendor';
+        $candidates[] = XOOPS_ROOT_PATH . '/class/libraries/vendor';
+
+        foreach ($candidates as $candidate) {
+            if (is_dir($candidate)) {
+                $found = $candidate;
+
+                break;
+            }
+        }
+
+        return $found;
+    }
+}
+
+if (!function_exists('xoops_errorScreenState')) {
+    /**
+     * Backing store for the error-screen outcome. Internal to this file.
+     *
+     * A provider runs inside an event, so it cannot return a value to the code that
+     * triggered it. This is the channel it reports through instead.
+     *
+     * @param array|null $set the outcome to record, or null to read the current one
+     * @return array ['status' => string, 'message' => string]
+     */
+    function xoops_errorScreenState($set = null)
+    {
+        static $state = ['status' => '', 'message' => ''];
+
+        // First writer wins. Two providers claiming the same owner token is a
+        // misconfiguration, and the second one silently overwriting the first is exactly
+        // the load-order roulette the owner token exists to end.
+        if (is_array($set) && '' === $state['status']) {
+            $state = [
+                'status'  => (string) ($set['status'] ?? ''),
+                'message' => (string) ($set['message'] ?? ''),
+            ];
+        }
+
+        return $state;
+    }
+}
+
+if (!function_exists('xoops_setErrorScreenStatus')) {
+    /**
+     * Report the outcome of an error-screen registration. Called BY a provider.
+     *
+     * A provider handling core.debug.errorscreen must call this exactly once, whatever
+     * happened -- including when it decided NOT to register. Reporting "I am installed and
+     * I chose to stay dormant, because X" is the entire difference between a diagnosable
+     * setup and a silent one, and silence is what this seam replaces.
+     *
+     * Any short lower-case string is a valid status; core does not interpret it. The
+     * vocabulary the shipped providers use is active | disabled | missing | incompatible
+     * | error, and a consumer that does not recognise a status should show it verbatim
+     * rather than treat it as a failure.
+     *
+     * @param string $status  short machine-readable outcome
+     * @param string $message short human explanation of that outcome
+     * @return void
+     */
+    function xoops_setErrorScreenStatus($status, $message = '')
+    {
+        xoops_errorScreenState(['status' => $status, 'message' => $message]);
+    }
+}
+
+if (!function_exists('xoops_getErrorScreenStatus')) {
+    /**
+     * What became of the error screen this request.
+     *
+     * Meaningful only after xoops_activateErrorScreen() has run; before that the status
+     * is an empty string. The same values are published as XOOPS_ERROR_SCREEN_STATUS and
+     * XOOPS_ERROR_SCREEN_MESSAGE for consumers that would rather read a constant.
+     *
+     * @return array ['status' => string, 'message' => string]
+     */
+    function xoops_getErrorScreenStatus()
+    {
+        return xoops_errorScreenState();
+    }
+}
+
+if (!function_exists('xoops_activateErrorScreen')) {
+    /**
+     * Hand PHP's error and exception handlers to whichever component the site declared.
+     *
+     * CALL THIS LAST, at the very end of include/common.php. An error screen takes over
+     * set_error_handler() and set_exception_handler(), and so did XoopsLogger earlier in
+     * the boot; whichever runs last owns them. Firing this any earlier produces a screen
+     * that is quietly displaced before the first error ever occurs -- which looks like the
+     * screen being broken rather than being overwritten.
+     *
+     * Core itself registers nothing here and knows no provider by name. It reads the
+     * declared owner from xoops_data/data/debug.php, triggers core.debug.errorscreen, and
+     * records whatever the provider reports back through xoops_setErrorScreenStatus().
+     * A provider is an ordinary module preload -- the same mechanism the xwhoops module
+     * has always used -- so a library falling out of use, or a new one arriving, is a
+     * module being uninstalled or installed and never a change to core.
+     *
+     * Always defines, whatever the outcome:
+     *
+     *   XOOPS_ERROR_SCREEN_OWNER    the owner token, 'core' when none applies
+     *   XOOPS_ERROR_SCREEN_SOURCE   config | recorded | default -- where that came from
+     *   XOOPS_ERROR_SCREEN_STATUS   core | active | disabled | unclaimed | error, or
+     *                               whatever else the provider reported
+     *   XOOPS_ERROR_SCREEN_MESSAGE  a short human explanation of that status
+     *
+     * Defining them unconditionally is what lets an admin screen tell "no provider is
+     * installed" apart from "a provider is installed and currently off" -- an absent
+     * constant means the core is older than this seam, which is a third, different
+     * statement.
+     *
+     * @return string the resulting status
+     */
+    function xoops_activateErrorScreen()
+    {
+        if (defined('XOOPS_ERROR_SCREEN_STATUS')) {
+            return (string) constant('XOOPS_ERROR_SCREEN_STATUS');
+        }
+
+        $owner = xoops_getErrorScreenOwner();
+
+        if ('core' === $owner) {
+            $status  = 'core';
+            $message = 'XoopsLogger keeps the error and exception handlers.';
+        } else {
+            // One boundary around the whole dispatch. An error screen is a debugging
+            // convenience; a broken or half-installed provider must not be able to take
+            // the site down on the last line of the bootstrap.
+            try {
+                $preload = $GLOBALS['xoopsPreload'] ?? null;
+                if (is_object($preload) && method_exists($preload, 'triggerEvent')) {
+                    $preload->triggerEvent('core.debug.errorscreen', ['owner' => $owner]);
+                }
+                $state   = xoops_errorScreenState();
+                $status  = $state['status'];
+                $message = $state['message'];
+            } catch (\Throwable $e) {
+                $status  = 'error';
+                $message = 'Error screen "' . $owner . '" failed to start (' . get_class($e) . ').';
+            }
+
+            if ('' === $status) {
+                // The owner names a provider that no installed module answers for --
+                // deactivated, uninstalled, or a token nobody was ever going to answer.
+                // Behaviour falls back to 'core': XoopsLogger keeps the handlers, which is
+                // exactly what happens when nothing registers. Reported under its own
+                // status rather than as 'core', because "the screen you configured is not
+                // running" and "you configured no screen" are different situations and
+                // only one of them wants looking at.
+                //
+                // Deliberately does NOT promote some other installed provider. Ownership
+                // changing without anybody asking is the surprise this mechanism exists to
+                // prevent; the other module takes over when it is next installed or
+                // updated, which is a deliberate act with a visible result.
+                $status  = 'unclaimed';
+                $message = 'No active module claims the error screen "' . $owner
+                    . '"; the handlers stay with XoopsLogger.';
+            }
+        }
+
+        xoops_errorScreenState(['status' => $status, 'message' => $message]);
+
+        define('XOOPS_ERROR_SCREEN_OWNER', $owner);
+        define('XOOPS_ERROR_SCREEN_SOURCE', xoops_getErrorScreenOwnerSource());
+        define('XOOPS_ERROR_SCREEN_STATUS', $status);
+        define('XOOPS_ERROR_SCREEN_MESSAGE', $message);
+
+        return $status;
+    }
+}
+
+if (!function_exists('xoops_readDebugRuntimeOverride')) {
+    /**
+     * Read xoops_data/data/debug-runtime.json.
+     *
+     * Small, machine-written companion to debug.php holding only the switches an admin
+     * screen may flip at runtime. Separate on purpose: the file an admin button writes is
+     * JSON, so a compromised or buggy toggle cannot introduce executable code into the
+     * bootstrap.
+     *
+     * @param bool $refresh re-read from disk instead of returning the cached copy
+     * @return array decoded settings, or [] when absent, unreadable or malformed
+     */
+    function xoops_readDebugRuntimeOverride($refresh = false)
+    {
+        static $override = null;
+
+        if (null !== $override && !$refresh) {
+            return $override;
+        }
+        $override = [];
+
+        if (!defined('XOOPS_VAR_PATH')) {
+            return $override;
+        }
+
+        $file = XOOPS_VAR_PATH . '/data/debug-runtime.json';
+        if (!is_file($file) || !is_readable($file)) {
+            return $override;
+        }
+
+        $json = file_get_contents($file);
+        if (!is_string($json) || '' === trim($json)) {
+            return $override;
+        }
+
+        $decoded = json_decode($json, true);
+        if (is_array($decoded)) {
+            $override = $decoded;
+        }
+
+        return $override;
+    }
+}
+
+if (!function_exists('xoops_writeDebugRuntimeOverride')) {
+    /**
+     * Merge changes into xoops_data/data/debug-runtime.json.
+     *
+     * The machine-written companion to debug.php. JSON on purpose: the file an admin
+     * button or an install routine edits must not be able to introduce executable code
+     * into the bootstrap, however it is written and whatever ends up in it.
+     *
+     * Merges rather than replaces, and a null value removes its key, so two independent
+     * writers -- a module install recording ownership, an admin toggle switching a bar
+     * off -- cannot erase each other's settings.
+     *
+     * Written to a temporary file and renamed, so a reader never sees a half-written
+     * file: on every platform this matters on, rename over an existing path is atomic.
+     *
+     * @param array $changes keys to set, or set to null to remove
+     * @return bool true when the file now reflects $changes
+     */
+    function xoops_writeDebugRuntimeOverride($changes)
+    {
+        if (!is_array($changes) || [] === $changes || !defined('XOOPS_VAR_PATH')) {
+            return false;
+        }
+
+        $directory = XOOPS_VAR_PATH . '/data';
+        if (!is_dir($directory) || !is_writable($directory)) {
+            return false;
+        }
+
+        $current = xoops_readDebugRuntimeOverride(true);
+        foreach ($changes as $key => $value) {
+            if (null === $value) {
+                unset($current[$key]);
+                continue;
+            }
+            $current[$key] = $value;
+        }
+
+        $json = json_encode($current, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if (!is_string($json)) {
+            return false;
+        }
+
+        $file      = $directory . '/debug-runtime.json';
+        $temporary = $file . '.' . getmypid() . '.tmp';
+        if (false === file_put_contents($temporary, $json . "\n")) {
+            return false;
+        }
+        if (!rename($temporary, $file)) {
+            @unlink($temporary);
+
+            return false;
+        }
+
+        // The static cache in the reader is now stale, and callers in this same request
+        // -- an install routine reading back what it just claimed -- would otherwise see
+        // the previous contents.
+        xoops_readDebugRuntimeOverride(true);
 
         return true;
     }

--- a/htdocs/include/debugconfig.php
+++ b/htdocs/include/debugconfig.php
@@ -604,8 +604,14 @@ if (!function_exists('xoops_findVendorDirectory')) {
                 $candidates[] = rtrim((string) constant($constantName), '/\\') . '/vendor';
             }
         }
-        $candidates[] = XOOPS_ROOT_PATH . '/xoops_lib/vendor';
-        $candidates[] = XOOPS_ROOT_PATH . '/class/libraries/vendor';
+        // Guarded like the two above: XOOPS_ROOT_PATH is defined by mainfile.php on any
+        // booted request, but this helper is also reachable from a provider module's preload
+        // and from tests, where a bare reference to an undefined constant is a fatal in
+        // PHP 8 -- not the empty-string "none found" this function promises.
+        if (defined('XOOPS_ROOT_PATH')) {
+            $candidates[] = XOOPS_ROOT_PATH . '/xoops_lib/vendor';
+            $candidates[] = XOOPS_ROOT_PATH . '/class/libraries/vendor';
+        }
 
         foreach ($candidates as $candidate) {
             if (is_dir($candidate)) {

--- a/htdocs/include/debugconfig.php
+++ b/htdocs/include/debugconfig.php
@@ -342,12 +342,16 @@ if (!function_exists('xoops_recordErrorScreenOwner')) {
      * to prevent, so the site falls back to 'core'.
      *
      * Handing the seat to a provider that is ALREADY installed therefore takes a
-     * deliberate act. Reinstalling it works, and so does pinning 'error_screen' in
-     * debug.php. An ordinary module update does NOT -- this function refuses while another
-     * token is recorded, so an update hook calling it without $force is declined, and
-     * saying otherwise would describe a handover that cannot happen. A first-class
-     * transfer operation is still to be designed; until it exists, $force is the hook it
-     * will use.
+     * deliberate act, and there are three: pin 'error_screen' in debug.php; uninstall the
+     * holder and reinstall the one you want; or deactivate the holder and update the one
+     * you want. The third works through $force -- an update hook establishes that the
+     * holder is gone or inactive, which is a question about the module table and so cannot
+     * be answered from this file, and then claims with $force = true. See xtracy's
+     * xoops_module_update_*() for the reference implementation.
+     *
+     * An update hook that calls this WITHOUT $force is declined while another token is
+     * recorded, which is correct: an ordinary update must not quietly take a seat from a
+     * provider that is still running.
      *
      * @param string $token the claiming module's dirname; '' is refused
      * @param bool   $force take ownership even when another provider holds it. The hook a
@@ -410,7 +414,11 @@ if (!function_exists('xoops_isDeveloperRequest')) {
      * Two conditions, both required:
      *  1. debugging is switched on by EITHER mechanism -- the XOOPS_DEBUG constant from
      *     xoops_data/data/debug.php, or Admin -> Preferences -> Debug Mode. They are
-     *     documented as independent and either alone is a legitimate way to work;
+     *     documented as independent and either alone is a legitimate way to work. That
+     *     equality is about EXPOSURE, which is what this function gates. It does not
+     *     extend to ACTIVATION of the error screen: xoops_activateErrorScreen() honours
+     *     the file configuration only, deliberately, and reports 'dormant' on a site
+     *     running Debug Mode alone;
      *  2. the request belongs to an authenticated member of the webmaster group.
      *
      * Group membership is the test rather than XoopsUser::isAdmin(), which resolves
@@ -775,8 +783,8 @@ if (!function_exists('xoops_activateErrorScreen')) {
      *
      *   XOOPS_ERROR_SCREEN_OWNER    the owner token, 'core' when none applies
      *   XOOPS_ERROR_SCREEN_SOURCE   config | recorded | default -- where that came from
-     *   XOOPS_ERROR_SCREEN_STATUS   core | active | disabled | unclaimed | error, or
-     *                               whatever else the provider reported
+     *   XOOPS_ERROR_SCREEN_STATUS   core | dormant | active | disabled | unclaimed |
+     *                               error, or whatever else the provider reported
      *   XOOPS_ERROR_SCREEN_MESSAGE  a short human explanation of that status
      *
      * Defining them unconditionally is what lets an admin screen tell "no provider is
@@ -797,6 +805,31 @@ if (!function_exists('xoops_activateErrorScreen')) {
         if ('core' === $owner) {
             $status  = 'core';
             $message = 'XoopsLogger keeps the error and exception handlers.';
+
+            // Recorded, but the file config that would activate it is not there.
+            //
+            // The error screen is a debug.php feature, deliberately and not merely as a
+            // side effect of this early return. Writing xoops_data/data/debug.php takes
+            // filesystem access -- the same privilege as the exposure an error screen
+            // risks -- while Admin -> Preferences -> Debug Mode is reachable from a web
+            // form by anyone holding an admin session. Handing PHP's handlers to
+            // third-party code asks for the stronger credential. Debug Mode has meant
+            // "XoopsLogger renders its log into the page" for twenty years, and quietly
+            // widening it to "a module takes over set_error_handler()" would change the
+            // meaning of an existing control on every site with a provider installed.
+            // The pin and the opt-out live in debug.php too, so a Debug Mode site would
+            // have no vocabulary to say "stop" without creating the file anyway.
+            //
+            // Said out loud, because a provider that is installed, recorded, and silently
+            // never running is exactly the invisible state this seam exists to end.
+            $recorded = xoops_getRecordedErrorScreenOwner();
+            if ('' !== $recorded && [] === xoops_getDebugConfig()) {
+                $status  = 'dormant';
+                $message = 'Provider "' . $recorded . '" is recorded as the error-screen owner, but'
+                    . ' xoops_data/data/debug.php is absent or disabled. The error screen activates'
+                    . ' only under the file-based debug configuration -- Admin -> Preferences ->'
+                    . ' Debug Mode does not activate it.';
+            }
         } else {
             $outcome = ['status' => '', 'message' => ''];
 

--- a/htdocs/include/debugconfig.php
+++ b/htdocs/include/debugconfig.php
@@ -134,7 +134,7 @@ if (!function_exists('xoops_getDebugConfig')) {
 
         // 'enabled' must be a real boolean. A string from an environment-backed config is
         // truthy whatever it happens to say, so 'false' would switch debugging ON.
-        if (!is_array($loaded) || true !== ($loaded['enabled'] ?? false)) {
+        if (true !== ($loaded['enabled'] ?? false)) {
             return $config;
         }
 
@@ -318,7 +318,7 @@ if (!function_exists('xoops_getRecordedErrorScreenOwner')) {
         $override = xoops_readDebugRuntimeOverride();
         $recorded = $override['error_screen_owner'] ?? '';
 
-        return is_string($recorded) ? trim($recorded) : '';
+        return is_string($recorded) ? strtolower(trim($recorded)) : '';
     }
 }
 
@@ -330,28 +330,43 @@ if (!function_exists('xoops_recordErrorScreenOwner')) {
      *
      * The rule is first-installed-wins, and it is enforced HERE rather than trusted to
      * each provider: a second provider installing must not be able to take a screen the
-     * first one is already showing, however it was written. Pass '' to release, which
-     * uninstalling should do -- and which deactivating deliberately should NOT, so that
-     * re-activating a module restores the setup the site already had.
+     * first one is already showing, however it was written.
+     *
+     * This function only CLAIMS. Release through xoops_releaseErrorScreenOwner($dirname),
+     * which checks that you are the holder first -- there is no caller identity here, so
+     * an anonymous "release" could only ever mean "clear whatever anybody else holds",
+     * and uninstalling one module must not free another module's seat.
      *
      * A released screen does not promote whatever else happens to be installed. Ownership
      * changing without anybody asking for it is the surprise this whole mechanism exists
-     * to prevent, so the site falls back to 'core' and the other provider takes over only
-     * when it is next installed or updated -- a deliberate act, with a visible result.
+     * to prevent, so the site falls back to 'core'.
      *
-     * @param string $token the claiming module's dirname, or '' to release
-     * @param bool   $force take ownership even when another provider holds it
+     * Handing the seat to a provider that is ALREADY installed therefore takes a
+     * deliberate act. Reinstalling it works, and so does pinning 'error_screen' in
+     * debug.php. An ordinary module update does NOT -- this function refuses while another
+     * token is recorded, so an update hook calling it without $force is declined, and
+     * saying otherwise would describe a handover that cannot happen. A first-class
+     * transfer operation is still to be designed; until it exists, $force is the hook it
+     * will use.
+     *
+     * @param string $token the claiming module's dirname; '' is refused
+     * @param bool   $force take ownership even when another provider holds it. The hook a
+     *                      deliberate handover uses, after verifying the holder is gone or
+     *                      inactive -- never on an ordinary install.
      * @return bool true when the record now names $token
      */
     function xoops_recordErrorScreenOwner($token, $force = false)
     {
-        $token = is_string($token) ? trim($token) : '';
+        // Lower-cased to match how a token written in debug.php is normalised. Without
+        // this a mixed-case dirname works when recorded and goes permanently 'unclaimed'
+        // when pinned, since every comparison is strict.
+        $token = is_string($token) ? strtolower(trim($token)) : '';
         $held  = xoops_getRecordedErrorScreenOwner();
 
         if ('' === $token) {
-            // Release only what you hold. An uninstall must not clear somebody else's
-            // claim just because it ran later.
-            return true;
+            // Refused, and reported as refused. Returning true here would let a caller
+            // that meant to release believe it had.
+            return false;
         }
 
         if ('' !== $held && $held !== $token && !$force) {
@@ -371,7 +386,7 @@ if (!function_exists('xoops_releaseErrorScreenOwner')) {
      */
     function xoops_releaseErrorScreenOwner($token)
     {
-        $token = is_string($token) ? trim($token) : '';
+        $token = is_string($token) ? strtolower(trim($token)) : '';
         if ('' === $token || xoops_getRecordedErrorScreenOwner() !== $token) {
             return true;
         }
@@ -541,7 +556,10 @@ if (!function_exists('xoops_findVendorDirectory')) {
         $found = '';
 
         $candidates = [];
-        foreach (['XOOPS_LIB_PATH', 'XOOPS_PATH', 'XOOPS_TRUST_PATH'] as $constantName) {
+        // XOOPS_PATH and XOOPS_TRUST_PATH only: both are defined by mainfile.php. An
+        // earlier revision also probed XOOPS_LIB_PATH, which no core release defines --
+        // harmless behind defined(), but it advertised an API that does not exist.
+        foreach (['XOOPS_PATH', 'XOOPS_TRUST_PATH'] as $constantName) {
             if (defined($constantName)) {
                 $candidates[] = rtrim((string) constant($constantName), '/\\') . '/vendor';
             }
@@ -561,163 +579,32 @@ if (!function_exists('xoops_findVendorDirectory')) {
     }
 }
 
-if (!function_exists('xoops_errorScreenState')) {
-    /**
-     * Backing store for the error-screen outcome. Internal to this file.
-     *
-     * A provider runs inside an event, so it cannot return a value to the code that
-     * triggered it. This is the channel it reports through instead.
-     *
-     * @param array|null $set the outcome to record, or null to read the current one
-     * @return array ['status' => string, 'message' => string]
-     */
-    function xoops_errorScreenState($set = null)
-    {
-        static $state = ['status' => '', 'message' => ''];
-
-        // First writer wins. Two providers claiming the same owner token is a
-        // misconfiguration, and the second one silently overwriting the first is exactly
-        // the load-order roulette the owner token exists to end.
-        if (is_array($set) && '' === $state['status']) {
-            $state = [
-                'status'  => (string) ($set['status'] ?? ''),
-                'message' => (string) ($set['message'] ?? ''),
-            ];
-        }
-
-        return $state;
-    }
-}
-
-if (!function_exists('xoops_setErrorScreenStatus')) {
-    /**
-     * Report the outcome of an error-screen registration. Called BY a provider.
-     *
-     * A provider handling core.debug.errorscreen must call this exactly once, whatever
-     * happened -- including when it decided NOT to register. Reporting "I am installed and
-     * I chose to stay dormant, because X" is the entire difference between a diagnosable
-     * setup and a silent one, and silence is what this seam replaces.
-     *
-     * Any short lower-case string is a valid status; core does not interpret it. The
-     * vocabulary the shipped providers use is active | disabled | missing | incompatible
-     * | error, and a consumer that does not recognise a status should show it verbatim
-     * rather than treat it as a failure.
-     *
-     * @param string $status  short machine-readable outcome
-     * @param string $message short human explanation of that outcome
-     * @return void
-     */
-    function xoops_setErrorScreenStatus($status, $message = '')
-    {
-        xoops_errorScreenState(['status' => $status, 'message' => $message]);
-    }
-}
-
 if (!function_exists('xoops_getErrorScreenStatus')) {
     /**
      * What became of the error screen this request.
      *
-     * Meaningful only after xoops_activateErrorScreen() has run; before that the status
-     * is an empty string. The same values are published as XOOPS_ERROR_SCREEN_STATUS and
-     * XOOPS_ERROR_SCREEN_MESSAGE for consumers that would rather read a constant.
+     * Reads the published constants rather than keeping a second copy of the answer.
+     * There is deliberately no store behind this: a function and a constant that both
+     * describe the same event are two things that can disagree, and they did -- a
+     * provider that reported success and then threw left the constant saying 'error'
+     * while the function still said 'active'. One source, no drift.
      *
-     * @return array ['status' => string, 'message' => string]
+     * Meaningful only after xoops_activateErrorScreen() has run; before that, and on a
+     * core too old to have the seam, every value is an empty string.
+     *
+     * @return array ['owner' => string, 'source' => string, 'status' => string, 'message' => string]
      */
     function xoops_getErrorScreenStatus()
     {
-        return xoops_errorScreenState();
+        return [
+            'owner'   => defined('XOOPS_ERROR_SCREEN_OWNER') ? (string) constant('XOOPS_ERROR_SCREEN_OWNER') : '',
+            'source'  => defined('XOOPS_ERROR_SCREEN_SOURCE') ? (string) constant('XOOPS_ERROR_SCREEN_SOURCE') : '',
+            'status'  => defined('XOOPS_ERROR_SCREEN_STATUS') ? (string) constant('XOOPS_ERROR_SCREEN_STATUS') : '',
+            'message' => defined('XOOPS_ERROR_SCREEN_MESSAGE') ? (string) constant('XOOPS_ERROR_SCREEN_MESSAGE') : '',
+        ];
     }
 }
 
-if (!function_exists('xoops_activateErrorScreen')) {
-    /**
-     * Hand PHP's error and exception handlers to whichever component the site declared.
-     *
-     * CALL THIS LAST, at the very end of include/common.php. An error screen takes over
-     * set_error_handler() and set_exception_handler(), and so did XoopsLogger earlier in
-     * the boot; whichever runs last owns them. Firing this any earlier produces a screen
-     * that is quietly displaced before the first error ever occurs -- which looks like the
-     * screen being broken rather than being overwritten.
-     *
-     * Core itself registers nothing here and knows no provider by name. It reads the
-     * declared owner from xoops_data/data/debug.php, triggers core.debug.errorscreen, and
-     * records whatever the provider reports back through xoops_setErrorScreenStatus().
-     * A provider is an ordinary module preload -- the same mechanism the xwhoops module
-     * has always used -- so a library falling out of use, or a new one arriving, is a
-     * module being uninstalled or installed and never a change to core.
-     *
-     * Always defines, whatever the outcome:
-     *
-     *   XOOPS_ERROR_SCREEN_OWNER    the owner token, 'core' when none applies
-     *   XOOPS_ERROR_SCREEN_SOURCE   config | recorded | default -- where that came from
-     *   XOOPS_ERROR_SCREEN_STATUS   core | active | disabled | unclaimed | error, or
-     *                               whatever else the provider reported
-     *   XOOPS_ERROR_SCREEN_MESSAGE  a short human explanation of that status
-     *
-     * Defining them unconditionally is what lets an admin screen tell "no provider is
-     * installed" apart from "a provider is installed and currently off" -- an absent
-     * constant means the core is older than this seam, which is a third, different
-     * statement.
-     *
-     * @return string the resulting status
-     */
-    function xoops_activateErrorScreen()
-    {
-        if (defined('XOOPS_ERROR_SCREEN_STATUS')) {
-            return (string) constant('XOOPS_ERROR_SCREEN_STATUS');
-        }
-
-        $owner = xoops_getErrorScreenOwner();
-
-        if ('core' === $owner) {
-            $status  = 'core';
-            $message = 'XoopsLogger keeps the error and exception handlers.';
-        } else {
-            // One boundary around the whole dispatch. An error screen is a debugging
-            // convenience; a broken or half-installed provider must not be able to take
-            // the site down on the last line of the bootstrap.
-            try {
-                $preload = $GLOBALS['xoopsPreload'] ?? null;
-                if (is_object($preload) && method_exists($preload, 'triggerEvent')) {
-                    $preload->triggerEvent('core.debug.errorscreen', ['owner' => $owner]);
-                }
-                $state   = xoops_errorScreenState();
-                $status  = $state['status'];
-                $message = $state['message'];
-            } catch (\Throwable $e) {
-                $status  = 'error';
-                $message = 'Error screen "' . $owner . '" failed to start (' . get_class($e) . ').';
-            }
-
-            if ('' === $status) {
-                // The owner names a provider that no installed module answers for --
-                // deactivated, uninstalled, or a token nobody was ever going to answer.
-                // Behaviour falls back to 'core': XoopsLogger keeps the handlers, which is
-                // exactly what happens when nothing registers. Reported under its own
-                // status rather than as 'core', because "the screen you configured is not
-                // running" and "you configured no screen" are different situations and
-                // only one of them wants looking at.
-                //
-                // Deliberately does NOT promote some other installed provider. Ownership
-                // changing without anybody asking is the surprise this mechanism exists to
-                // prevent; the other module takes over when it is next installed or
-                // updated, which is a deliberate act with a visible result.
-                $status  = 'unclaimed';
-                $message = 'No active module claims the error screen "' . $owner
-                    . '"; the handlers stay with XoopsLogger.';
-            }
-        }
-
-        xoops_errorScreenState(['status' => $status, 'message' => $message]);
-
-        define('XOOPS_ERROR_SCREEN_OWNER', $owner);
-        define('XOOPS_ERROR_SCREEN_SOURCE', xoops_getErrorScreenOwnerSource());
-        define('XOOPS_ERROR_SCREEN_STATUS', $status);
-        define('XOOPS_ERROR_SCREEN_MESSAGE', $message);
-
-        return $status;
-    }
-}
 
 if (!function_exists('xoops_readDebugRuntimeOverride')) {
     /**
@@ -773,7 +660,16 @@ if (!function_exists('xoops_writeDebugRuntimeOverride')) {
      *
      * Merges rather than replaces, and a null value removes its key, so two independent
      * writers -- a module install recording ownership, an admin toggle switching a bar
-     * off -- cannot erase each other's settings.
+     * off -- do not erase each other's settings.
+     *
+     * The whole read-modify-write runs under an exclusive lock on a sidecar file. The
+     * merge alone is not enough: two writers can both read the same JSON and then write
+     * back, and the second silently drops the first one's key. Atomic rename prevents a
+     * reader seeing a torn file; it does nothing about a lost update, and an earlier
+     * revision of this docblock claimed otherwise.
+     *
+     * The sidecar rather than the file itself, because the write is a rename: locking a
+     * path that is about to be replaced protects nothing.
      *
      * Written to a temporary file and renamed, so a reader never sees a half-written
      * file: on every platform this matters on, rename over an existing path is atomic.
@@ -792,6 +688,17 @@ if (!function_exists('xoops_writeDebugRuntimeOverride')) {
             return false;
         }
 
+        $lockFile   = $directory . '/debug-runtime.lock';
+        $lockHandle = @fopen($lockFile, 'c');
+        if (false === $lockHandle) {
+            return false;
+        }
+        if (!flock($lockHandle, LOCK_EX)) {
+            fclose($lockHandle);
+
+            return false;
+        }
+
         $current = xoops_readDebugRuntimeOverride(true);
         foreach ($changes as $key => $value) {
             if (null === $value) {
@@ -801,27 +708,168 @@ if (!function_exists('xoops_writeDebugRuntimeOverride')) {
             $current[$key] = $value;
         }
 
-        $json = json_encode($current, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-        if (!is_string($json)) {
-            return false;
-        }
-
+        $json      = json_encode($current, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
         $file      = $directory . '/debug-runtime.json';
         $temporary = $file . '.' . getmypid() . '.tmp';
-        if (false === file_put_contents($temporary, $json . "\n")) {
-            return false;
-        }
-        if (!rename($temporary, $file)) {
-            @unlink($temporary);
+        $written   = false;
 
-            return false;
+        if (is_string($json) && false !== file_put_contents($temporary, $json . "\n")) {
+            $written = rename($temporary, $file);
+            if (!$written) {
+                @unlink($temporary);
+            }
         }
 
         // The static cache in the reader is now stale, and callers in this same request
         // -- an install routine reading back what it just claimed -- would otherwise see
-        // the previous contents.
+        // the previous contents. Refreshed inside the lock so the next reader in this
+        // process cannot observe the pre-write state.
         xoops_readDebugRuntimeOverride(true);
 
-        return true;
+        flock($lockHandle, LOCK_UN);
+        fclose($lockHandle);
+
+        return $written;
+    }
+}
+
+if (!function_exists('xoops_activateErrorScreen')) {
+    /**
+     * Hand PHP's error and exception handlers to whichever component the site declared.
+     *
+     * CALL THIS LAST, at the very end of include/common.php. An error screen takes over
+     * set_error_handler() and set_exception_handler(), and so did XoopsLogger earlier in
+     * the boot; whichever runs last owns them. Firing this any earlier produces a screen
+     * that is quietly displaced before the first error ever occurs -- which looks like the
+     * screen being broken rather than being overwritten.
+     *
+     * Core itself registers nothing here and knows no provider by name. It reads the
+     * declared owner, triggers core.debug.errorscreen, and records whatever the provider
+     * reports back. A provider is an ordinary module preload -- the same mechanism the
+     * xwhoops module has always used -- so a library falling out of use, or a new one
+     * arriving, is a module being uninstalled or installed and never a change to core.
+     *
+     * The event receives three arguments:
+     *
+     *   'owner'              the token being offered. Answer only to your own.
+     *   'developer_request'  whether xoops_isDeveloperRequest() is true for this request.
+     *                        ADVISORY, and passed rather than enforced because a provider
+     *                        may legitimately register a production-safe error page for
+     *                        anonymous visitors. A provider that exposes source, file
+     *                        paths, request data or superglobals MUST refuse when this is
+     *                        false -- the one obligation core cannot check for you.
+     *   'report'             callable(string $status, string $message = ''): bool
+     *                        Call it exactly once, whatever happened -- INCLUDING when you
+     *                        decide not to register. "I am installed and chose to stay
+     *                        dormant, because X" is the whole difference between a
+     *                        diagnosable setup and a silent one. First caller wins; later
+     *                        calls return false. Any short lower-case status is valid and
+     *                        core does not interpret it; the shipped vocabulary is
+     *                        active | disabled | missing | incompatible | error.
+     *
+     * Passing the reporter in the event rather than exposing a global setter keeps the
+     * outcome in this function's own scope: the catch below can finalise a status without
+     * competing with a store a half-failed provider already wrote to.
+     *
+     * Always defines, whatever the outcome:
+     *
+     *   XOOPS_ERROR_SCREEN_OWNER    the owner token, 'core' when none applies
+     *   XOOPS_ERROR_SCREEN_SOURCE   config | recorded | default -- where that came from
+     *   XOOPS_ERROR_SCREEN_STATUS   core | active | disabled | unclaimed | error, or
+     *                               whatever else the provider reported
+     *   XOOPS_ERROR_SCREEN_MESSAGE  a short human explanation of that status
+     *
+     * Defining them unconditionally is what lets an admin screen tell "no provider is
+     * installed" apart from "a provider is installed and currently off" -- an absent
+     * constant means the core is older than this seam, which is a third, different
+     * statement.
+     *
+     * @return string the resulting status
+     */
+    function xoops_activateErrorScreen()
+    {
+        if (defined('XOOPS_ERROR_SCREEN_STATUS')) {
+            return (string) constant('XOOPS_ERROR_SCREEN_STATUS');
+        }
+
+        $owner = xoops_getErrorScreenOwner();
+
+        if ('core' === $owner) {
+            $status  = 'core';
+            $message = 'XoopsLogger keeps the error and exception handlers.';
+        } else {
+            $outcome = ['status' => '', 'message' => ''];
+
+            // First caller wins. Two providers answering one token is a misconfiguration,
+            // and the second silently overwriting the first is the load-order roulette the
+            // owner token exists to end. Note this governs the REPORT only: the preload
+            // dispatcher runs every listener, so two providers would both still register
+            // and the later one would own the handlers while the status describes the
+            // earlier. Core cannot prevent that; it can refuse to lie about which one it
+            // heard from first.
+            $report = static function ($status, $message = '') use (&$outcome) {
+                if ('' !== $outcome['status']) {
+                    return false;
+                }
+                $status = is_string($status) ? trim($status) : '';
+                if ('' === $status) {
+                    return false;
+                }
+                $outcome = [
+                    'status'  => $status,
+                    'message' => is_string($message) ? $message : '',
+                ];
+
+                return true;
+            };
+
+            // One boundary around the whole dispatch. An error screen is a debugging
+            // convenience; a broken or half-installed provider must not be able to take
+            // the site down on the last line of the bootstrap.
+            try {
+                $preload = $GLOBALS['xoopsPreload'] ?? null;
+                if (is_object($preload) && method_exists($preload, 'triggerEvent')) {
+                    $preload->triggerEvent('core.debug.errorscreen', [
+                        'owner'             => $owner,
+                        'developer_request' => function_exists('xoops_isDeveloperRequest')
+                            && xoops_isDeveloperRequest(),
+                        'report'            => $report,
+                    ]);
+                }
+                $status  = $outcome['status'];
+                $message = $outcome['message'];
+            } catch (\Throwable $e) {
+                // Authoritative. A provider that reported success and then threw is a
+                // provider that failed, and the outcome it wrote is stale by the time we
+                // are here -- which is exactly why the outcome lives in this scope and not
+                // in a store that would have refused this correction.
+                $status  = 'error';
+                $message = 'Error screen "' . $owner . '" failed to start (' . get_class($e) . ').';
+            }
+
+            if ('' === $status) {
+                // The owner names a provider that no installed module answers for --
+                // deactivated, uninstalled, or a token nobody was ever going to answer.
+                // Behaviour falls back to 'core': XoopsLogger keeps the handlers, which is
+                // exactly what happens when nothing registers. Reported under its own
+                // status rather than as 'core', because "the screen you configured is not
+                // running" and "you configured no screen" are different situations and
+                // only one of them wants looking at.
+                //
+                // Deliberately does NOT promote some other installed provider. Ownership
+                // changing without anybody asking is the surprise this mechanism exists to
+                // prevent.
+                $status  = 'unclaimed';
+                $message = 'No active module claims the error screen "' . $owner
+                    . '"; the handlers stay with XoopsLogger.';
+            }
+        }
+
+        define('XOOPS_ERROR_SCREEN_OWNER', $owner);
+        define('XOOPS_ERROR_SCREEN_SOURCE', xoops_getErrorScreenOwnerSource());
+        define('XOOPS_ERROR_SCREEN_STATUS', $status);
+        define('XOOPS_ERROR_SCREEN_MESSAGE', $message);
+
+        return $status;
     }
 }

--- a/htdocs/include/debugconfig.php
+++ b/htdocs/include/debugconfig.php
@@ -141,13 +141,14 @@ if (!function_exists('xoops_getDebugConfig')) {
         // Normalise the nested shapes now, so nothing downstream has to defend itself
         // against an object or a string where an array belongs.
         $loaded['database'] = isset($loaded['database']) && is_array($loaded['database']) ? $loaded['database'] : [];
-        $loaded['ray']      = isset($loaded['ray']) && is_array($loaded['ray']) ? $loaded['ray'] : [];
-        $loaded['debugbar'] = isset($loaded['debugbar']) && is_array($loaded['debugbar']) ? $loaded['debugbar'] : [];
 
-        // Any OTHER key is passed through untouched. debug.php is a per-install file, so
-        // a site is free to keep a provider's settings in it -- but core does not know
-        // what those keys mean and must not pretend to. A provider normalises its own
-        // block, in its own repository, on the same terms as every other consumer.
+        // Any OTHER key is passed through untouched -- with no exceptions, which is a
+        // stronger statement than this file used to be able to make. debug.php is a
+        // per-install file, so a site is free to keep a module's settings in it, but core
+        // does not know what those keys mean and must not pretend to. Every module
+        // normalises its own block, in its own repository, on the same terms as every
+        // other consumer -- including the modules the XOOPS project ships itself, which
+        // get no shortcut here for being ours.
 
         // The core file log. Named 'core_log' from 2.7.3 on, matching the "core" source
         // the DebugBar module lists on its Logs page and keeping it clearly distinct from
@@ -169,14 +170,6 @@ if (!function_exists('xoops_getDebugConfig')) {
         // one level further down.
         $loaded['core_log']['enabled']    = true === ($loaded['core_log']['enabled'] ?? false);
         $loaded['database']['legacy_log'] = true === ($loaded['database']['legacy_log'] ?? false);
-        $loaded['ray']['enabled']         = true === ($loaded['ray']['enabled'] ?? false);
-
-        // The DebugBar module reads this as a SECOND activation source, alongside the
-        // database-backed Admin -> Preferences -> Debug Mode. Normalised here rather than
-        // in the module so it gets the same strict treatment as every other switch: the
-        // module reads it with a truthiness test somewhere, and 'false' as a string is
-        // truthy, which is the exact trap closed above for the other three.
-        $loaded['debugbar']['enabled']    = true === ($loaded['debugbar']['enabled'] ?? false);
 
         // Exactly one component may own PHP's error and exception handlers. The value is
         // a free-form token naming that component, resolved by xoops_getErrorScreenOwner()
@@ -194,7 +187,22 @@ if (!function_exists('xoops_getDebugConfig')) {
             ? strtolower(trim($screen))
             : 'auto';
 
+        // Opt-in hard gate. Off by default, and that default is the whole design: core
+        // passes 'developer_request' to the provider and lets it decide, because a
+        // provider may legitimately render a PRODUCTION-SAFE page for anonymous visitors
+        // and core cannot tell that apart from a stack trace full of superglobals.
+        //
+        // A site that does not want to extend that trust to every provider it might ever
+        // install can say so here, and then core does not dispatch at all for a
+        // non-developer request. Same strict-boolean treatment as every other switch.
+        $loaded['error_screen_strict'] = true === ($loaded['error_screen_strict'] ?? false);
+
         // Alias, kept in step with core_log so pre-2.7.3 consumers see the same array.
+        //
+        // @deprecated 2.7.3 Read 'core_log'. The 'log' spelling is accepted as INPUT and
+        // published as output through the 2.7.x line, and comes out in 2.8.0 -- named now,
+        // while it costs one line, because an alias with no expiry is a permanent second
+        // vocabulary that nobody ever feels entitled to remove.
         $loaded['log'] = $loaded['core_log'];
 
         $config = $loaded;
@@ -328,9 +336,16 @@ if (!function_exists('xoops_recordErrorScreenOwner')) {
      *
      * Called by a provider module's install and uninstall routines, not at request time.
      *
-     * The rule is first-installed-wins, and it is enforced HERE rather than trusted to
-     * each provider: a second provider installing must not be able to take a screen the
-     * first one is already showing, however it was written.
+     * The rule is first-installed-wins, enforced HERE against ordinary claims rather than
+     * trusted to each provider: a second provider installing must not take a screen the
+     * first one is already showing, however carelessly it was written.
+     *
+     * Enforced against ORDINARY claims -- the precise wording matters. $force skips the
+     * precondition, and is how a deliberate handover happens once the holder is gone or
+     * inactive. Module code is trusted code and could take the seat regardless, so this is
+     * a correctness boundary rather than a security one: it stops an accident, not an
+     * attacker. An earlier version of this docblock said "cannot take a seat another
+     * module is sitting in even if it asks", which promised more than the parameter list.
      *
      * This function only CLAIMS. Release through xoops_releaseErrorScreenOwner($dirname),
      * which checks that you are the holder first -- there is no caller identity here, so
@@ -373,11 +388,27 @@ if (!function_exists('xoops_recordErrorScreenOwner')) {
             return false;
         }
 
+        // Fail fast on the obvious refusal, so a caller that is plainly not entitled to
+        // the seat does not touch the file at all. This is a courtesy, NOT the guard --
+        // $held was read outside the lock and may already be stale by the time we act on
+        // it. The guard that counts is the $expect below, evaluated inside the lock.
         if ('' !== $held && $held !== $token && !$force) {
             return false;
         }
 
-        return xoops_writeDebugRuntimeOverride(['error_screen_owner' => $token]);
+        // Compare-and-set: write only if the seat is still free or already ours.
+        //
+        // Without this, two modules installing at the same moment can both read an empty
+        // owner, both pass the check above, and both write -- so "the first provider
+        // installed wins" quietly becomes "whichever finished last wins". A narrow race,
+        // but the rule it breaks is the one this whole mechanism exists to state.
+        //
+        // $force skips the precondition, which is what makes it a deliberate handover
+        // rather than a louder claim: a provider's update hook uses it after establishing
+        // that the holder is gone or inactive, a question core's bootstrap cannot answer.
+        $expect = $force ? null : ['error_screen_owner' => ['', $token]];
+
+        return xoops_writeDebugRuntimeOverride(['error_screen_owner' => $token], $expect);
     }
 }
 
@@ -391,11 +422,26 @@ if (!function_exists('xoops_releaseErrorScreenOwner')) {
     function xoops_releaseErrorScreenOwner($token)
     {
         $token = is_string($token) ? strtolower(trim($token)) : '';
-        if ('' === $token || xoops_getRecordedErrorScreenOwner() !== $token) {
+        if ('' === $token) {
+            return true;
+        }
+        if (xoops_getRecordedErrorScreenOwner() !== $token) {
+            // Not ours to release, and that is a success: the caller wanted the record to
+            // stop naming it, and it does not.
             return true;
         }
 
-        return xoops_writeDebugRuntimeOverride(['error_screen_owner' => null]);
+        // ...but re-checked inside the lock, because between the read above and the write
+        // below a forced transfer can have handed the seat to somebody else. An
+        // unconditional delete here would erase the new owner's record on the way out.
+        $done = xoops_writeDebugRuntimeOverride(
+            ['error_screen_owner' => null],
+            ['error_screen_owner' => [$token]]
+        );
+
+        // A refusal means the seat changed hands while we were uninstalling. The record no
+        // longer names us either way, which is what the caller asked for.
+        return $done || xoops_getRecordedErrorScreenOwner() !== $token;
     }
 }
 
@@ -474,23 +520,6 @@ if (!function_exists('xoops_isDeveloperRequest')) {
     }
 }
 
-if (!function_exists('xoops_mayRegisterErrorScreen')) {
-    /**
-     * May this component take over the error screen?
-     *
-     * The single question every contender asks before calling register()/enable().
-     * Callers should guard with function_exists() so they keep working on a core that
-     * predates this seam.
-     *
-     * @param string $component the caller's own owner token
-     * @return bool
-     */
-    function xoops_mayRegisterErrorScreen($component)
-    {
-        return is_string($component) && $component === xoops_getErrorScreenOwner();
-    }
-}
-
 if (!function_exists('xoops_applyDebugConfig')) {
     /**
      * Apply the PHP-level settings: display_errors and error_reporting.
@@ -518,8 +547,6 @@ if (!function_exists('xoops_applyDebugConfig')) {
         // defined() and pick a fallback, and the fallbacks drift apart.
         defined('XOOPS_ENVIRONMENT') || define('XOOPS_ENVIRONMENT', xoops_getDebugEnvironment());
         defined('XOOPS_ENV') || define('XOOPS_ENV', XOOPS_ENVIRONMENT);
-        defined('RAY_ENABLED')
-            || define('RAY_ENABLED', [] !== $config && true === ($config['ray']['enabled'] ?? false));
 
         if ([] === $config) {
             return false;
@@ -527,6 +554,11 @@ if (!function_exists('xoops_applyDebugConfig')) {
 
         // Strict booleans only: a string such as 'false' is truthy and would turn
         // display_errors ON against the stated intent.
+        // Only when the key is present, unlike error_reporting which has a documented
+        // default. Deliberate: the absence of a display_errors setting means "leave
+        // php.ini alone", and php.ini's answer on a server is more likely to be right for
+        // that server than a default invented here. The asymmetry is worth a line because
+        // it reads like an oversight.
         if (array_key_exists('display_errors', $config)) {
             ini_set('display_errors', true === $config['display_errors'] ? '1' : '0');
         }
@@ -599,6 +631,11 @@ if (!function_exists('xoops_getErrorScreenStatus')) {
      *
      * Meaningful only after xoops_activateErrorScreen() has run; before that, and on a
      * core too old to have the seam, every value is an empty string.
+     *
+     * The message is PLAIN TEXT and interpolates the owner token verbatim. Anything
+     * rendering it into HTML must escape it. The token is a lowercased dirname or a value
+     * an admin wrote into debug.php -- both privileged -- so this is a note for consumers
+     * rather than a hole, but it is not pre-sanitised and nobody should assume it is.
      *
      * @return array ['owner' => string, 'source' => string, 'status' => string, 'message' => string]
      */
@@ -682,10 +719,19 @@ if (!function_exists('xoops_writeDebugRuntimeOverride')) {
      * Written to a temporary file and renamed, so a reader never sees a half-written
      * file: on every platform this matters on, rename over an existing path is atomic.
      *
-     * @param array $changes keys to set, or set to null to remove
+     * $expect makes the whole thing a compare-and-set. Pass ['key' => [allowed, values]]
+     * and the write only happens if the file's current value for that key is one of them
+     * -- checked INSIDE the lock, which is the only place a check can mean anything. A
+     * caller that reads first and then writes has already lost: between its read and its
+     * write, another request can have changed the value it was relying on.
+     *
+     * @param array      $changes keys to set, or set to null to remove
+     * @param array|null $expect  key => list of acceptable current values, or null for
+     *                            an unconditional write. A key absent from the file
+     *                            reads as ''.
      * @return bool true when the file now reflects $changes
      */
-    function xoops_writeDebugRuntimeOverride($changes)
+    function xoops_writeDebugRuntimeOverride($changes, $expect = null)
     {
         if (!is_array($changes) || [] === $changes || !defined('XOOPS_VAR_PATH')) {
             return false;
@@ -708,6 +754,22 @@ if (!function_exists('xoops_writeDebugRuntimeOverride')) {
         }
 
         $current = xoops_readDebugRuntimeOverride(true);
+
+        // The precondition, re-read under the lock. Anything the caller checked before
+        // calling is stale by definition, however carefully it looked.
+        if (is_array($expect)) {
+            foreach ($expect as $key => $acceptable) {
+                $held = $current[$key] ?? '';
+                $held = is_string($held) ? $held : '';
+                if (!in_array($held, (array) $acceptable, true)) {
+                    flock($lockHandle, LOCK_UN);
+                    fclose($lockHandle);
+
+                    return false;
+                }
+            }
+        }
+
         foreach ($changes as $key => $value) {
             if (null === $value) {
                 unset($current[$key]);
@@ -716,11 +778,18 @@ if (!function_exists('xoops_writeDebugRuntimeOverride')) {
             $current[$key] = $value;
         }
 
-        // JSON_FORCE_OBJECT so a file emptied of every key stays {} rather than turning
-        // into [], which is what an empty PHP array encodes to. Both decode to an empty
-        // array here, but a consumer in another language reading [] where it expected an
-        // object has been handed a different type by an implementation detail.
-        $json      = json_encode($current, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_FORCE_OBJECT);
+        // The empty document is the only one that needs forcing: a file emptied of every
+        // key would otherwise encode as [], because that is what an empty PHP array is.
+        // Both decode to an empty array here, but a consumer in another language reading
+        // [] where it expected an object has been handed a different type by an
+        // implementation detail.
+        //
+        // JSON_FORCE_OBJECT would do it -- and would also quietly turn any nested LIST a
+        // future writer stores into {"0":...}. Nothing stores one today, which is exactly
+        // why it would be found late and by somebody who did not put it there.
+        $json = [] === $current
+            ? '{}'
+            : json_encode($current, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
         $file      = $directory . '/debug-runtime.json';
         $temporary = $file . '.' . getmypid() . '.tmp';
         $written   = false;
@@ -770,6 +839,11 @@ if (!function_exists('xoops_activateErrorScreen')) {
      *                        anonymous visitors. A provider that exposes source, file
      *                        paths, request data or superglobals MUST refuse when this is
      *                        false -- the one obligation core cannot check for you.
+     *                        A site that would rather not take that on trust can set
+     *                        'error_screen_strict' => true in debug.php, and then core
+     *                        does not dispatch at all when this would be false. Off by
+     *                        default, because enforcing it for everybody would forbid a
+     *                        provider from rendering a production-safe page.
      *   'report'             callable(string $status, string $message = ''): bool
      *                        Call it exactly once, whatever happened -- INCLUDING when you
      *                        decide not to register. "I am installed and chose to stay
@@ -778,6 +852,17 @@ if (!function_exists('xoops_activateErrorScreen')) {
      *                        calls return false. Any short lower-case status is valid and
      *                        core does not interpret it; the shipped vocabulary is
      *                        active | disabled | missing | incompatible | error.
+     *                        ONE exception: reporting 'error' tells core the activation
+     *                        failed, and core restores the error and exception handlers it
+     *                        held before the dispatch. Report 'error' only when you mean
+     *                        it, and register your handlers LAST -- after everything that
+     *                        can throw -- because a shutdown function you have already
+     *                        registered cannot be taken back by core or by anyone.
+     *                        Register BEFORE you report, never after: core compares who
+     *                        holds the handlers at your report against who holds them at
+     *                        the end of the dispatch, to detect a second module
+     *                        registering on top of you. Reporting first makes your own
+     *                        registration look like exactly that.
      *
      * Passing the reporter in the event rather than exposing a global setter keeps the
      * outcome in this function's own scope: the catch below can finalise a status without
@@ -788,7 +873,14 @@ if (!function_exists('xoops_activateErrorScreen')) {
      *   XOOPS_ERROR_SCREEN_OWNER    the owner token, 'core' when none applies
      *   XOOPS_ERROR_SCREEN_SOURCE   config | recorded | default -- where that came from
      *   XOOPS_ERROR_SCREEN_STATUS   core | dormant | active | disabled | unclaimed |
-     *                               error, or whatever else the provider reported
+     *                               error | contested | suppressed, or whatever else the
+     *                               provider reported. 'suppressed' means the site set
+     *                               error_screen_strict and this was not a developer
+     *                               request, so nothing was dispatched at all.
+     *                               'contested' is core's own: more than one
+     *                               listener registered for one token, so the handlers
+     *                               went back to XoopsLogger rather than staying with
+     *                               whichever module happened to run last
      *   XOOPS_ERROR_SCREEN_MESSAGE  a short human explanation of that status
      *
      * Defining them unconditionally is what lets an admin screen tell "no provider is
@@ -834,18 +926,65 @@ if (!function_exists('xoops_activateErrorScreen')) {
                     . ' only under the file-based debug configuration -- Admin -> Preferences ->'
                     . ' Debug Mode does not activate it.';
             }
+        } elseif (true === (xoops_getDebugConfig()['error_screen_strict'] ?? false)
+                  && !(function_exists('xoops_isDeveloperRequest') && xoops_isDeveloperRequest())) {
+            // The site asked core to enforce the gate rather than advise it, and this
+            // request is not a developer's. Nothing is dispatched, so no provider gets the
+            // chance to decide for itself.
+            //
+            // Reported under its own status rather than as 'core': "the screen you
+            // configured was suppressed for this request" and "you configured no screen"
+            // are different situations, and a provider author staring at a page with no
+            // BlueScreen needs to be able to tell which one they are looking at.
+            $status  = 'suppressed';
+            $message = 'The error screen "' . $owner . '" was not offered this request:'
+                . ' error_screen_strict is on and this is not a developer request.';
         } else {
             $outcome = ['status' => '', 'message' => ''];
 
+            // Read the handlers we are about to lend out, without disturbing them.
+            //
+            // set_*_handler() returns the previous handler and installs the new one, so
+            // the restore() immediately after puts the stack back exactly as it was. This
+            // is the only way to READ the current handler in PHP; there is no getter.
+            //
+            // Kept so that a provider which fails AFTER registering can be undone -- see
+            // the rollback below the dispatch. Snapshotted here rather than inside the
+            // try, because a failure is exactly the case where the try's scope is the
+            // wrong place to be keeping the thing that repairs it.
+            $priorErrorHandler     = set_error_handler(null);
+            restore_error_handler();
+            $priorExceptionHandler = set_exception_handler(null);
+            restore_exception_handler();
+
             // First caller wins. Two providers answering one token is a misconfiguration,
             // and the second silently overwriting the first is the load-order roulette the
-            // owner token exists to end. Note this governs the REPORT only: the preload
-            // dispatcher runs every listener, so two providers would both still register
-            // and the later one would own the handlers while the status describes the
-            // earlier. Core cannot prevent that; it can refuse to lie about which one it
-            // heard from first.
-            $report = static function ($status, $message = '') use (&$outcome) {
+            // owner token exists to end.
+            //
+            // Stated exactly, because the honest version is narrower than "exactly one
+            // module owns the error screen": the preload dispatcher runs every listener,
+            // so core cannot stop a second one registering. What core does is DETECT that
+            // it happened -- by the refusal count below, and by comparing who held the
+            // handlers when the winning report arrived against who holds them at the end
+            // -- publish it as 'contested', and put the handlers back where they were. A
+            // registry that invoked exactly one provider would PREVENT it instead; that is
+            // the 2.8 direction, not this one.
+            $refusedReports          = 0;
+            $handlerAtFirstReport    = null;
+            $exceptionAtFirstReport  = null;
+
+            $report = static function ($status, $message = '') use (
+                &$outcome,
+                &$refusedReports,
+                &$handlerAtFirstReport,
+                &$exceptionAtFirstReport
+            ) {
                 if ('' !== $outcome['status']) {
+                    // Refused -- but remembered. A second module answering one token is
+                    // the misconfiguration this whole mechanism exists to surface, and
+                    // core knew about it all along and threw the knowledge away.
+                    ++$refusedReports;
+
                     return false;
                 }
                 $status = is_string($status) ? trim($status) : '';
@@ -857,8 +996,20 @@ if (!function_exists('xoops_activateErrorScreen')) {
                     'message' => is_string($message) ? $message : '',
                 ];
 
+                // Whoever holds the handlers at the moment the winning report is accepted.
+                // If that is not who holds them when the dispatch ends, a later listener
+                // registered on top -- the case the published status would otherwise
+                // describe wrongly. Assumes a provider registers BEFORE it reports, which
+                // the contract above now requires.
+                $handlerAtFirstReport = set_error_handler(null);
+                restore_error_handler();
+                $exceptionAtFirstReport = set_exception_handler(null);
+                restore_exception_handler();
+
                 return true;
             };
+
+            $dispatchThrew = false;
 
             // One boundary around the whole dispatch. An error screen is a debugging
             // convenience; a broken or half-installed provider must not be able to take
@@ -880,6 +1031,7 @@ if (!function_exists('xoops_activateErrorScreen')) {
                 // provider that failed, and the outcome it wrote is stale by the time we
                 // are here -- which is exactly why the outcome lives in this scope and not
                 // in a store that would have refused this correction.
+                $dispatchThrew = true;
                 $status  = 'error';
                 $message = 'Error screen "' . $owner . '" failed to start (' . get_class($e) . ').';
             }
@@ -899,6 +1051,94 @@ if (!function_exists('xoops_activateErrorScreen')) {
                 $status  = 'unclaimed';
                 $message = 'No active module claims the error screen "' . $owner
                     . '"; the handlers stay with XoopsLogger.';
+            }
+
+            // A failed provider does not get to keep the handlers.
+            //
+            // Core promises above that a broken or half-installed provider cannot take the
+            // site down. Without this it can: a provider that calls set_error_handler()
+            // and only then fails still owns PHP's handlers for the rest of the request,
+            // while the constants below say the activation failed. The site's error path
+            // then belongs to something core has already declared broken.
+            //
+            // Keyed on the OUTCOME, not on the catch. Both reference providers wrap their
+            // own activation in a try/catch and report 'error' without ever throwing at
+            // core -- xtracy around Debugger::enable(), xwhoops around registerWhoops() --
+            // so a restore that lived in the catch above would miss the two implementations
+            // shipped as the worked examples.
+            //
+            // 'error' is therefore the one status core interprets. Every other status is
+            // still opaque to core and passed through untouched.
+            //
+            // Two honest limits. set_*_handler() pushes a frame rather than popping one,
+            // so this restores the EFFECTIVE handler at one extra stack level -- correct,
+            // and cheap on the last line of a bootstrap. And a shutdown function the
+            // provider registered CANNOT be removed by anybody; providers close that
+            // residue by doing everything that can throw before they register, not after.
+            // Who ended up with the handlers, whatever anybody said about it.
+            //
+            // BOTH of them. An earlier version of this compared only the error handler,
+            // which missed a listener that takes just the exception handler -- and PHP
+            // will hand you one without the other perfectly happily. The prose says
+            // "handlers", plural, so the check has to mean it.
+            $finalErrorHandler = set_error_handler(null);
+            restore_error_handler();
+            $finalExceptionHandler = set_exception_handler(null);
+            restore_exception_handler();
+
+            // Registration is not mediated; only reporting is.
+            //
+            // The preload dispatcher runs every listener. The reporter closure decides
+            // which OUTCOME is published, but nothing stops a second listener calling
+            // set_error_handler() after the first, and that loser owns the handlers while
+            // the constants describe the winner. Core cannot prevent this without
+            // replacing the broadcast with a registry -- but it can notice, say so, and
+            // refuse to leave a contested seat occupied.
+            //
+            // Three ways the published outcome can be a lie. Core has the evidence for all
+            // three and used to discard it.
+            $contested = '';
+            if ($refusedReports > 0) {
+                // Two modules answered one token and both reported. Unambiguous.
+                $contested = $refusedReports . ' further module(s) answered the error screen "'
+                    . $owner . '" after the first; core cannot tell which one holds the handlers.';
+            } elseif ('' !== $outcome['status']
+                      && ($handlerAtFirstReport !== $finalErrorHandler
+                          || $exceptionAtFirstReport !== $finalExceptionHandler)) {
+                // Somebody registered after the module whose report was accepted.
+                $contested = 'A second listener registered handlers after "' . $owner
+                    . '" reported, so the published status may not describe the module that holds them.';
+            } elseif (!$dispatchThrew && '' === $outcome['status']
+                      && ($priorErrorHandler !== $finalErrorHandler
+                          || $priorExceptionHandler !== $finalExceptionHandler)) {
+                // Nobody reported, yet the handlers moved. Without this the status below
+                // reads 'unclaimed' -- "the handlers stay with XoopsLogger" -- which in
+                // this case is flatly false.
+                //
+                // Not when the dispatch THREW, though. A provider that registers and then
+                // throws before it can report looks identical to a silent second listener
+                // from the handlers alone -- but it is not identical, and core knows the
+                // difference, because it caught the exception. 'error' is the more
+                // specific and more useful answer, so it wins; overwriting it with
+                // 'contested' would report a multi-listener problem that did not happen.
+                $contested = 'A module registered handlers for the error screen "' . $owner
+                    . '" without reporting an outcome.';
+            }
+
+            // Hand the handlers back on failure, and on a contested seat.
+            //
+            // Reporting the problem while leaving the last registrant installed would keep
+            // the guarantee false and merely annotate it. Falling back to XoopsLogger is
+            // the direction the rest of this design fails in: a surprise toward core is
+            // recoverable, a surprise toward a module is not.
+            if ('error' === $status || '' !== $contested) {
+                set_error_handler($priorErrorHandler);
+                set_exception_handler($priorExceptionHandler);
+            }
+
+            if ('' !== $contested) {
+                $status  = 'contested';
+                $message = $contested . ' The handlers were returned to XoopsLogger.';
             }
         }
 

--- a/htdocs/include/debugconfig.php
+++ b/htdocs/include/debugconfig.php
@@ -716,7 +716,11 @@ if (!function_exists('xoops_writeDebugRuntimeOverride')) {
             $current[$key] = $value;
         }
 
-        $json      = json_encode($current, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        // JSON_FORCE_OBJECT so a file emptied of every key stays {} rather than turning
+        // into [], which is what an empty PHP array encodes to. Both decode to an empty
+        // array here, but a consumer in another language reading [] where it expected an
+        // object has been handed a different type by an implementation detail.
+        $json      = json_encode($current, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_FORCE_OBJECT);
         $file      = $directory . '/debug-runtime.json';
         $temporary = $file . '.' . getmypid() . '.tmp';
         $written   = false;

--- a/htdocs/mainfile.dist.php
+++ b/htdocs/mainfile.dist.php
@@ -96,8 +96,11 @@ if (!defined('XOOPS_MAINFILE_INCLUDED')) {
         } catch (\Throwable $e) {
             // Deliberately silent. Nothing has configured error display yet, so anything
             // said here is said under php.ini's rules -- which on a misconfigured host
-            // means a path printed to whoever loaded the page. The reason is recorded by
-            // xoops_getDebugConfigError() and surfaced by DebugBar's Diagnostics instead.
+            // means a path printed to whoever loaded the page.
+            //
+            // Nothing is recorded either: xoops_setDebugConfigError() lives in the file
+            // that just failed to parse. It records a broken debug.php, not a broken
+            // debugconfig.php, and an earlier comment here claimed otherwise.
         }
     }
     unset($xoopsDebugLoader);
@@ -107,9 +110,11 @@ if (!defined('XOOPS_MAINFILE_INCLUDED')) {
     // missing one is a fatal before secure.php is even read.
     if (function_exists('xoops_getDebugConfig') && function_exists('xoops_applyDebugConfig')) {
         $xoopsDebugConfig = xoops_getDebugConfig();
-        if ([] !== $xoopsDebugConfig) {
-            xoops_applyDebugConfig();
-        }
+
+        // Unconditionally: it publishes XOOPS_ENVIRONMENT, XOOPS_ENV and RAY_ENABLED
+        // before it looks at the config at all, and those are documented as existing on
+        // every request. With no debug.php it defines them and returns.
+        xoops_applyDebugConfig();
     }
 
     define('XOOPS_DB_LEGACY_LOG', !empty($xoopsDebugConfig['database']['legacy_log']));

--- a/htdocs/mainfile.dist.php
+++ b/htdocs/mainfile.dist.php
@@ -83,11 +83,31 @@ if (!defined('XOOPS_MAINFILE_INCLUDED')) {
     // then be a fatal "Call to undefined function" -- taking the whole site down before
     // secure.php is even read. mainfile.php survives upgrades while include/ is replaced,
     // so a partial or interrupted upgrade can genuinely produce this pairing.
-    $xoopsDebugConfig = [];
-    if (is_readable(XOOPS_ROOT_PATH . '/include/debugconfig.php')) {
-        include_once XOOPS_ROOT_PATH . '/include/debugconfig.php';
-        if (function_exists('xoops_getDebugConfig')) {
-            $xoopsDebugConfig = xoops_getDebugConfig();
+    $xoopsDebugConfig  = [];
+    $xoopsDebugLoader  = XOOPS_ROOT_PATH . '/include/debugconfig.php';
+
+    if (is_readable($xoopsDebugLoader)) {
+        // try/catch, not just is_readable(). The realistic failure here is not a MISSING
+        // file -- is_readable() covers that -- but a TRUNCATED one, left by an upload or
+        // a write that died halfway. That is a ParseError, and a ParseError raised by an
+        // include IS catchable, unlike one in this file. Fail closed to production.
+        try {
+            require_once $xoopsDebugLoader;
+        } catch (\Throwable $e) {
+            // Deliberately silent. Nothing has configured error display yet, so anything
+            // said here is said under php.ini's rules -- which on a misconfigured host
+            // means a path printed to whoever loaded the page. The reason is recorded by
+            // xoops_getDebugConfigError() and surfaced by DebugBar's Diagnostics instead.
+        }
+    }
+    unset($xoopsDebugLoader);
+
+    // BOTH functions, not just the first. They live in one file, so a half-written copy
+    // of it is exactly the state that defines one and not the other -- and calling the
+    // missing one is a fatal before secure.php is even read.
+    if (function_exists('xoops_getDebugConfig') && function_exists('xoops_applyDebugConfig')) {
+        $xoopsDebugConfig = xoops_getDebugConfig();
+        if ([] !== $xoopsDebugConfig) {
             xoops_applyDebugConfig();
         }
     }

--- a/htdocs/mainfile.dist.php
+++ b/htdocs/mainfile.dist.php
@@ -111,9 +111,9 @@ if (!defined('XOOPS_MAINFILE_INCLUDED')) {
     if (function_exists('xoops_getDebugConfig') && function_exists('xoops_applyDebugConfig')) {
         $xoopsDebugConfig = xoops_getDebugConfig();
 
-        // Unconditionally: it publishes XOOPS_ENVIRONMENT, XOOPS_ENV and RAY_ENABLED
-        // before it looks at the config at all, and those are documented as existing on
-        // every request. With no debug.php it defines them and returns.
+        // Unconditionally: it publishes XOOPS_ENVIRONMENT and XOOPS_ENV before it looks
+        // at the config at all, and those are documented as existing on every request.
+        // With no debug.php it defines them and returns.
         xoops_applyDebugConfig();
     }
 

--- a/htdocs/xoops_data/data/debug.dist.php
+++ b/htdocs/xoops_data/data/debug.dist.php
@@ -69,11 +69,19 @@ if (!defined('XOOPS_ROOT_PATH')) {
 return [
     // Master switch. false leaves XOOPS in its normal production behaviour even
     // if the rest of this file says otherwise.
+    //
+    // MUST be a real boolean, and this applies to every 'enabled' in this file. Anything
+    // else -- 1, 'true', 'yes' -- is treated as false and debugging stays OFF, silently.
+    // That is deliberate rather than lax: a string is truthy whatever it says, so a
+    // lenient test would read 'false' as ON, which is the dangerous direction to be wrong
+    // in. It does mean 'enabled' => 1 leaves this file doing nothing at all, and this is
+    // the line where that is most likely to be typed.
     'enabled' => true,
 
-    // 'development' | 'production'. Read by xoops_getDebugEnvironment() and published as
-    // XOOPS_ENVIRONMENT / XOOPS_ENV, for any component that behaves differently on a
-    // developer's machine than on a live site.
+    // 'development' | 'staging' | 'production'. Read by xoops_getDebugEnvironment() and
+    // published as XOOPS_ENVIRONMENT / XOOPS_ENV, for any component that behaves
+    // differently on a developer's machine than on a live site. Anything else falls back
+    // to 'production' -- the safe end -- rather than being passed through.
     'environment' => 'development',
 
     // Sets XOOPS_DEBUG, and PHP's display_errors / error_reporting, as early as
@@ -113,7 +121,48 @@ return [
     //
     // A provider may read its own settings from this file under its own key -- core
     // passes unknown keys through untouched and never interprets them.
+    //
+    // Whatever happens, four constants are published on EVERY request, so a site can
+    // always find out what is going on without guessing:
+    //
+    //     XOOPS_ERROR_SCREEN_OWNER     the token that won, or 'core'
+    //     XOOPS_ERROR_SCREEN_SOURCE    config | recorded | default -- where it came from
+    //     XOOPS_ERROR_SCREEN_STATUS    see below
+    //     XOOPS_ERROR_SCREEN_MESSAGE   one sentence explaining that status
+    //
+    // The statuses core itself can publish:
+    //
+    //     core        nothing was asked for; XoopsLogger keeps the handlers
+    //     dormant     a provider is recorded, but this file is absent or disabled
+    //     unclaimed   the owner names a module that did not answer -- deactivated,
+    //                 uninstalled, or a token nothing was ever going to answer
+    //     error       the provider failed to start; core took the handlers back
+    //     suppressed  error_screen_strict is on and this was not a developer request,
+    //                 so no provider was offered the seat at all
+    //     contested   more than one module registered for the token, so core could not
+    //                 tell which one held the handlers and returned them to XoopsLogger
+    //
+    // A provider reports its own outcome too, and core publishes that verbatim without
+    // interpreting it. The shipped vocabulary is active | disabled | missing |
+    // incompatible | error.
     'error_screen' => 'auto',
+
+    // Enforce the developer gate instead of advising it. Off by default.
+    //
+    // Core works out whether diagnostics may be exposed to whoever is making the request
+    // -- debugging on, and an authenticated member of the webmaster group -- and passes
+    // the answer to the provider, which is expected to refuse when it is false. That is
+    // an obligation, not a lock: a provider MAY legitimately render a production-safe
+    // page for anonymous visitors, and core cannot tell that apart from a stack trace
+    // full of superglobals, so it does not try.
+    //
+    // Turn this on and core stops dispatching altogether for a non-developer request, so
+    // a provider that ignored the flag never gets the chance. The status reads
+    // 'suppressed' on those requests, which is deliberately not the same as 'core'.
+    //
+    // Worth it if you install providers you have not read. Leave it off if you rely on a
+    // provider's production-safe error page, because this switches that off too.
+    'error_screen_strict' => false,
 
     'database' => [
         // Sets XOOPS_DB_LEGACY_LOG, which makes the database layer report legacy call
@@ -123,18 +172,17 @@ return [
         'legacy_log' => false,
     ],
 
-    'ray' => [
-        'enabled' => false,
-    ],
-
     // The DebugBar module, as a SECOND activation source alongside the database-backed
     // Admin -> Preferences -> Debug Mode. Either switches the toolbar on; the module's own
     // 'debugbar_enable' preference and the authenticated-administrator requirement still
     // apply, and neither is configurable from here. Useful on a local checkout where you
     // would rather not carry a debug flag in the database.
     //
-    // Must be a real boolean: the core coerces anything else to false, so 'true' as a
-    // string will NOT switch this on.
+    // Must be a real boolean. The DebugBar module tests this with a strict comparison,
+    // so 'true' as a STRING will NOT switch it on -- and a string is what you get if you
+    // copy a value out of an .env file or a form. Core does not normalise this block: it
+    // passes the key through untouched, exactly as it does for a provider module's own
+    // settings, and the module that owns the setting is the one that validates it.
     'debugbar' => [
         'enabled' => false,
     ],

--- a/htdocs/xoops_data/data/debug.dist.php
+++ b/htdocs/xoops_data/data/debug.dist.php
@@ -104,6 +104,13 @@ return [
     // another installed provider: it falls back to core behaviour and reports
     // 'unclaimed'. Ownership only ever changes when somebody asks for it.
     //
+    // The error screen is activated by THIS FILE only. Admin -> Preferences -> Debug Mode
+    // remains what it has always been -- XoopsLogger rendering its log into the page --
+    // and does not hand PHP's handlers to a module: writing this file takes filesystem
+    // access, which is the privilege that matches the exposure an error screen risks, and
+    // an admin session is not. A provider installed on a site with no debug.php reports
+    // 'dormant' rather than failing silently.
+    //
     // A provider may read its own settings from this file under its own key -- core
     // passes unknown keys through untouched and never interprets them.
     'error_screen' => 'auto',

--- a/htdocs/xoops_data/data/debug.dist.php
+++ b/htdocs/xoops_data/data/debug.dist.php
@@ -71,11 +71,42 @@ return [
     // if the rest of this file says otherwise.
     'enabled' => true,
 
+    // 'development' | 'production'. Read by xoops_getDebugEnvironment() and published as
+    // XOOPS_ENVIRONMENT / XOOPS_ENV, for any component that behaves differently on a
+    // developer's machine than on a live site.
+    'environment' => 'development',
+
     // Sets XOOPS_DEBUG, and PHP's display_errors / error_reporting, as early as
     // the bootstrap allows. E_ALL includes the E_USER_DEPRECATED notices XOOPS
     // raises for legacy module APIs.
     'display_errors'  => true,
     'error_reporting' => E_ALL,
+
+    // Who owns PHP's error and exception handlers.
+    //
+    // 'auto' -- the default -- means the first error-screen module you installed, which
+    // recorded itself in debug-runtime.json at install time. Install one module and it
+    // works; install a second and it tells you the seat is taken and leaves it alone.
+    // With none installed this is 'core': XoopsLogger keeps both handlers and DebugBar
+    // receives everything.
+    //
+    // Naming a module here instead pins it, and beats whatever was recorded. The token is
+    // the provider MODULE'S DIRNAME -- 'xwhoops', and so on -- so this line names the
+    // directory to go and look in. Core ships no provider, keeps no list of them, and
+    // does not know what any token means; a module may also answer to older spellings of
+    // its own choosing.
+    //
+    //     'error_screen' => 'auto',      first installed provider (default)
+    //     'error_screen' => 'core',      never hand the handlers to anything
+    //     'error_screen' => 'xwhoops',   pin this one, whatever else is installed
+    //
+    // A pinned or recorded module that is deactivated does NOT pass the screen to
+    // another installed provider: it falls back to core behaviour and reports
+    // 'unclaimed'. Ownership only ever changes when somebody asks for it.
+    //
+    // A provider may read its own settings from this file under its own key -- core
+    // passes unknown keys through untouched and never interprets them.
+    'error_screen' => 'auto',
 
     'database' => [
         // Sets XOOPS_DB_LEGACY_LOG, which makes the database layer report legacy call
@@ -85,6 +116,22 @@ return [
         'legacy_log' => false,
     ],
 
+    'ray' => [
+        'enabled' => false,
+    ],
+
+    // The DebugBar module, as a SECOND activation source alongside the database-backed
+    // Admin -> Preferences -> Debug Mode. Either switches the toolbar on; the module's own
+    // 'debugbar_enable' preference and the authenticated-administrator requirement still
+    // apply, and neither is configurable from here. Useful on a local checkout where you
+    // would rather not carry a debug flag in the database.
+    //
+    // Must be a real boolean: the core coerces anything else to false, so 'true' as a
+    // string will NOT switch this on.
+    'debugbar' => [
+        'enabled' => false,
+    ],
+
     /*
      * Persistent log file.
      *
@@ -92,7 +139,7 @@ return [
      * still have it when a page dies before rendering — which is exactly when
      * you need it most. Notices and warnings are included, not only errors.
      */
-    'log' => [
+    'core_log' => [
         'enabled' => true,
 
         // Logging REFUSES to run while xoops_data sits inside the document root, because

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -941,7 +941,11 @@ class XoopsTestDatabasePreload extends XoopsPreloadItem
 $preloadInstance = XoopsPreload::getInstance();
 $ref = new ReflectionClass($preloadInstance);
 $prop = $ref->getProperty('_events');
-$prop->setAccessible(true);
+// The setAccessible() call that used to be here is gone: it has done nothing since PHP 8.1,
+// reflection reaches private members regardless, and PHP 8.5 deprecates it. Not cosmetic --
+// the deprecation is emitted during bootstrap, so it lands in the output of every test that
+// asserts on a clean stream, and it took out two XoopsFormTinymce7Test cases on 8.5 as
+// "PHPUnit\Framework\Exception".
 $events = $prop->getValue($preloadInstance);
 $events['coreclassdatabasedatabasefactoryconnection'][] = [
     'class_name' => 'XoopsTestDatabasePreload',
@@ -1004,7 +1008,7 @@ function xoops_getHandler($name, $optional = false)
                 while ($current) {
                     if ($current->hasProperty('db')) {
                         $prop = $current->getProperty('db');
-                        $prop->setAccessible(true);
+                        // See the note above: no-op since 8.1, deprecated in 8.5.
                         $prop->setValue($handler, $GLOBALS['xoopsDB']);
                         break;
                     }

--- a/tests/unit/htdocs/class/LostPassSecurityTest.php
+++ b/tests/unit/htdocs/class/LostPassSecurityTest.php
@@ -42,6 +42,75 @@ class LostPassSecurityTest extends KernelTestCase
 {
     private LostPassSecurity $security;
 
+    /**
+     * The IP / identifier pairs these tests feed to isRateLimited().
+     *
+     * Kept in one place because the cache purge below has to know them. Add a case that
+     * uses a new IP or identifier and it belongs here too, or the purge stops covering it.
+     *
+     * @var list<array{0: string, 1: string}>
+     */
+    private const RATE_LIMIT_INPUTS = [
+        ['127.0.0.1', 'test@example.com'],
+        ['127.0.0.1', ''],
+        ['192.168.1.1', 'uid:42'],
+    ];
+
+    /**
+     * Rate-limit state is on DISK, and it outlives the process.
+     *
+     * isRateLimited() counts attempts in XoopsCache, which the file engine keeps under
+     * xoops_data/caches/xoops_cache/. Nothing here ever removed them, so a second run of
+     * the suite in the same working copy read the FIRST run's attempts, crossed the limit
+     * and returned true where these tests assert false.
+     *
+     * The failure looks like a bug in whatever you changed most recently, which is what
+     * makes it worth fixing rather than documenting: it is a test that accuses the
+     * innocent. Purging on the way in as well as on the way out matters -- on the way out
+     * alone still leaves a run that was interrupted, or predates this fix, to poison the
+     * next one.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::purgeRateLimitCache();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::purgeRateLimitCache();
+        parent::tearDownAfterClass();
+    }
+
+    private static function purgeRateLimitCache(): void
+    {
+        if (! defined('XOOPS_ROOT_PATH')) {
+            return;
+        }
+        if (! class_exists('XoopsCache', false)) {
+            $file = XOOPS_ROOT_PATH . '/class/cache/xoopscache.php';
+            if (! is_file($file)) {
+                return;
+            }
+            require_once $file;
+        }
+        if (! class_exists('XoopsCache', false)) {
+            return;
+        }
+
+        // Mirrors LostPassSecurity::isRateLimited() -- same prefix, same hashing, same
+        // normalisation. Duplicated rather than exposed, because widening a private
+        // constant's visibility for a test is a worse trade than six lines that a comment
+        // ties to their original.
+        foreach (self::RATE_LIMIT_INPUTS as [$ip, $identifier]) {
+            \XoopsCache::delete('lostpass_rl_ip_' . hash('sha256', $ip));
+            $idNorm = strtolower(trim($identifier));
+            if ('' !== $idNorm) {
+                \XoopsCache::delete('lostpass_rl_id_' . hash('sha256', $idNorm));
+            }
+        }
+    }
+
     protected function setUp(): void
     {
         parent::setUp();

--- a/tests/unit/htdocs/class/MyTextSanitizerTest.php
+++ b/tests/unit/htdocs/class/MyTextSanitizerTest.php
@@ -261,23 +261,27 @@ class MyTextSanitizerTest extends TestCase
         $exceptionBefore = set_exception_handler(null);
         restore_exception_handler();
 
-        $out = $this->sanitizer->displayTarea('<script>alert(1)</script> visit https://xoops.org', 0);
-
-        for ($i = 0; $i < 16; ++$i) {
-            $current = set_error_handler(null);
-            restore_error_handler();
-            if ($current === $errorBefore) {
-                break;
+        // finally, so a throw out of displayTarea() cannot skip the cleanup and leak the
+        // logger's handlers into every later test in the process.
+        try {
+            $out = $this->sanitizer->displayTarea('<script>alert(1)</script> visit https://xoops.org', 0);
+        } finally {
+            for ($i = 0; $i < 16; ++$i) {
+                $current = set_error_handler(null);
+                restore_error_handler();
+                if ($current === $errorBefore) {
+                    break;
+                }
+                restore_error_handler();
             }
-            restore_error_handler();
-        }
-        for ($i = 0; $i < 16; ++$i) {
-            $current = set_exception_handler(null);
-            restore_exception_handler();
-            if ($current === $exceptionBefore) {
-                break;
+            for ($i = 0; $i < 16; ++$i) {
+                $current = set_exception_handler(null);
+                restore_exception_handler();
+                if ($current === $exceptionBefore) {
+                    break;
+                }
+                restore_exception_handler();
             }
-            restore_exception_handler();
         }
 
         $this->assertStringNotContainsString('<script>', $out);

--- a/tests/unit/htdocs/class/MyTextSanitizerTest.php
+++ b/tests/unit/htdocs/class/MyTextSanitizerTest.php
@@ -239,14 +239,46 @@ class MyTextSanitizerTest extends TestCase
 
     public function testDisplayTareaWithHtmlDisabledKeepsMarkupEncoded()
     {
+        // Snapshot first, and pop only what actually moved.
+        //
+        // displayTarea()'s legacy path reaches XoopsLogger::getInstance(), which installs
+        // an error and an exception handler and never restores them -- but only on its
+        // FIRST call in the process. `static $instance` means every later call returns the
+        // cached logger and installs nothing.
+        //
+        // So whether this test has anything to pop depends on what ran before it. Run this
+        // file alone and it does; run the full suite and something earlier has already
+        // built the logger, so an unconditional restore_*_handler() pair pops frames
+        // belonging to PHPUnit instead -- which PHPUnit reports as "removed error handlers
+        // other than its own", and failOnRisky would turn red. That is what the previous
+        // version of this teardown did, and it passed in isolation, which is why it stood.
+        //
+        // set_*_handler(null) followed by restore_*_handler() is the only way to read the
+        // current handler; the pair is net zero frames. Bounded, because a runaway loop in
+        // a test is a hung build rather than a failed one.
+        $errorBefore = set_error_handler(null);
+        restore_error_handler();
+        $exceptionBefore = set_exception_handler(null);
+        restore_exception_handler();
+
         $out = $this->sanitizer->displayTarea('<script>alert(1)</script> visit https://xoops.org', 0);
 
-        // displayTarea()'s legacy path installs an error and an exception handler
-        // and never restores them. Confirmed by PHPUnit: removing these two calls
-        // makes this test "risky — did not remove its own error/exception
-        // handlers". Pop them so handler state does not leak into later tests.
-        restore_error_handler();
-        restore_exception_handler();
+        for ($i = 0; $i < 16; ++$i) {
+            $current = set_error_handler(null);
+            restore_error_handler();
+            if ($current === $errorBefore) {
+                break;
+            }
+            restore_error_handler();
+        }
+        for ($i = 0; $i < 16; ++$i) {
+            $current = set_exception_handler(null);
+            restore_exception_handler();
+            if ($current === $exceptionBefore) {
+                break;
+            }
+            restore_exception_handler();
+        }
 
         $this->assertStringNotContainsString('<script>', $out);
         $this->assertStringContainsString('&lt;script&gt;', $out);

--- a/tests/unit/htdocs/include/ErrorScreenSeamTest.php
+++ b/tests/unit/htdocs/include/ErrorScreenSeamTest.php
@@ -19,6 +19,28 @@ use PHPUnit\Framework\TestCase;
  * publishes its outcome as constants, and constants are defined once per process; sharing
  * one would let the first case decide every later one. A subprocess is also the only
  * honest way to exercise a truncated include/debugconfig.php, which fails at compile time.
+ *
+ * ---------------------------------------------------------------------------------------
+ * IF YOU CHANGE ONE OF THE THREE CONTESTED DETECTORS, OR ONE OF THEIR CASES: break the
+ * detector by hand, re-run its case, and require RED before you put it back.
+ *
+ * This is not ceremony. One of these cases was once green against the exact regression it
+ * was named for -- its fixture took BOTH handlers, so detector 3 fired on the error handler
+ * and the exception-handler comparison the case existed to protect was never reached.
+ * Reverting detector 3 to the one-eyed version left the whole suite green. Nothing in a
+ * passing run can tell you that; only the mutant can.
+ *
+ * | Detector | The case that must kill it |
+ * |---|---|
+ * | 1 refused reports         | two listeners report; the second is refused |
+ * | 2 report-time vs final    | exception-only registration AFTER the accepted report |
+ * | 3 pre-dispatch vs final   | exception-only SILENT registration, with the first
+ * |                           | provider taking only the exception handler |
+ *
+ * The cases also carry self-guards (detector 3's asserts error_handler_is_provider is
+ * false) so that a later well-meaning fixture change fails loudly instead of quietly
+ * going vacuous again. ADR-0001 Appendix A is the long version.
+ * ---------------------------------------------------------------------------------------
  */
 #[CoversFunction('xoops_activateErrorScreen')]
 #[CoversFunction('xoops_getErrorScreenOwner')]
@@ -61,9 +83,17 @@ class ErrorScreenSeamTest extends TestCase
     {
         $spec['var_path'] = $spec['var_path'] ?? $this->varPath;
 
+        // base64, not raw JSON.
+        //
+        // escapeshellarg() on Windows wraps the argument in double quotes and REPLACES
+        // every embedded double quote with a space -- so a JSON spec arrives at the
+        // runner as { var_path : ... }, which is not JSON, and every case here failed on
+        // the exact host this seam is developed on while passing on Linux CI. Base64 has
+        // no characters any shell cares about, on any platform, so the quoting question
+        // stops existing rather than being answered per-OS.
         $command = escapeshellarg(PHP_BINARY)
             . ' ' . escapeshellarg(__DIR__ . '/fixtures/errorscreen-runner.php')
-            . ' ' . escapeshellarg((string) json_encode($spec));
+            . ' ' . escapeshellarg(base64_encode((string) json_encode($spec)));
 
         $output = shell_exec($command);
         $this->assertIsString($output, 'the fixture runner produced no output');
@@ -178,7 +208,166 @@ class ErrorScreenSeamTest extends TestCase
         $result = $this->runCase(['debug' => false]);
 
         $this->assertSame('production', $result['environment']);
-        $this->assertFalse($result['ray_enabled']);
+    }
+
+    // --------------------------------------------------- the boot's own guard chain
+
+    /**
+     * Every call site in the REAL common.php, not a copy of it.
+     *
+     * The subprocess 'truncated-loader' case below proves the boot survives a
+     * debugconfig.php that fails to compile -- but it proves it against a hand-written
+     * replay of common.php's guard sequence, so a bare xoops_applyDebugConfig() added to
+     * the real file tomorrow would leave that case green. It guards a copy.
+     *
+     * This reads the shipped file and audits it directly. The two are not redundant: one
+     * asks "does the boot survive?", this one asks "is every call still guarded?", and it
+     * is the second question that rots.
+     *
+     * @return list<array{0: string, 1: string}>
+     */
+    public static function guardedBootFiles(): array
+    {
+        $root = dirname(__DIR__, 4) . '/htdocs';
+
+        return [
+            ['include/common.php', $root . '/include/common.php'],
+            ['mainfile.dist.php', $root . '/mainfile.dist.php'],
+        ];
+    }
+
+    #[Test]
+    public function everyDebugCallInTheBootIsGuardedByFunctionExists(): void
+    {
+        $guarded = ['xoops_getDebugConfig', 'xoops_applyDebugConfig', 'xoops_activateErrorScreen'];
+
+        foreach (self::guardedBootFiles() as [$label, $path]) {
+            $this->assertFileExists($path, $label . ' is missing');
+            $lines = file($path, FILE_IGNORE_NEW_LINES);
+            $this->assertIsArray($lines);
+
+            foreach ($lines as $number => $line) {
+                // Comments and docblocks name these functions constantly; only code counts.
+                $code = trim($line);
+                if ('' === $code || str_starts_with($code, '//') || str_starts_with($code, '*')
+                    || str_starts_with($code, '/*')) {
+                    continue;
+                }
+
+                foreach ($guarded as $function) {
+                    if (!str_contains($line, $function . '(')) {
+                        continue;
+                    }
+                    // The guard is either on this line (the ternary form) or on an
+                    // enclosing if (the block form). Walk back over the three nearest
+                    // lines of CODE rather than three raw lines: mainfile.dist.php puts a
+                    // four-line comment between its guard and the guarded call, and a raw
+                    // window narrow enough to be useful would read that as a violation.
+                    $window  = $line;
+                    $seen    = 0;
+                    for ($back = $number - 1; $back >= 0 && $seen < 3; --$back) {
+                        $previous = trim($lines[$back]);
+                        if ('' === $previous || str_starts_with($previous, '//')
+                            || str_starts_with($previous, '*') || str_starts_with($previous, '/*')) {
+                            continue;
+                        }
+                        $window .= "\n" . $lines[$back];
+                        ++$seen;
+                    }
+                    $this->assertStringContainsString(
+                        "function_exists('" . $function . "')",
+                        $window,
+                        sprintf(
+                            '%s line %d calls %s() with no function_exists() guard within'
+                            . ' three lines. Every call site must survive a debugconfig.php'
+                            . ' that fails to compile; one bare call makes the try/catch'
+                            . ' around the loader decorative.',
+                            $label,
+                            $number + 1,
+                            $function
+                        )
+                    );
+                }
+            }
+        }
+    }
+
+    // ---------------------------------------------------- the opt-in strict gate
+
+    #[Test]
+    public function theGateIsAdvisoryUntilASiteAsksForItToBeEnforced(): void
+    {
+        // The default, and the argument for it: a provider MAY render a production-safe
+        // page for an anonymous visitor, and core cannot tell that apart from a stack
+        // trace full of superglobals. So core passes the answer and lets the provider
+        // decide.
+        $result = $this->runCase([
+            'debug'             => ['enabled' => true, 'error_screen' => 'xprovider'],
+            'provider'          => 'xprovider',
+            'developer_request' => false,
+        ]);
+
+        $this->assertSame('active', $result['status']);
+        $this->assertTrue($result['provider_ran'], 'the provider must still be offered the seat');
+        $this->assertFalse($result['provider_saw_gate'], 'and must be told this is not a developer');
+    }
+
+    #[Test]
+    public function strictModeStopsTheDispatchForANonDeveloperRequest(): void
+    {
+        // A site that would rather not extend that trust to every provider it might
+        // install can say so, and then a provider that ignores the flag never gets the
+        // chance to ignore it.
+        $result = $this->runCase([
+            'debug' => [
+                'enabled'             => true,
+                'error_screen'        => 'xprovider',
+                'error_screen_strict' => true,
+            ],
+            'provider'          => 'xprovider',
+            'developer_request' => false,
+        ]);
+
+        $this->assertSame('suppressed', $result['status']);
+        $this->assertFalse($result['provider_ran'], 'strict mode must not dispatch at all');
+        $this->assertStringContainsString('error_screen_strict', $result['message']);
+    }
+
+    #[Test]
+    public function strictModeIsInvisibleToADeveloperRequest(): void
+    {
+        $result = $this->runCase([
+            'debug' => [
+                'enabled'             => true,
+                'error_screen'        => 'xprovider',
+                'error_screen_strict' => true,
+            ],
+            'provider'          => 'xprovider',
+            'developer_request' => true,
+        ]);
+
+        $this->assertSame('active', $result['status']);
+        $this->assertTrue($result['provider_ran']);
+    }
+
+    #[Test]
+    public function strictModeNeedsARealBooleanLikeEveryOtherSwitch(): void
+    {
+        // 'true' as a STRING leaves it off. That is the same trap, and the same answer,
+        // as every other switch in debug.php -- and here failing closed means failing
+        // toward the documented default rather than toward a stricter one nobody asked
+        // for, which would silently stop providers running.
+        $result = $this->runCase([
+            'debug' => [
+                'enabled'             => true,
+                'error_screen'        => 'xprovider',
+                'error_screen_strict' => 'true',
+            ],
+            'provider'          => 'xprovider',
+            'developer_request' => false,
+        ]);
+
+        $this->assertSame('active', $result['status']);
     }
 
     // ------------------------------------------------------------- failure modes
@@ -194,6 +383,223 @@ class ErrorScreenSeamTest extends TestCase
 
         $this->assertSame('error', $result['status']);
         $this->assertStringContainsString('xbroken', $result['message']);
+    }
+
+    #[Test]
+    public function aProviderThatRegistersAndThenThrowsGetsTheHandlersTakenBack(): void
+    {
+        // The guarantee the seam is built on: a broken provider must not be able to take
+        // the site down. Without the rollback it could -- a provider that calls
+        // set_error_handler() and only THEN fails keeps PHP's handlers for the rest of
+        // the request, while the constants say the activation failed. The site's error
+        // path then belongs to something core has already declared broken.
+        //
+        // aProviderThatThrowsLeavesTheBootStanding() cannot catch this: its provider
+        // never registers, so there is nothing to hand back.
+        $result = $this->runCase([
+            'debug'              => ['enabled' => true, 'error_screen' => 'xbroken'],
+            'provider'           => 'xbroken',
+            'provider_registers' => true,
+            'provider_throws'    => true,
+        ]);
+
+        $this->assertSame('error', $result['status']);
+        $this->assertTrue($result['provider_registered'], 'the fixture provider must take the handlers first');
+        $this->assertTrue($result['error_handler_is_core'], 'the error handler must be handed back');
+        $this->assertTrue($result['exc_handler_is_core'], 'the exception handler must be handed back');
+        $this->assertFalse($result['error_handler_is_provider']);
+        $this->assertFalse($result['exc_handler_is_provider']);
+    }
+
+    #[Test]
+    public function aProviderThatRegistersAndSelfCatchesGetsTheHandlersTakenBack(): void
+    {
+        // The path a restore living in core's catch would miss, and the one BOTH shipped
+        // providers take: the provider wraps its own activation, catches its own failure,
+        // reports 'error' and returns normally. Core's catch never runs -- so the
+        // rollback is keyed on the outcome, not on the exception.
+        $result = $this->runCase([
+            'debug'              => ['enabled' => true, 'error_screen' => 'xbroken'],
+            'provider'           => 'xbroken',
+            'provider_registers' => true,
+            'provider_status'    => 'error',
+            'provider_throws'    => false,
+        ]);
+
+        $this->assertSame('error', $result['status']);
+        $this->assertSame('error', $result['read_back']['status'], 'constant and read-back must agree');
+        $this->assertTrue($result['provider_registered']);
+        $this->assertTrue($result['error_handler_is_core'], 'the error handler must be handed back');
+        $this->assertTrue($result['exc_handler_is_core'], 'the exception handler must be handed back');
+    }
+
+    #[Test]
+    public function aProviderThatSucceedsKeepsTheHandlersItRegistered(): void
+    {
+        // The other half of the contract, and the reason the rollback is keyed on 'error'
+        // rather than on "did the handlers change": a provider that works must keep them.
+        $result = $this->runCase([
+            'debug'              => ['enabled' => true, 'error_screen' => 'xworks'],
+            'provider'           => 'xworks',
+            'provider_registers' => true,
+            'provider_status'    => 'active',
+        ]);
+
+        $this->assertSame('active', $result['status']);
+        $this->assertTrue($result['error_handler_is_provider'], 'a working provider keeps the error handler');
+        $this->assertTrue($result['exc_handler_is_provider'], 'a working provider keeps the exception handler');
+        $this->assertFalse($result['error_handler_is_core']);
+    }
+
+    #[Test]
+    public function twoModulesAnsweringOneTokenAreReportedAndTheSeatIsVacated(): void
+    {
+        // Detector 1. The reporter closure has always refused the second report; it used
+        // to throw that knowledge away and publish the first module's status as though
+        // nothing else had happened -- while the second module's handlers were the ones
+        // actually installed.
+        $result = $this->runCase([
+            'debug'              => ['enabled' => true, 'error_screen' => 'xshared'],
+            'provider'           => 'xshared',
+            'provider_registers' => true,
+            'second_listener'    => 'report',
+        ]);
+
+        $this->assertTrue($result['second_listener_ran']);
+        $this->assertSame('contested', $result['status']);
+        $this->assertStringContainsString('xshared', $result['message']);
+        $this->assertTrue($result['error_handler_is_core'], 'a contested seat goes back to XoopsLogger');
+        $this->assertFalse($result['error_handler_is_provider']);
+    }
+
+    #[Test]
+    public function aSecondListenerThatRegistersWithoutReportingIsDetected(): void
+    {
+        // Detector 2. The dangerous half of the same problem: the second module says
+        // nothing, so the refusal count is zero and the published status looks perfectly
+        // healthy. Core catches it by comparing who held the handlers when the winning
+        // report arrived against who holds them at the end.
+        $result = $this->runCase([
+            'debug'              => ['enabled' => true, 'error_screen' => 'xshared'],
+            'provider'           => 'xshared',
+            'provider_registers' => true,
+            'second_listener'    => 'silent',
+        ]);
+
+        $this->assertTrue($result['second_listener_ran']);
+        $this->assertSame('contested', $result['status']);
+        $this->assertTrue($result['error_handler_is_core']);
+    }
+
+    #[Test]
+    public function aListenerThatRegistersAndNeverReportsIsNotCalledUnclaimed(): void
+    {
+        // Detector 3. Nobody reports at all, so the old code published 'unclaimed' --
+        // "no active module claims the error screen; the handlers stay with XoopsLogger"
+        // -- while a module had quietly taken them. That message was not merely unhelpful,
+        // it was false.
+        $result = $this->runCase([
+            'debug'              => ['enabled' => true, 'error_screen' => 'xsilent'],
+            'provider'           => 'xsilent',
+            'provider_registers' => true,
+            'second_listener'    => 'silent',
+            'provider_status'    => '',
+        ]);
+
+        $this->assertNotSame('unclaimed', $result['status']);
+        $this->assertSame('contested', $result['status']);
+        $this->assertTrue($result['error_handler_is_core']);
+    }
+
+    #[Test]
+    public function aListenerThatTakesOnlyTheExceptionHandlerIsStillDetected(): void
+    {
+        // PHP hands out the two handlers separately, and a listener is free to take one
+        // without the other. The detectors used to compare only the error handler, so a
+        // listener that quietly took just the exception handler was published as
+        // 'unclaimed' -- "the handlers stay with XoopsLogger" -- while the exception path
+        // was already somebody else's. The message was not merely unhelpful, it was false
+        // for half of what it described.
+        //
+        // 'exception', not true, and that is the whole test. With `provider_registers =>
+        // true` the FIRST listener takes the error handler as well, so detector 3 sees a
+        // moved error handler and publishes 'contested' whether or not it ever looks at
+        // the exception handler -- the case would stay green against the exact regression
+        // it is named for. Nothing here may touch the error handler, so the only evidence
+        // available to core is the exception handler, and the assertion means something.
+        $result = $this->runCase([
+            'debug'              => ['enabled' => true, 'error_screen' => 'xshared'],
+            'provider'           => 'xshared',
+            'provider_registers' => 'exception',
+            'second_listener'    => 'silent-exception',
+            'provider_status'    => '',
+        ]);
+
+        $this->assertSame('contested', $result['status']);
+        $this->assertTrue(
+            $result['error_handler_is_core'],
+            'no listener in this case touches the error handler; it must still be the core stand-in'
+        );
+        $this->assertFalse(
+            $result['error_handler_is_provider'],
+            'if this is ever true the case has stopped being exception-only and proves nothing'
+        );
+        $this->assertTrue($result['exc_handler_is_core'], 'the exception handler must come back too');
+    }
+
+    #[Test]
+    public function anExceptionOnlyListenerAfterTheWinningReportIsDetected(): void
+    {
+        // The same blind spot on detector 2: a provider reports and is accepted, then a
+        // later listener takes only the exception handler. Comparing error handlers alone
+        // saw nothing and published 'active'.
+        $result = $this->runCase([
+            'debug'              => ['enabled' => true, 'error_screen' => 'xshared'],
+            'provider'           => 'xshared',
+            'provider_registers' => true,
+            'second_listener'    => 'silent-exception',
+        ]);
+
+        $this->assertSame('contested', $result['status']);
+        $this->assertTrue($result['exc_handler_is_core']);
+    }
+
+    #[Test]
+    public function aProviderThatThrowsBeforeReportingIsCalledErrorNotContested(): void
+    {
+        // Core caught the exception, so it KNOWS this was a failure rather than a second
+        // listener — 'error' is the more specific answer and must win. Detector 3 used to
+        // overwrite it with 'contested', reporting a multi-listener problem that never
+        // happened. The handlers go back either way; only the diagnosis was wrong.
+        $result = $this->runCase([
+            'debug'                         => ['enabled' => true, 'error_screen' => 'xbroken'],
+            'provider'                      => 'xbroken',
+            'provider_registers'            => true,
+            'provider_throws_before_report' => true,
+        ]);
+
+        $this->assertSame('error', $result['status']);
+        $this->assertStringContainsString('xbroken', $result['message']);
+        $this->assertTrue($result['error_handler_is_core']);
+        $this->assertTrue($result['exc_handler_is_core']);
+    }
+
+    #[Test]
+    public function aSingleWellBehavedProviderIsNotReportedAsContested(): void
+    {
+        // The false-positive guard. All three detectors compare handler identity, so a
+        // lone provider doing everything right must come through untouched -- otherwise
+        // the mitigation would disable every working error screen and nothing would fail.
+        $result = $this->runCase([
+            'debug'              => ['enabled' => true, 'error_screen' => 'xworks'],
+            'provider'           => 'xworks',
+            'provider_registers' => true,
+            'provider_status'    => 'active',
+        ]);
+
+        $this->assertSame('active', $result['status']);
+        $this->assertFalse($result['second_listener_ran']);
+        $this->assertTrue($result['error_handler_is_provider']);
     }
 
     #[Test]

--- a/tests/unit/htdocs/include/ErrorScreenSeamTest.php
+++ b/tests/unit/htdocs/include/ErrorScreenSeamTest.php
@@ -1,0 +1,280 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The error-screen seam in htdocs/include/debugconfig.php.
+ *
+ * Ownership resolves in three steps -- an explicit token in debug.php, else the owner a
+ * provider module recorded at install, else 'core' -- and core triggers
+ * core.debug.errorscreen for whichever module that names. Every case below was a defect
+ * or a design question raised in review; they are here so that re-running the suite
+ * answers them, rather than a reviewer having to take a claim on trust.
+ *
+ * Each case runs in its OWN PROCESS through fixtures/errorscreen-runner.php. The seam
+ * publishes its outcome as constants, and constants are defined once per process; sharing
+ * one would let the first case decide every later one. A subprocess is also the only
+ * honest way to exercise a truncated include/debugconfig.php, which fails at compile time.
+ */
+#[CoversFunction('xoops_activateErrorScreen')]
+#[CoversFunction('xoops_getErrorScreenOwner')]
+#[CoversFunction('xoops_getErrorScreenOwnerSource')]
+#[CoversFunction('xoops_getErrorScreenStatus')]
+#[CoversFunction('xoops_recordErrorScreenOwner')]
+#[CoversFunction('xoops_releaseErrorScreenOwner')]
+#[CoversFunction('xoops_writeDebugRuntimeOverride')]
+#[CoversFunction('xoops_applyDebugConfig')]
+class ErrorScreenSeamTest extends TestCase
+{
+    private string $varPath = '';
+
+    protected function setUp(): void
+    {
+        $this->varPath = sys_get_temp_dir() . '/xoops-errorscreen-' . bin2hex(random_bytes(6));
+        mkdir($this->varPath . '/data', 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if ('' === $this->varPath || !is_dir($this->varPath)) {
+            return;
+        }
+        $items = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($this->varPath, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($items as $item) {
+            $item->isDir() ? @rmdir($item->getPathname()) : @unlink($item->getPathname());
+        }
+        @rmdir($this->varPath);
+    }
+
+    /**
+     * @param array<string, mixed> $spec
+     * @return array<string, mixed>
+     */
+    private function runCase(array $spec): array
+    {
+        $spec['var_path'] = $spec['var_path'] ?? $this->varPath;
+
+        $command = escapeshellarg(PHP_BINARY)
+            . ' ' . escapeshellarg(__DIR__ . '/fixtures/errorscreen-runner.php')
+            . ' ' . escapeshellarg((string) json_encode($spec));
+
+        $output = shell_exec($command);
+        $this->assertIsString($output, 'the fixture runner produced no output');
+
+        $decoded = json_decode($output, true);
+        $this->assertIsArray($decoded, 'the fixture runner did not return JSON: ' . $output);
+
+        return $decoded;
+    }
+
+    // ---------------------------------------------------------------- resolution
+
+    #[Test]
+    public function withNoProviderTheHandlersStayWithTheCore(): void
+    {
+        $result = $this->runCase(['debug' => ['enabled' => true]]);
+
+        $this->assertSame('core', $result['owner']);
+        $this->assertSame('default', $result['source']);
+        $this->assertSame('core', $result['status']);
+    }
+
+    #[Test]
+    public function aRecordedOwnerIsUsedWhenNothingIsPinned(): void
+    {
+        $result = $this->runCase([
+            'debug'    => ['enabled' => true],
+            'record'   => 'xprovider',
+            'provider' => 'xprovider',
+        ]);
+
+        $this->assertSame('xprovider', $result['owner']);
+        $this->assertSame('recorded', $result['source']);
+        $this->assertSame('active', $result['status']);
+        $this->assertTrue($result['provider_ran']);
+    }
+
+    #[Test]
+    public function anExplicitTokenBeatsTheRecordedOwner(): void
+    {
+        $result = $this->runCase([
+            'debug'    => ['enabled' => true, 'error_screen' => 'xpinned'],
+            'record'   => 'xrecorded',
+            'provider' => 'xpinned',
+        ]);
+
+        $this->assertSame('xpinned', $result['owner']);
+        $this->assertSame('config', $result['source']);
+        $this->assertSame('active', $result['status']);
+    }
+
+    #[Test]
+    public function anExplicitCoreKeepsTheHandlersEvenWithAnOwnerRecorded(): void
+    {
+        // 'core' is a statement, not an absence: a site that says it wants nothing to take
+        // the handlers must outrank a record written by an install months earlier.
+        $result = $this->runCase([
+            'debug'    => ['enabled' => true, 'error_screen' => 'core'],
+            'record'   => 'xrecorded',
+            'provider' => 'xrecorded',
+        ]);
+
+        $this->assertSame('core', $result['owner']);
+        $this->assertSame('config', $result['source']);
+        $this->assertFalse($result['provider_ran']);
+    }
+
+    #[Test]
+    public function anUnansweredTokenIsReportedRatherThanPassedOn(): void
+    {
+        // A deactivated provider must not hand its seat to whatever else is installed:
+        // ownership moving without anybody asking is the surprise this seam exists to end.
+        $result = $this->runCase([
+            'debug'    => ['enabled' => true],
+            'record'   => 'xabsent',
+            'provider' => 'xrival',
+        ]);
+
+        $this->assertSame('xabsent', $result['owner']);
+        $this->assertSame('unclaimed', $result['status']);
+        $this->assertFalse($result['provider_ran'], 'another provider took an unclaimed seat');
+    }
+
+    // ------------------------------------------------------- file-config-only rule
+
+    #[Test]
+    public function aRecordedOwnerLiesDormantWithoutAnEnabledDebugFile(): void
+    {
+        // The error screen is a debug.php feature by decision, not by accident: writing
+        // that file takes filesystem access, which is the privilege matching the exposure
+        // an error screen risks. Announced rather than silent, because a provider that is
+        // installed, recorded and never running is the invisible state this seam ends.
+        $result = $this->runCase([
+            'debug'    => false,
+            'record'   => 'xprovider',
+            'provider' => 'xprovider',
+        ]);
+
+        $this->assertSame('core', $result['owner']);
+        $this->assertSame('dormant', $result['status']);
+        $this->assertFalse($result['provider_ran']);
+        $this->assertStringContainsString('xprovider', $result['message']);
+        $this->assertStringContainsString('debug.php', $result['message']);
+    }
+
+    #[Test]
+    public function environmentConstantsExistWithNoDebugFileAtAll(): void
+    {
+        // Their docblock promises they are defined on every request. Guarding the call
+        // meant they were absent on exactly the sites with no debug.php -- every
+        // production site -- so a consumer reading them bare fatalled only in production.
+        $result = $this->runCase(['debug' => false]);
+
+        $this->assertSame('production', $result['environment']);
+        $this->assertFalse($result['ray_enabled']);
+    }
+
+    // ------------------------------------------------------------- failure modes
+
+    #[Test]
+    public function aProviderThatThrowsLeavesTheBootStanding(): void
+    {
+        $result = $this->runCase([
+            'debug'           => ['enabled' => true, 'error_screen' => 'xbroken'],
+            'provider'        => 'xbroken',
+            'provider_throws' => true,
+        ]);
+
+        $this->assertSame('error', $result['status']);
+        $this->assertStringContainsString('xbroken', $result['message']);
+    }
+
+    #[Test]
+    public function aProviderThatReportsThenThrowsIsReportedAsFailed(): void
+    {
+        // The published constant and the read-back function must not disagree. They did:
+        // the outcome lived in a first-writer-wins store, so a provider that reported
+        // success and then died left the store saying 'active' while the constant said
+        // 'error' -- two APIs answering one question differently, in precisely the
+        // half-broken-provider case the diagnostics exist for.
+        $result = $this->runCase([
+            'debug'           => ['enabled' => true, 'error_screen' => 'xbroken'],
+            'provider'        => 'xbroken',
+            'provider_status' => 'active',
+            'provider_throws' => true,
+        ]);
+
+        $this->assertSame('error', $result['status']);
+        $this->assertSame('error', $result['read_back']['status'], 'constant and function disagree');
+        $this->assertSame($result['returned'], $result['read_back']['status']);
+    }
+
+    #[Test]
+    public function aTruncatedLoaderDoesNotStopTheBoot(): void
+    {
+        // Every call site in common.php must survive a debugconfig.php that fails to
+        // compile. Guarding only the first one made the try/catch decorative: the boot
+        // cleared it and fatalled a hundred lines later anyway.
+        $result = $this->runCase(['case' => 'truncated-loader']);
+
+        $this->assertContains('guard-caught-ParseError', $result['reached']);
+        $this->assertContains('end-of-boot', $result['reached'], 'the boot died before the last line');
+    }
+
+    // --------------------------------------------------------------- the record
+
+    #[Test]
+    public function theGateAnswerIsHandedToTheProvider(): void
+    {
+        // Advisory, not enforced: a provider may legitimately render a production-safe
+        // page for anonymous visitors, so core passes the answer instead of refusing to
+        // dispatch. It must actually arrive.
+        $result = $this->runCase([
+            'debug'             => ['enabled' => true, 'error_screen' => 'xprovider'],
+            'provider'          => 'xprovider',
+            'developer_request' => true,
+        ]);
+
+        $this->assertTrue($result['provider_saw_gate']);
+    }
+
+    #[Test]
+    public function aSecondProviderCannotTakeASeatThatIsHeld(): void
+    {
+        $first = $this->runCase([
+            'debug'  => ['enabled' => true],
+            'record' => 'xfirst',
+        ]);
+        $this->assertSame('xfirst', $first['recorded_owner']);
+
+        // Same var_path: the record persists between the two processes, which is the point.
+        $second = $this->runCase([
+            'debug'  => ['enabled' => true],
+            'record' => 'xsecond',
+        ]);
+
+        $this->assertFalse($second['record_call'], 'the second claim was accepted');
+        $this->assertSame('xfirst', $second['recorded_owner']);
+    }
+
+    #[Test]
+    public function aTokenIsRecordedInTheSameCaseThatConfigWouldUse(): void
+    {
+        // Config tokens are lower-cased on the way in and every comparison is strict, so
+        // a mixed-case dirname that recorded verbatim worked when recorded and went
+        // permanently unclaimed when pinned.
+        $result = $this->runCase([
+            'debug'  => ['enabled' => true],
+            'record' => 'XProvider',
+        ]);
+
+        $this->assertSame('xprovider', $result['recorded_owner']);
+    }
+}

--- a/tests/unit/htdocs/include/ErrorScreenSeamTest.php
+++ b/tests/unit/htdocs/include/ErrorScreenSeamTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -42,14 +42,15 @@ use PHPUnit\Framework\TestCase;
  * going vacuous again. ADR-0001 Appendix A is the long version.
  * ---------------------------------------------------------------------------------------
  */
-#[CoversFunction('xoops_activateErrorScreen')]
-#[CoversFunction('xoops_getErrorScreenOwner')]
-#[CoversFunction('xoops_getErrorScreenOwnerSource')]
-#[CoversFunction('xoops_getErrorScreenStatus')]
-#[CoversFunction('xoops_recordErrorScreenOwner')]
-#[CoversFunction('xoops_releaseErrorScreenOwner')]
-#[CoversFunction('xoops_writeDebugRuntimeOverride')]
-#[CoversFunction('xoops_applyDebugConfig')]
+// CoversNothing, deliberately. Every case executes the seam in a SUBPROCESS (see above),
+// so the parent PHPUnit process never runs -- and cannot collect coverage for -- the
+// functions under test: xoops_activateErrorScreen, xoops_getErrorScreenOwner,
+// xoops_getErrorScreenOwnerSource, xoops_getErrorScreenStatus, xoops_recordErrorScreenOwner,
+// xoops_releaseErrorScreenOwner, xoops_writeDebugRuntimeOverride, xoops_applyDebugConfig.
+// Declaring those as CoversFunction targets made the coverage job fail with "not a valid
+// target" (the functions are never defined in this process), and loading the file here just
+// to validate the metadata would record a misleading 0%.
+#[CoversNothing]
 class ErrorScreenSeamTest extends TestCase
 {
     private string $varPath = '';
@@ -682,5 +683,42 @@ class ErrorScreenSeamTest extends TestCase
         ]);
 
         $this->assertSame('xprovider', $result['recorded_owner']);
+    }
+
+    #[Test]
+    public function theHolderCanReleaseItsSeatAndTheFileStaysAnObject(): void
+    {
+        // The release half of the ownership lifecycle, exercised end to end: claim, then
+        // release the same token. The seat must be free afterwards, and the runtime file
+        // -- emptied of its last key -- must serialise as the JSON OBJECT {}, not the
+        // array [] an empty PHP array would encode to. A consumer in another language
+        // reading [] where it expected an object has been handed a different type.
+        $result = $this->runCase([
+            'debug'   => ['enabled' => true],
+            'record'  => 'xprovider',
+            'release' => 'xprovider',
+        ]);
+
+        $this->assertTrue($result['record_call']);
+        $this->assertTrue($result['release_call']);
+        $this->assertSame('', $result['recorded_owner'], 'the released seat must be free');
+        $this->assertSame('{}', $result['runtime_raw'], 'the emptied file must stay a JSON object');
+    }
+
+    #[Test]
+    public function aNonHolderCannotReleaseAnotherModulesSeat(): void
+    {
+        // Release checks identity: uninstalling one module must not free another module's
+        // seat just because it ran later. The call still returns true -- the caller asked
+        // for "the record no longer names me", and it does not -- but the holder's record
+        // survives untouched.
+        $result = $this->runCase([
+            'debug'   => ['enabled' => true],
+            'record'  => 'xfirst',
+            'release' => 'xother',
+        ]);
+
+        $this->assertTrue($result['release_call']);
+        $this->assertSame('xfirst', $result['recorded_owner'], "another module's seat must survive a foreign release");
     }
 }

--- a/tests/unit/htdocs/include/fixtures/errorscreen-runner.php
+++ b/tests/unit/htdocs/include/fixtures/errorscreen-runner.php
@@ -9,7 +9,7 @@
  * A subprocess is also the only honest way to exercise a TRUNCATED include/debugconfig.php,
  * which is a compile-time failure of the file under test.
  *
- * Usage: php errorscreen-runner.php '<json spec>'
+ * Usage: php errorscreen-runner.php '<base64 of the json spec>'
  *
  * Spec keys, all optional:
  *   var_path            directory to use as XOOPS_VAR_PATH (required in practice)
@@ -19,7 +19,23 @@
  *   provider            token a fake provider answers to
  *   provider_status     status that provider reports
  *   provider_throws     bool: throw after reporting
+ *   provider_registers  bool|'exception': install handlers BEFORE reporting, so the case
+ *                       can tell whether core hands them back when activation fails.
+ *                       true installs BOTH; 'exception' installs only the exception
+ *                       handler and leaves the error handler with the core stand-in --
+ *                       the only way to write a case in which NOTHING touches the error
+ *                       handler, which is what a detector-3 regression test has to be to
+ *                       mean anything.
+ *   second_listener     'report' | 'silent' | 'silent-exception': add a SECOND listener
+ *                       answering the same token, which registers its own handlers and
+ *                       either reports (and is refused) or stays quiet. 'silent-exception'
+ *                       takes ONLY the exception handler, which PHP allows and which a
+ *                       detector watching only the error handler cannot see.
+ *   provider_throws_before_report  bool: register, then throw WITHOUT reporting. Core
+ *                       caught this and then mislabelled it 'contested'.
  *   developer_request   bool: what xoops_isDeveloperRequest() should answer
+ *                       (the strict switch lives in the 'debug' array as
+ *                       'error_screen_strict')
  *   case                'truncated-loader' replays common.php's guard chain instead
  *
  * @copyright   (c) 2000-2026 XOOPS Project (https://xoops.org)
@@ -27,7 +43,15 @@
  * @package     core
  */
 
-$spec = json_decode($argv[1] ?? '{}', true);
+// Nothing may reach STDOUT before the JSON payload: the caller decodes the whole stream.
+// A noisy php.ini (a stale extension, a startup deprecation) would otherwise prepend a
+// warning and make every case look like a seam failure.
+ini_set('display_errors', '0');
+
+// The spec arrives base64-encoded -- see the note in ErrorScreenSeamTest::runCase(). Raw
+// JSON through escapeshellarg() is silently mangled on Windows.
+$raw  = base64_decode((string) ($argv[1] ?? ''), true);
+$spec = json_decode(false === $raw ? '' : $raw, true);
 if (!is_array($spec)) {
     fwrite(STDOUT, json_encode(['fatal' => 'bad spec']));
     exit(1);
@@ -133,14 +157,42 @@ $GLOBALS['xoopsPreload']    = $preload;
 $providerRan                = false;
 $providerSawDeveloperFlag   = null;
 
+// Stand-ins for XoopsLogger's handlers, installed before activation so a case can ask
+// "who owns them now?" by identity rather than by hope. Only set up when the case cares.
+$coreErrorHandler     = null;
+$coreExceptionHandler = null;
+$fixtureErrorHandler  = null;
+$fixtureExcHandler    = null;
+
+$registerMode = $spec['provider_registers'] ?? false;
+
+// The core stand-ins go in whichever way the provider is going to register, including
+// 'exception' -- the error handler still needs a known owner for the case to be able to
+// say "and this one never moved" by identity rather than by absence.
+if (false !== $registerMode && null !== $registerMode) {
+    $coreErrorHandler     = static function () { return false; };
+    $coreExceptionHandler = static function ($e) { };
+    set_error_handler($coreErrorHandler);
+    set_exception_handler($coreExceptionHandler);
+
+    $fixtureErrorHandler = static function () { return false; };
+    $fixtureExcHandler   = static function ($e) { };
+}
+
 if (isset($spec['provider'])) {
     $provider       = (string) $spec['provider'];
     $status         = (string) ($spec['provider_status'] ?? 'active');
     $throws         = (bool) ($spec['provider_throws'] ?? false);
+    $registers      = $registerMode;
+    $throwsFirst    = (bool) ($spec['provider_throws_before_report'] ?? false);
     $preload->handlers['core.debug.errorscreen'][] = static function ($args) use (
         $provider,
         $status,
         $throws,
+        $registers,
+        $throwsFirst,
+        $fixtureErrorHandler,
+        $fixtureExcHandler,
         &$providerRan,
         &$providerSawDeveloperFlag
     ) {
@@ -149,12 +201,58 @@ if (isset($spec['provider'])) {
         }
         $providerRan              = true;
         $providerSawDeveloperFlag = $args['developer_request'] ?? null;
-        $report                   = $args['report'] ?? null;
+
+        // Registering BEFORE the report is what makes the rollback case real. The bug
+        // this guards was invisible for a round because the old fake provider reported
+        // and threw without ever taking the handlers, so there was nothing to hand back.
+        if (false !== $registers && null !== $registers) {
+            // 'exception' takes only the exception handler. PHP hands the two out
+            // separately and a real provider may well want just one of them.
+            if ('exception' !== $registers) {
+                set_error_handler($fixtureErrorHandler);
+            }
+            set_exception_handler($fixtureExcHandler);
+        }
+
+        if ($throwsFirst) {
+            throw new RuntimeException('fixture provider failed before it could report');
+        }
+
+        $report = $args['report'] ?? null;
         if (is_callable($report)) {
             $report($status, 'fixture provider reporting ' . $status);
         }
         if ($throws) {
             throw new RuntimeException('fixture provider failed after reporting');
+        }
+    };
+}
+
+// A second module answering one token: the misconfiguration the contested detectors
+// exist for. It registers AFTER the first, so it ends up owning PHP's handlers whatever
+// the published status says -- which is the whole point.
+$secondListenerRan = false;
+if (isset($spec['provider']) && isset($spec['second_listener'])) {
+    $secondProvider = (string) $spec['provider'];
+    $secondMode     = (string) $spec['second_listener'];
+    $secondReports  = 'report' === $secondMode;
+    $preload->handlers['core.debug.errorscreen'][] = static function ($args) use (
+        $secondProvider,
+        $secondReports,
+        $secondMode,
+        &$secondListenerRan
+    ) {
+        if ($secondProvider !== ($args['owner'] ?? '')) {
+            return;
+        }
+        $secondListenerRan = true;
+        if ('silent-exception' !== $secondMode) {
+            set_error_handler(static function () { return false; });
+        }
+        set_exception_handler(static function ($e) { });
+        $report = $args['report'] ?? null;
+        if ($secondReports && is_callable($report)) {
+            $report('active', 'the second listener also thinks it is the owner');
         }
     };
 }
@@ -173,6 +271,13 @@ if (function_exists('xoops_applyDebugConfig')) {
 $returned = xoops_activateErrorScreen();
 $read     = xoops_getErrorScreenStatus();
 
+// Read the effective handlers the same way the seam does: set-then-restore is the only
+// way PHP offers to look at the current one.
+$liveErrorHandler = set_error_handler(static function () { return false; });
+restore_error_handler();
+$liveExcHandler = set_exception_handler(static function ($e) { });
+restore_exception_handler();
+
 fwrite(STDOUT, json_encode([
     'returned'          => $returned,
     'owner'             => XOOPS_ERROR_SCREEN_OWNER,
@@ -184,6 +289,13 @@ fwrite(STDOUT, json_encode([
     'provider_saw_gate' => $providerSawDeveloperFlag,
     'recorded_owner'    => xoops_getRecordedErrorScreenOwner(),
     'environment'       => defined('XOOPS_ENVIRONMENT') ? XOOPS_ENVIRONMENT : null,
-    'ray_enabled'       => defined('RAY_ENABLED') ? RAY_ENABLED : null,
     'record_call'       => $recorded ?? null,
+    'provider_registered'      => null !== $fixtureErrorHandler,
+    'second_listener_ran'      => $secondListenerRan,
+    'error_handler_is_core'    => null !== $coreErrorHandler && $liveErrorHandler === $coreErrorHandler,
+    'error_handler_is_provider'=> null !== $fixtureErrorHandler && $liveErrorHandler === $fixtureErrorHandler,
+    'exc_handler_is_core'      => null !== $coreExceptionHandler && $liveExcHandler === $coreExceptionHandler,
+    'exc_handler_is_second'    => $secondListenerRan && $liveExcHandler !== $coreExceptionHandler
+                                  && $liveExcHandler !== $fixtureExcHandler,
+    'exc_handler_is_provider'  => null !== $fixtureExcHandler && $liveExcHandler === $fixtureExcHandler,
 ]));

--- a/tests/unit/htdocs/include/fixtures/errorscreen-runner.php
+++ b/tests/unit/htdocs/include/fixtures/errorscreen-runner.php
@@ -16,6 +16,7 @@
  *   root_path           directory to use as XOOPS_ROOT_PATH; defaults to the real core
  *   debug               array to write as debug.php, or false to leave it absent
  *   record              token to record as the error-screen owner before activating
+ *   release             token to release AFTER the record above, before activating
  *   provider            token a fake provider answers to
  *   provider_status     status that provider reports
  *   provider_throws     bool: throw after reporting
@@ -261,6 +262,13 @@ if (isset($spec['record'])) {
     $recorded = xoops_recordErrorScreenOwner((string) $spec['record']);
 }
 
+// Release AFTER the record above, so a case can exercise both halves of the ownership
+// lifecycle in one process: claim a seat, then release it (or fail to, when the token is
+// not the holder's).
+if (isset($spec['release'])) {
+    $released = xoops_releaseErrorScreenOwner((string) $spec['release']);
+}
+
 // As include/common.php calls it: unconditionally, behind function_exists() only. The
 // environment constants are published before the early return precisely so they exist on
 // a site with no debug.php, and a fixture that skipped this call could not observe that.
@@ -290,6 +298,12 @@ fwrite(STDOUT, json_encode([
     'recorded_owner'    => xoops_getRecordedErrorScreenOwner(),
     'environment'       => defined('XOOPS_ENVIRONMENT') ? XOOPS_ENVIRONMENT : null,
     'record_call'       => $recorded ?? null,
+    'release_call'      => $released ?? null,
+    // The runtime file VERBATIM, so a test can assert on the serialised shape itself --
+    // e.g. that a file emptied of its last key is the JSON object {} and not the array [].
+    'runtime_raw'       => is_file($varPath . '/data/debug-runtime.json')
+        ? trim((string) file_get_contents($varPath . '/data/debug-runtime.json'))
+        : null,
     'provider_registered'      => null !== $fixtureErrorHandler,
     'second_listener_ran'      => $secondListenerRan,
     'error_handler_is_core'    => null !== $coreErrorHandler && $liveErrorHandler === $coreErrorHandler,

--- a/tests/unit/htdocs/include/fixtures/errorscreen-runner.php
+++ b/tests/unit/htdocs/include/fixtures/errorscreen-runner.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Out-of-process fixture runner for the error-screen seam.
+ *
+ * The seam publishes its outcome as CONSTANTS, which can be defined once per process, so
+ * the cases cannot share one. Each is run here in its own PHP process and reports back as
+ * JSON on stdout; ErrorScreenSeamTest asserts on that.
+ *
+ * A subprocess is also the only honest way to exercise a TRUNCATED include/debugconfig.php,
+ * which is a compile-time failure of the file under test.
+ *
+ * Usage: php errorscreen-runner.php '<json spec>'
+ *
+ * Spec keys, all optional:
+ *   var_path            directory to use as XOOPS_VAR_PATH (required in practice)
+ *   root_path           directory to use as XOOPS_ROOT_PATH; defaults to the real core
+ *   debug               array to write as debug.php, or false to leave it absent
+ *   record              token to record as the error-screen owner before activating
+ *   provider            token a fake provider answers to
+ *   provider_status     status that provider reports
+ *   provider_throws     bool: throw after reporting
+ *   developer_request   bool: what xoops_isDeveloperRequest() should answer
+ *   case                'truncated-loader' replays common.php's guard chain instead
+ *
+ * @copyright   (c) 2000-2026 XOOPS Project (https://xoops.org)
+ * @license     GNU GPL 2 (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @package     core
+ */
+
+$spec = json_decode($argv[1] ?? '{}', true);
+if (!is_array($spec)) {
+    fwrite(STDOUT, json_encode(['fatal' => 'bad spec']));
+    exit(1);
+}
+
+$varPath  = (string) ($spec['var_path'] ?? '');
+$rootPath = (string) ($spec['root_path'] ?? dirname(__DIR__, 5) . '/htdocs');
+
+define('XOOPS_ROOT_PATH', $rootPath);
+define('XOOPS_VAR_PATH', $varPath);
+
+@mkdir($varPath . '/data', 0777, true);
+if (array_key_exists('debug', $spec) && false !== $spec['debug']) {
+    file_put_contents($varPath . '/data/debug.php', '<?php return ' . var_export($spec['debug'], true) . ';');
+} else {
+    @unlink($varPath . '/data/debug.php');
+}
+
+// Pre-defined so the loader's own function_exists() guard leaves it alone. Group
+// membership needs a session and a database; the seam only needs the answer.
+if (array_key_exists('developer_request', $spec)) {
+    $xoopsErrorScreenFixtureDeveloper = (bool) $spec['developer_request'];
+    /**
+     * @param string|null $dirname
+     * @return bool
+     */
+    function xoops_isDeveloperRequest($dirname = null)
+    {
+        return $GLOBALS['xoopsErrorScreenFixtureDeveloper'];
+    }
+    $GLOBALS['xoopsErrorScreenFixtureDeveloper'] = $xoopsErrorScreenFixtureDeveloper;
+}
+
+/**
+ * Replays include/common.php's guard chain against a deliberately truncated loader.
+ *
+ * Every call site in common.php must survive a debugconfig.php that fails to compile --
+ * that is the whole point of the try/catch around the include. A bare call anywhere later
+ * in the file makes the guard decorative, which is what this case exists to catch.
+ */
+if ('truncated-loader' === ($spec['case'] ?? '')) {
+    $reached = [];
+    @mkdir($varPath . '/include', 0777, true);
+    file_put_contents(
+        $varPath . '/include/debugconfig.php',
+        "<?php\nfunction xoops_getDebugConfig() { return []; }\nif (true) {\n"
+    );
+
+    $loader = $varPath . '/include/debugconfig.php';
+    if (is_readable($loader)) {
+        try {
+            require_once $loader;
+        } catch (\Throwable $e) {
+            $reached[] = 'guard-caught-' . (new ReflectionClass($e))->getShortName();
+        }
+    }
+
+    $config    = function_exists('xoops_getDebugConfig') ? xoops_getDebugConfig() : [];
+    $reached[] = 'early-read';
+    if (function_exists('xoops_applyDebugConfig')) {
+        xoops_applyDebugConfig();
+    }
+    $reached[] = 'early-apply';
+    $config    = function_exists('xoops_getDebugConfig') ? xoops_getDebugConfig() : [];
+    $reached[] = 'debug-mode-read';
+    if (function_exists('xoops_applyDebugConfig')) {
+        xoops_applyDebugConfig();
+    }
+    $reached[] = 'debug-mode-apply';
+    if (function_exists('xoops_activateErrorScreen')) {
+        xoops_activateErrorScreen();
+    }
+    $reached[] = 'end-of-boot';
+
+    fwrite(STDOUT, json_encode(['reached' => $reached]));
+
+    return;
+}
+
+require XOOPS_ROOT_PATH . '/include/debugconfig.php';
+
+/** Minimal stand-in with XoopsPreload's triggerEvent contract. */
+class XoopsErrorScreenFixturePreload
+{
+    /** @var array<string, callable[]> */
+    public $handlers = [];
+
+    /**
+     * @param string $name
+     * @param array  $args
+     * @return void
+     */
+    public function triggerEvent($name, $args = [])
+    {
+        foreach ($this->handlers[$name] ?? [] as $handler) {
+            $handler($args);
+        }
+    }
+}
+
+$preload                    = new XoopsErrorScreenFixturePreload();
+$GLOBALS['xoopsPreload']    = $preload;
+$providerRan                = false;
+$providerSawDeveloperFlag   = null;
+
+if (isset($spec['provider'])) {
+    $provider       = (string) $spec['provider'];
+    $status         = (string) ($spec['provider_status'] ?? 'active');
+    $throws         = (bool) ($spec['provider_throws'] ?? false);
+    $preload->handlers['core.debug.errorscreen'][] = static function ($args) use (
+        $provider,
+        $status,
+        $throws,
+        &$providerRan,
+        &$providerSawDeveloperFlag
+    ) {
+        if ($provider !== ($args['owner'] ?? '')) {
+            return;
+        }
+        $providerRan              = true;
+        $providerSawDeveloperFlag = $args['developer_request'] ?? null;
+        $report                   = $args['report'] ?? null;
+        if (is_callable($report)) {
+            $report($status, 'fixture provider reporting ' . $status);
+        }
+        if ($throws) {
+            throw new RuntimeException('fixture provider failed after reporting');
+        }
+    };
+}
+
+if (isset($spec['record'])) {
+    $recorded = xoops_recordErrorScreenOwner((string) $spec['record']);
+}
+
+// As include/common.php calls it: unconditionally, behind function_exists() only. The
+// environment constants are published before the early return precisely so they exist on
+// a site with no debug.php, and a fixture that skipped this call could not observe that.
+if (function_exists('xoops_applyDebugConfig')) {
+    xoops_applyDebugConfig();
+}
+
+$returned = xoops_activateErrorScreen();
+$read     = xoops_getErrorScreenStatus();
+
+fwrite(STDOUT, json_encode([
+    'returned'          => $returned,
+    'owner'             => XOOPS_ERROR_SCREEN_OWNER,
+    'source'            => XOOPS_ERROR_SCREEN_SOURCE,
+    'status'            => XOOPS_ERROR_SCREEN_STATUS,
+    'message'           => XOOPS_ERROR_SCREEN_MESSAGE,
+    'read_back'         => $read,
+    'provider_ran'      => $providerRan,
+    'provider_saw_gate' => $providerSawDeveloperFlag,
+    'recorded_owner'    => xoops_getRecordedErrorScreenOwner(),
+    'environment'       => defined('XOOPS_ENVIRONMENT') ? XOOPS_ENVIRONMENT : null,
+    'ray_enabled'       => defined('RAY_ENABLED') ? RAY_ENABLED : null,
+    'record_call'       => $recorded ?? null,
+]));


### PR DESCRIPTION
# File-based debug configuration, and the error-screen provider seam

**Base** `e15ede8f6` (master) · **11 commits** · **10 files, +2342/−33**

Two related things, in that order: debugging is configured by a file rather than by a
database preference, and the error screen it can turn on now has a declared owner instead of
whoever registered last.

**Commits 1–5 — file-based debug configuration.** `xoops_data/data/debug.php` returns an
array and `debugconfig.php` reads it, before any database exists. That ordering is the point:
the things most worth debugging happen before the database connects, and a preference stored
*in* the database cannot help you there. Writing a file on the server is also a stronger
credential than holding an admin session, which is what lets the rest of this be safe.

The loader is written to be unable to take a site down. Every call site in `common.php` sits
behind `function_exists()`, the include is wrapped, and a `debug.php` that is missing,
unreadable or truncated leaves the boot running with debugging off. `ErrorScreenSeamTest`
replays that guard chain against a deliberately truncated loader, because a guard that is
never exercised is decoration.

**Commits 6–11 — the provider seam**, below, plus four suite fixes that are not about
debugging at all.

---

## The seam

XOOPS decides which module renders an uncaught error, and until now that was decided by
whoever called `set_error_handler()` last. Module weight and id chose your error screen,
reinstalling something unrelated could change it, and nothing anywhere reported which module
had won.

`include/common.php` fires `core.debug.errorscreen` as its final statement, for one owner.
Ownership resolves in three steps, first answer wins:

1. an explicit token in `xoops_data/data/debug.php`,
2. else the token a provider recorded at install,
3. else `core`.

Four constants publish the result on every request — `XOOPS_ERROR_SCREEN_OWNER`, `_SOURCE`,
`_STATUS`, `_MESSAGE` — so "who owns the error screen here?" is a question a diagnostics page
can answer.

**Core knows a token, never a provider's code.** That single rule is why activation is
`debug.php`-only, why a released seat is not passed on to some other installed provider, and
why the developer gate is advisory rather than enforced. `ADR-0001` has the reasoning and
records the dissent on that last point, which was argued across eight review rounds and did
not move.

Three parts exist because review found them, and they are the interesting ones:

- **A provider that registers handlers and then fails does not keep them.** The restore keys
  on the reported *outcome*, not on the `catch` — both reference providers wrap their own
  activation and report `error` without ever throwing at core, so a restore living in the
  catch would miss the two implementations shipped as the worked examples.
- **Three detectors notice when the published status would be a lie**: a second module
  reporting, a listener registering after the accepted report, and a silent registration
  nobody reported. All three compare *both* handlers, because PHP hands them out
  independently — an earlier version watched only the error handler and published "the
  handlers stay with XoopsLogger" while the exception path belonged to somebody else.
- **Ownership is a compare-and-set under the lock.** Read-then-write let two concurrent
  installs both believe they had claimed the seat.

Rollback is partial and says so: a shutdown function cannot be unregistered by anybody, so
providers close that residue by doing everything that can throw *before* they register.

## Why `htdocs/class/file/folder.php` is in a debug branch

Fair question, and it deserves the first answer rather than the last.

Running this seam's suite on Windows — for the first time, as it turns out — surfaced three
defects that have nothing to do with the error screen and everything to do with whether the
suite tells the truth:

| Commit | Defect |
|---|---|
| `8092bb04a` | `XoopsFolderHandler::isAbsolute()` accepts `C:/` but not `C:\`, while `isWindowsPath()` twenty lines above matches the opposite spelling. PHP's `dirname()` and `realpath()` return backslashes on Windows, so `cd()` treated absolute paths as relative and left `pwd()` null. **The file cache engine has never initialised on Windows.** UNC paths were never matched at all. |
| `84a54402f` | `MyTextSanitizerTest` popped two handler frames believing `displayTarea()` installed them. `XoopsLogger::getInstance()` installs them, and only on its *first* call — so in a full suite the test popped PHPUnit's frames instead. |
| `a3ca1900a` | `LostPassSecurityTest` never cleared its rate-limit cache. `$idLimit` is 3 and each run adds one hit, so **the suite was reproducible exactly twice** in one working copy and failed on the third — blaming whatever had changed most recently. |
| `50213f752` | `tests/bootstrap.php` called `ReflectionProperty::setAccessible()`, a no-op since 8.1 and deprecated in 8.5. The deprecation is emitted during bootstrap, so it contaminated the output of every test asserting on a clean stream. |

They are separate commits, first in the branch, one concern each. Leaving them out would have
meant opening this PR with a "known failures, please ignore these" paragraph, and a reviewer
should not have to be told which red is safe.

The fix in `8092bb04a` is worth one extra line: it did not just remove two errors. **Fifty-eight
tests had been skipping** because `XoopsCache` could not initialise, and had been skipping for
as long as this suite has run on Windows. They now execute and pass. A skip fails nothing, so
nobody had seen them.

## Verification

Full core suite, PHP 8.2.0 / 8.3.0 / 8.4.0 / 8.5.0, identical on each:

```
Tests: 6520, Assertions: 12704, Errors: 1, Failures: 3, Skipped: 18, Incomplete: 2, Risky: 0
```

The remaining error and three failures are all `LanguageManagerSmokeTest` against
`docs/language-contracts/2.7.0/required-constants.json`, which is not in the tree and arrives
with 2.8.0. Nothing else in 6520 tests is red.

Against the branch point:

| | before | after |
|---|---|---|
| Errors | 3 | 1 |
| Risky | 1 | 0 |
| Skipped | 76 | 18 |
| Assertions | 12606 | 12704 |

`ErrorScreenSeamTest` is 28 cases, each in its own process — the seam publishes constants, and
constants are defined once per process, so sharing one would let the first case decide every
later one. The fixture spec crosses that boundary as base64, because raw JSON through
`escapeshellarg()` is silently mangled on Windows and every case failed there while passing on
Linux CI.

The three contested detectors carry a standing rule in the test's docblock: change one, break
it by hand, and require its case to go red before restoring it. That is not ceremony — one of
those cases was once green against the exact regression it was named for.

## Review

Eight rounds, four reviewers, all four approving. What it caught, beyond the three items
above: the handler rollback on a failed provider; the one-eyed detectors; a thrown failure
mislabelled `contested`; the ownership race; the Windows fixture transport; a reference
provider holding the error handler against five documents that said it did not, and then the
first fix for that unbalancing Whoops' own `unregister()`; a contract test whose teardown made
every one of its own cases risky; eighteen PHPStan errors a regenerated baseline would have
frozen.

**None of them were in the design.**

## The public surface

`debug.php` keys: `enabled`, `environment`, `display_errors`, `error_reporting`,
`error_screen`, `error_screen_strict`, `database`, `debugbar`, `core_log`. `debug.dist.php`
is the annotated template.

Functions core publishes for providers: `xoops_getDebugConfig()`,
`xoops_getDebugEnvironment()`, `xoops_isDeveloperRequest()`, `xoops_activateErrorScreen()`,
`xoops_getErrorScreenOwner()` / `…OwnerSource()` / `…Status()`,
`xoops_recordErrorScreenOwner()`, `xoops_getRecordedErrorScreenOwner()`,
`xoops_releaseErrorScreenOwner()`.

Providers should test for `xoops_activateErrorScreen()` at install, **not** for a version
number: the seam landed during 2.7.3's own development, so even a 2.7.3 install may predate
it, and a version number cannot express a capability.

## Companion changes, shipping separately

Three modules adopt the seam in their own repositories — `xwhoops`, `xtracy` and `debugbar`.
None is required by this PR; the seam falls back to `core` when nothing claims it.

## Not in this PR

- `docs/language-contracts/` — the four remaining suite issues, arriving with 2.8.0.
- `XoopsLogger::getInstance()` installing PHP's handlers as a side effect of a getter, which
  is the root cause behind `84a54402f`. Filed separately; `image.php` and the installer both
  reach it without booting `common.php`.
- An `xtracy` PHPUnit harness, so the ADR's provider-gate promise stays half-kept — stated
  rather than glossed.

## Summary by Sourcery

Switch debug configuration to a file-based system and introduce an error-screen ownership seam with supporting diagnostics and tests.

New Features:
- Publish environment and error-screen ownership/status information via configuration, constants, and helper functions for core and modules.
- Provide a vendor directory locator and developer-request gate to standardise how diagnostics and error screens are activated.

Bug Fixes:
- Fix rate-limit tests to purge disk-backed cache state between runs so results are reproducible.
- Correct MyTextSanitizer tests to snapshot and restore handlers safely without interfering with PHPUnit’s own handlers.

Enhancements:
- Strengthen bootstrap robustness by guarding debug configuration loading and error-screen activation so truncated or missing config files cannot take down the site.
- Normalise and rename core file logging configuration while maintaining backward compatibility for existing debug setups.
- Improve Windows path handling in the folder utility to correctly recognise absolute drive and UNC paths.
- Adjust test bootstrap reflection usage to avoid deprecated APIs and noisy deprecation output.

Tests:
- Add a comprehensive ErrorScreenSeam test harness and out-of-process fixture runner to validate error-screen ownership, failure modes, and contention detection across processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable error-screen handling with ownership, strict-mode controls, provider status reporting, and runtime debug overrides.
  - Added environment configuration and improved debug logging controls.
  - Added support for Unix, drive-letter, and UNC absolute paths.

- **Bug Fixes**
  - Improved startup resilience when debug configuration files are missing, unreadable, or incomplete.
  - Prevented configuration errors from interrupting application startup.
  - Improved error-handler rollback and detection of conflicting error-screen providers.
  - Reduced deprecation-related output during automated testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->