### PR TITLE
2.7.3 RC1

### DIFF
--- a/docs/changelog.270.txt
+++ b/docs/changelog.270.txt
@@ -1,6 +1,47 @@
 XOOPS 2.7.x Changelog (Language changes: see: /docs/lang_diff.txt)
 
 ===================================
+2.7.3 RC 1                    2026-08
+===================================
+Editors:
+- add SCEditor as an optional BBCode editor, selectable from the editor preference dropdown alongside the existing editors. The 3.2.1 distribution ships bundled under minified/ (MIT, licence text included), so no separate download is needed and an upgrade is a wholesale replacement of that directory (mamba) in #152
+- lock SCEditor in source mode deliberately: startInSourceMode is set and both sourceMode(false) and toggleSourceMode() are guarded, so existing content never passes through a WYSIWYG round-trip that could rewrite or drop XOOPS-specific BBCode such as [siteurl], [d], named [size=] values or arbitrary smilie codes. Toolbar buttons insert at the caret and never re-serialise the rest of the document (mamba) in #152
+- render one shared dhtml toolbar for every renderer. The same editor showed a different toolbar in the control panel than on the front end, and different again between front-end themes: renderFormDhtmlTAXoopsCode() and renderFormDhtmlTATypography() were independently hand-written HTML in five renderers, and since no admin theme selects a renderer the control panel fell back to the Legacy one, whose Bootstrap class names no admin theme defines. XoopsDhtmlToolbar now produces the toolbar once and all five renderers delegate to it, with framework-neutral xo-edtb-* classes. The two protected helpers are kept as thin delegates for any third-party subclass that calls or overrides them (mamba) in #151
+- repair the dhtml toolbar's no-selection actions (mamba) in #151
+
+Compatibility:
+- repair [code] and [quote] rendering on PHP 8.3+. highlight_string() changed in 8.3, returning "<pre><code style=...>" with real newlines where earlier versions returned "<code><span style=...>" with <br /> and &nbsp;. The extension located its opening marker with strpos($buffer, '&lt;?php&nbsp;') and added a hard-coded 14; on 8.3+ that strpos() returns false, false + 14 evaluates to 14, and the first fourteen characters of real output were cut, leaving a block beginning with the literal text le="color: #000000">. The marker is now found with a pattern accepting either encoding and its length taken from the match (mamba) in #150
+- keep code-block whitespace intact and scope the trailing-break trim to XOOPS' own boxes (mamba) in #150
+- drop deprecated curl_close() calls for PHP 8.5 (mamba) in #153
+- drop ReflectionProperty::setAccessible() from the test bootstrap; a no-op since 8.1 and deprecated in 8.5, and emitted during bootstrap it contaminated the output of every test asserting on a clean stream (mamba) in #157
+
+Debugging and logging:
+- offer the error screen to one declared owner instead of whichever module registered last. Ownership resolves in three steps, first answer wins: an explicit token in xoops_data/data/debug.php, else the token a provider recorded at install, else 'core'. Four constants publish the result on every request - XOOPS_ERROR_SCREEN_OWNER, _SOURCE, _STATUS and _MESSAGE - so a diagnostics page can answer "who owns the error screen here?" (mamba) in #157
+- hand the handlers back when a provider registers and then fails to activate, keyed on the reported outcome rather than on the catch, since both reference providers wrap their own activation and report 'error' without throwing at core (mamba) in #157
+- detect and report a contested error screen: a second module reporting, a listener registering after the accepted report, and a silent registration nobody reported. All three compare both the error and the exception handler, because PHP hands them out independently (mamba) in #157
+- make error-screen ownership a compare-and-set under the lock; read-then-write let two concurrent installs both believe they had claimed the seat (mamba) in #157
+- add an opt-in error_screen_strict setting, for a site that wants the developer gate enforced by core rather than left advisory to the provider (mamba) in #157
+
+Security:
+- escape element values in all five form renderers, which wrote them straight into quoted attributes and textarea bodies. Values now route through a shared XoopsFormRendererValueEscapeTrait, and toolbar and TextSanitizer extension handlers build their JavaScript arguments with json_encode rather than htmlspecialchars, which is the correct encoder for a JS string literal inside an HTML attribute (mamba) in #151
+- escape module-manifest values (name, dirname, adminindex, version, image) at the point of output on the install, uninstall, update and activate log pages; getInfo() returns these raw whatever format is requested, and several were interpolated into href and src attributes unescaped (mamba) in #155
+- build the testdata link's filesystem probe from the directory actually being installed - basename() plus a strict character allowlist - so a manifest value cannot point the file_exists() check outside the module's own directory (mamba) in #155
+- enforce authorization on the image category create, update and delete handlers, which validated the CSRF token but not the caller's permission; the admin check governed only which controls were rendered (mamba) in #151
+- remove three stale copies of core renderers under the TinyMCE image-manager plugins, which were installed as the global renderer so those screens never received core renderer changes; the endpoints now xoops_load() the core class (mamba) in #151
+- guard getByDirname() on the module uninstall and update confirm screens (mamba) in #156
+
+Database:
+- render an empty IN list as a constant predicate. Criteria::render() emitted the literal IN (), which MySQL rejects as a syntax error; an empty set is now 1=0 for IN and 1=1 for NOT IN. Returning an empty fragment would be wrong, since CriteriaCompo drops empty fragments and the condition would silently match every row. This also fixes search.php, which built mid IN () for any user whose module-read permission list was empty (mamba) in #154
+- preserve the caller's PHP type in an IN array: an int renders as an SQL integer, anything else as a quoted string literal. Previously a numeric-looking string was cast, so a text-column search for '001' rendered IN (1), which MySQL evaluates numerically and matches against '1', '01' and ' 1'; a list of '001' and '1' collapsed to IN (1,1). Integer columns are unaffected (mamba) in #154
+
+Filesystem:
+- treat drive-letter and UNC paths as absolute in XoopsFolderHandler::isAbsolute(), which accepted C:/ but not C:\ while isWindowsPath() twenty lines above matched the opposite spelling. PHP's dirname() and realpath() return the backslash form on Windows, so cd() treated absolute paths as relative, built a path that does not exist and left pwd() null - which is why the file cache engine had never initialised on Windows. UNC paths were never matched at all (mamba) in #157
+
+Tests:
+- cover the error-screen seam in 28 cases, each in its own process, since the seam publishes its outcome as constants and constants are defined once per process. The fixture spec crosses that boundary as base64, because raw JSON through escapeshellarg() is silently mangled on Windows (mamba) in #157
+- stop two tests leaking state into the rest of the suite: MyTextSanitizerTest popped two handler frames believing displayTarea() installed them, when XoopsLogger::getInstance() installs them and only on its first call in the process; and LostPassSecurityTest never cleared its rate-limit cache, so with an idLimit of 3 the suite was reproducible exactly twice in one working copy and failed on the third run (mamba) in #157
+
+===================================
 2.7.3 Beta 1                  2026-07
 ===================================
 Debugging and logging:

--- a/htdocs/include/version.php
+++ b/htdocs/include/version.php
@@ -32,4 +32,4 @@ if (file_exists($licenseFile)) {
 /**
  *  Define XOOPS version
  */
-define('XOOPS_VERSION', 'XOOPS 2.7.3-Beta1');
+define('XOOPS_VERSION', 'XOOPS 2.7.3-RC1');


### PR DESCRIPTION
## Summary by Sourcery

Update project to XOOPS 2.7.3 RC1 release candidate.

Enhancements:
- Bump core version constant from 2.7.3 Beta1 to 2.7.3 RC1.

Documentation:
- Prepare changelog file for the 2.7.3 RC1 release.