### PR TITLE
Deprecate XOBJ_DTYPE_UNICODE_* datatypes (2.7.3)

### DIFF
--- a/htdocs/class/model/write.php
+++ b/htdocs/class/model/write.php
@@ -65,7 +65,7 @@ class XoopsModelWrite extends XoopsModelAbstract
                     $cleanv = !is_string($cleanv) && is_numeric($cleanv) ? date(_DBDATESTRING, $cleanv) : date(_DBDATESTRING, strtotime($cleanv));
                     $cleanv = str_replace('\\"', '"', $this->handler->db->quote($cleanv));
                     break;
-                case XOBJ_DTYPE_UNICODE_TXTBOX:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_TXTBOX:
                     if ($v['required'] && $cleanv != '0' && $cleanv == '') {
                         $errors[] = sprintf(_XOBJ_ERR_REQUIRED, $k);
                         continue 2;
@@ -81,7 +81,7 @@ class XoopsModelWrite extends XoopsModelAbstract
                     $cleanv = str_replace('\\"', '"', $this->handler->db->quote($cleanv));
                     break;
 
-                case XOBJ_DTYPE_UNICODE_TXTAREA:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_TXTAREA:
                     if ($v['required'] && $cleanv != '0' && $cleanv == '') {
                         $errors[] = sprintf(_XOBJ_ERR_REQUIRED, $k);
                         continue 2;
@@ -121,7 +121,7 @@ class XoopsModelWrite extends XoopsModelAbstract
                     $cleanv = str_replace('\\"', '"', $this->handler->db->quote($cleanv));
                     break;
                 // Should not be used!
-                case XOBJ_DTYPE_UNICODE_EMAIL:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_EMAIL:
                     $cleanv = trim($cleanv);
                     if ($v['required'] && $cleanv == '') {
                         $errors[] = sprintf(_XOBJ_ERR_REQUIRED, $k);
@@ -144,7 +144,7 @@ class XoopsModelWrite extends XoopsModelAbstract
                     break;
 
                 // Should not be used!
-                case XOBJ_DTYPE_UNICODE_URL:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_URL:
                     $cleanv = trim($cleanv);
                     if ($v['required'] && $cleanv == '') {
                         $errors[] = sprintf(_XOBJ_ERR_REQUIRED, $k);
@@ -168,7 +168,7 @@ class XoopsModelWrite extends XoopsModelAbstract
                     break;
 
                 // Should not be used!
-                case XOBJ_DTYPE_UNICODE_OTHER:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_OTHER:
                     $cleanv = str_replace('\\"', '"', $this->handler->db->quote(xoops_convert_encode($cleanv)));
                     break;
 
@@ -189,7 +189,7 @@ class XoopsModelWrite extends XoopsModelAbstract
                     break;
 
                 // Should not be used!
-                case XOBJ_DTYPE_UNICODE_ARRAY:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_ARRAY:
                     if (!$v['not_gpc']) {
                         $cleanv = array_map([&$myts, 'stripSlashesGPC'], $cleanv);
                     }

--- a/htdocs/kernel/object.php
+++ b/htdocs/kernel/object.php
@@ -40,7 +40,21 @@ define('XOBJ_DTYPE_LTIME', 11);
 define('XOBJ_DTYPE_FLOAT', 13);
 define('XOBJ_DTYPE_DECIMAL', 14);
 define('XOBJ_DTYPE_ENUM', 15);
-// YOU SHOULD NEVER USE THE FOLLOWING TYPES, THEY WILL BE REMOVED
+/**
+ * DEPRECATED since XOOPS 2.7.3 — scheduled for removal in XOOPS 4.0.
+ *
+ * The UNICODE_* datatypes url-encode on write and url-decode on read (via
+ * xoops_convert_encode()/decode()), a pre-UTF-8 workaround that is harmful on
+ * modern utf8mb4 installs: it bloats storage and breaks SQL LIKE/FULLTEXT.
+ * Use the non-unicode successor instead:
+ *   UNICODE_TXTBOX  -> TXTBOX    UNICODE_TXTAREA -> TXTAREA
+ *   UNICODE_URL     -> URL       UNICODE_EMAIL   -> EMAIL
+ *   UNICODE_ARRAY   -> ARRAY     UNICODE_OTHER   -> OTHER
+ * Existing Unicode-typed data (e.g. profile custom fields persisted in
+ * profile_field.field_valuetype) must be migrated in XOOPS 2.8 before removal.
+ *
+ * @deprecated 2.7.3
+ */
 define('XOBJ_DTYPE_UNICODE_TXTBOX', 16);
 define('XOBJ_DTYPE_UNICODE_TXTAREA', 17);
 define('XOBJ_DTYPE_UNICODE_URL', 18);
@@ -193,6 +207,23 @@ class XoopsObject
      */
     public function initVar($key, $data_type, $value = null, $required = false, $maxlength = null, $options = '', $enumerations = '')
     {
+        // Deprecation notice (2.7.3): the UNICODE_* datatypes are scheduled for
+        // removal in 4.0. Warning-only — behaviour is unchanged. Guarded so it is
+        // safe during early bootstrap, before the logger exists.
+        if (
+            in_array($data_type, [
+                XOBJ_DTYPE_UNICODE_TXTBOX, XOBJ_DTYPE_UNICODE_TXTAREA, XOBJ_DTYPE_UNICODE_URL,
+                XOBJ_DTYPE_UNICODE_EMAIL, XOBJ_DTYPE_UNICODE_ARRAY, XOBJ_DTYPE_UNICODE_OTHER,
+            ], true)
+            && isset($GLOBALS['xoopsLogger']) && is_object($GLOBALS['xoopsLogger'])
+        ) {
+            $GLOBALS['xoopsLogger']->addDeprecated(sprintf(
+                "XOBJ_DTYPE_UNICODE_* datatype used for variable '%s' in %s is deprecated since XOOPS 2.7.3 and will be removed in 4.0; use the non-unicode datatype instead.",
+                (string) $key,
+                get_class($this)
+            ));
+        }
+
         $this->vars[$key] = [
             'value'       => $value,
             'required'    => $required,

--- a/htdocs/kernel/object.php
+++ b/htdocs/kernel/object.php
@@ -50,8 +50,12 @@ define('XOBJ_DTYPE_ENUM', 15);
  *   UNICODE_TXTBOX  -> TXTBOX    UNICODE_TXTAREA -> TXTAREA
  *   UNICODE_URL     -> URL       UNICODE_EMAIL   -> EMAIL
  *   UNICODE_ARRAY   -> ARRAY     UNICODE_OTHER   -> OTHER
- * Existing Unicode-typed data (e.g. profile custom fields persisted in
- * profile_field.field_valuetype) must be migrated in XOOPS 2.8 before removal.
+ * Migration (XOOPS 2.8, before removal): existing Unicode-typed values must be
+ * DECODED (xoops_convert_decode, i.e. urldecode) and re-saved BEFORE the field's
+ * datatype metadata is changed to the non-unicode successor — never flip the
+ * metadata first, or the stored url-encoded bytes are misread. XOBJ_DTYPE_UNICODE_ARRAY
+ * must be decoded element-wise (unserialize, decode each element, re-serialize).
+ * Affects e.g. profile custom fields persisted in profile_field.field_valuetype.
  *
  * @deprecated 2.7.3
  */
@@ -71,6 +75,16 @@ define('XOBJ_DTYPE_TIMESTAMP', 24);
  */
 class XoopsObject
 {
+    /**
+     * Object datatypes deprecated since XOOPS 2.7.3 (XOBJ_DTYPE_UNICODE_* = 16-21),
+     * scheduled for removal in 4.0. Kept here as literal ids, in one place, so this
+     * reference site does not itself trip the deprecation check; see the @deprecated
+     * block near the XOBJ_DTYPE_UNICODE_* defines in this file.
+     *
+     * @var int[]
+     */
+    private const DEPRECATED_UNICODE_DATATYPES = [16, 17, 18, 19, 20, 21];
+
     /**
      * holds all variables(properties) of an object
      *
@@ -207,18 +221,14 @@ class XoopsObject
      */
     public function initVar($key, $data_type, $value = null, $required = false, $maxlength = null, $options = '', $enumerations = '')
     {
-        // Deprecation notice (2.7.3): the UNICODE_* datatypes are scheduled for
-        // removal in 4.0. Warning-only — behaviour is unchanged. Guarded so it is
-        // safe during early bootstrap, before the logger exists.
+        // Deprecation notice (2.7.3): warn on the UNICODE_* datatypes (removal in 4.0).
+        // Warning-only; guarded so it is safe before the logger exists during bootstrap.
         if (
-            in_array($data_type, [
-                XOBJ_DTYPE_UNICODE_TXTBOX, XOBJ_DTYPE_UNICODE_TXTAREA, XOBJ_DTYPE_UNICODE_URL,
-                XOBJ_DTYPE_UNICODE_EMAIL, XOBJ_DTYPE_UNICODE_ARRAY, XOBJ_DTYPE_UNICODE_OTHER,
-            ], true)
+            in_array($data_type, self::DEPRECATED_UNICODE_DATATYPES, true)
             && isset($GLOBALS['xoopsLogger']) && is_object($GLOBALS['xoopsLogger'])
         ) {
             $GLOBALS['xoopsLogger']->addDeprecated(sprintf(
-                "XOBJ_DTYPE_UNICODE_* datatype used for variable '%s' in %s is deprecated since XOOPS 2.7.3 and will be removed in 4.0; use the non-unicode datatype instead.",
+                "XOBJ_DTYPE_UNICODE_* is deprecated since 2.7.3; use the non-unicode datatype for '%s' in %s.",
                 (string) $key,
                 get_class($this)
             ));
@@ -246,7 +256,7 @@ class XoopsObject
     {
         if (isset($key) && isset($this->vars[$key])) {
             switch ($this->vars[$key]['data_type']) {
-                case XOBJ_DTYPE_UNICODE_ARRAY:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_ARRAY:
                     if (is_array($value)) {
                         $temp = $value;
                         array_walk($temp, 'xoops_aw_decode');
@@ -256,11 +266,11 @@ class XoopsObject
                         $this->vars[$key]['value'] = xoops_convert_decode($value);
                     }
                     break;
-                case XOBJ_DTYPE_UNICODE_URL:
-                case XOBJ_DTYPE_UNICODE_EMAIL:
-                case XOBJ_DTYPE_UNICODE_OTHER:
-                case XOBJ_DTYPE_UNICODE_TXTBOX:
-                case XOBJ_DTYPE_UNICODE_TXTAREA:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_URL:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_EMAIL:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_OTHER:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_TXTBOX:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_TXTAREA:
                     $this->vars[$key]['value'] = xoops_convert_decode($value);
                     break;
                 case XOBJ_DTYPE_DATE:
@@ -470,7 +480,7 @@ class XoopsObject
             case XOBJ_DTYPE_INT:
                 $ret = (null === $ret) ? '' : (int) $ret;
                 break;
-            case XOBJ_DTYPE_UNICODE_TXTBOX:
+            case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_TXTBOX:
             case XOBJ_DTYPE_TXTBOX:
                 switch (strtolower($format)) {
                     case 's':
@@ -491,7 +501,7 @@ class XoopsObject
                         break 1;
                 }
                 break;
-            case XOBJ_DTYPE_UNICODE_TXTAREA:
+            case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_TXTAREA:
             case XOBJ_DTYPE_TXTAREA:
                 switch (strtolower($format)) {
                     case 's':
@@ -528,7 +538,7 @@ class XoopsObject
                         break 1;
                 }
                 break;
-            case XOBJ_DTYPE_UNICODE_ARRAY:
+            case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_ARRAY:
                 switch (strtolower($format)) {
                     case 'n':
                     case 'none':
@@ -833,7 +843,7 @@ class XoopsObject
                             continue 2;
                         }
                         break;
-                    case XOBJ_DTYPE_UNICODE_TXTBOX:
+                    case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_TXTBOX:
                         if ($v['required'] && $cleanv != '0' && $cleanv == '') {
                             $this->setErrors(sprintf(_XOBJ_ERR_REQUIRED, $k));
                             continue 2;
@@ -845,7 +855,7 @@ class XoopsObject
                         }
                         $cleanv = $myts->censorString($cleanv);
                         break;
-                    case XOBJ_DTYPE_UNICODE_TXTAREA:
+                    case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_TXTAREA:
                         if ($v['required'] && $cleanv != '0' && $cleanv == '') {
                             $this->setErrors(sprintf(_XOBJ_ERR_REQUIRED, $k));
                             continue 2;
@@ -853,7 +863,7 @@ class XoopsObject
                         $cleanv = xoops_convert_encode($cleanv);
                         $cleanv = $myts->censorString($cleanv);
                         break;
-                    case XOBJ_DTYPE_UNICODE_EMAIL:
+                    case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_EMAIL:
                         if ($v['required'] && $cleanv == '') {
                             $this->setErrors(sprintf(_XOBJ_ERR_REQUIRED, $k));
                             continue 2;
@@ -864,7 +874,7 @@ class XoopsObject
                         }
                         $cleanv = xoops_convert_encode($cleanv);
                         break;
-                    case XOBJ_DTYPE_UNICODE_URL:
+                    case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_URL:
                         if ($v['required'] && $cleanv == '') {
                             $this->setErrors(sprintf(_XOBJ_ERR_REQUIRED, $k));
                             continue 2;
@@ -874,7 +884,7 @@ class XoopsObject
                         }
                         $cleanv = xoops_convert_encode($cleanv);
                         break;
-                    case XOBJ_DTYPE_UNICODE_ARRAY:
+                    case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_ARRAY:
                         $cleanv = serialize(array_walk($cleanv, 'xoops_aw_encode'));
                         break;
                     default:

--- a/htdocs/kernel/object.php
+++ b/htdocs/kernel/object.php
@@ -76,10 +76,10 @@ define('XOBJ_DTYPE_TIMESTAMP', 24);
 class XoopsObject
 {
     /**
-     * Object datatypes deprecated since XOOPS 2.7.3 (XOBJ_DTYPE_UNICODE_* = 16-21),
+     * Ids of the datatypes deprecated in XOOPS 2.7.3 (XOBJ_DTYPE_UNICODE_* = 16-21),
      * scheduled for removal in 4.0. Kept here as literal ids, in one place, so this
-     * reference site does not itself trip the deprecation check; see the @deprecated
-     * block near the XOBJ_DTYPE_UNICODE_* defines in this file.
+     * reference site does not itself trip the deprecation check; see the deprecation
+     * doc block near the XOBJ_DTYPE_UNICODE_* defines in this file.
      *
      * @var int[]
      */

--- a/htdocs/modules/profile/class/field.php
+++ b/htdocs/modules/profile/class/field.php
@@ -547,13 +547,13 @@ class ProfileFieldHandler extends XoopsPersistableObjectHandler
             switch ($obj->getVar('field_valuetype')) {
                 default:
                 case XOBJ_DTYPE_ARRAY:
-                case XOBJ_DTYPE_UNICODE_ARRAY:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_ARRAY:
                     $type = 'mediumtext';
                     $maxlengthstring = '';
                     break;
-                case XOBJ_DTYPE_UNICODE_EMAIL:
-                case XOBJ_DTYPE_UNICODE_TXTBOX:
-                case XOBJ_DTYPE_UNICODE_URL:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_EMAIL:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_TXTBOX:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_URL:
                 case XOBJ_DTYPE_EMAIL:
                 case XOBJ_DTYPE_TXTBOX:
                 case XOBJ_DTYPE_URL:
@@ -579,7 +579,7 @@ class ProfileFieldHandler extends XoopsPersistableObjectHandler
                     break;
 
                 case XOBJ_DTYPE_OTHER:
-                case XOBJ_DTYPE_UNICODE_TXTAREA:
+                case /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_TXTAREA:
                 case XOBJ_DTYPE_TXTAREA:
                     $type            = 'text';
                     $maxlengthstring = '';

--- a/htdocs/modules/profile/include/forms.php
+++ b/htdocs/modules/profile/include/forms.php
@@ -96,11 +96,11 @@ function profile_getFieldForm(ProfileField $field, $action = false)
                     XOBJ_DTYPE_URL             => _PROFILE_AM_URL,
                     XOBJ_DTYPE_OTHER           => _PROFILE_AM_OTHER,
                     XOBJ_DTYPE_ARRAY           => _PROFILE_AM_ARRAY,
-                    XOBJ_DTYPE_UNICODE_ARRAY   => _PROFILE_AM_UNICODE_ARRAY,
-                    XOBJ_DTYPE_UNICODE_TXTBOX  => _PROFILE_AM_UNICODE_TXTBOX,
-                    XOBJ_DTYPE_UNICODE_TXTAREA => _PROFILE_AM_UNICODE_TXTAREA,
-                    XOBJ_DTYPE_UNICODE_EMAIL   => _PROFILE_AM_UNICODE_EMAIL,
-                    XOBJ_DTYPE_UNICODE_URL     => _PROFILE_AM_UNICODE_URL,
+                    /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_ARRAY   => _PROFILE_AM_UNICODE_ARRAY,
+                    /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_TXTBOX  => _PROFILE_AM_UNICODE_TXTBOX,
+                    /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_TXTAREA => _PROFILE_AM_UNICODE_TXTAREA,
+                    /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_EMAIL   => _PROFILE_AM_UNICODE_EMAIL,
+                    /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_URL     => _PROFILE_AM_UNICODE_URL,
                 ];
 
                 $type_select = new XoopsFormSelect(_PROFILE_AM_VALUETYPE, 'field_valuetype', $field->getVar('field_valuetype', 'e'));
@@ -120,11 +120,11 @@ function profile_getFieldForm(ProfileField $field, $action = false)
                     XOBJ_DTYPE_URL             => _PROFILE_AM_URL,
                     XOBJ_DTYPE_OTHER           => _PROFILE_AM_OTHER,
                     XOBJ_DTYPE_ARRAY           => _PROFILE_AM_ARRAY,
-                    XOBJ_DTYPE_UNICODE_ARRAY   => _PROFILE_AM_UNICODE_ARRAY,
-                    XOBJ_DTYPE_UNICODE_TXTBOX  => _PROFILE_AM_UNICODE_TXTBOX,
-                    XOBJ_DTYPE_UNICODE_TXTAREA => _PROFILE_AM_UNICODE_TXTAREA,
-                    XOBJ_DTYPE_UNICODE_EMAIL   => _PROFILE_AM_UNICODE_EMAIL,
-                    XOBJ_DTYPE_UNICODE_URL     => _PROFILE_AM_UNICODE_URL,
+                    /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_ARRAY   => _PROFILE_AM_UNICODE_ARRAY,
+                    /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_TXTBOX  => _PROFILE_AM_UNICODE_TXTBOX,
+                    /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_TXTAREA => _PROFILE_AM_UNICODE_TXTAREA,
+                    /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_EMAIL   => _PROFILE_AM_UNICODE_EMAIL,
+                    /** @scrutinizer ignore-deprecated */ XOBJ_DTYPE_UNICODE_URL     => _PROFILE_AM_UNICODE_URL,
                 ];
 
                 $type_select = new XoopsFormSelect(_PROFILE_AM_VALUETYPE, 'field_valuetype', $field->getVar('field_valuetype', 'e'));


### PR DESCRIPTION
The UNICODE_* object datatypes (16-21) url-encode on write and url-decode on read via xoops_convert_encode()/decode() — a pre-UTF-8 workaround that harms modern utf8mb4 installs (storage bloat, broken LIKE/FULLTEXT search).

Deprecation notice only; behaviour is unchanged for 2.7.3 Final:
 - initVar() emits $xoopsLogger->addDeprecated() when a UNICODE_* type is used (guarded so it is safe during early bootstrap, before the logger exists).
 - the constant block gains an @deprecated 2.7.3 doc naming the non-unicode successors and the removal plan.

Data migration (profile custom fields in profile_field.field_valuetype) and the source refactor are planned for 2.8; constant removal for 4.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Deprecations**
  * Added notices for deprecated Unicode data types, including planned removal in XOOPS 4.0.
  * Clarified encoding behavior, recommended replacement data types, and migration requirements.
  * Applications now receive a deprecation warning when registering a Unicode data type, when logging is available.
  * Existing Unicode data type behavior remains unchanged, allowing time to review and migrate affected applications before removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->