### PR TITLE
fix(system): restore the show-all guard in system_search.tpl

### DIFF
--- a/htdocs/modules/system/templates/system_search.tpl
+++ b/htdocs/modules/system/templates/system_search.tpl
@@ -36,8 +36,8 @@
 <{/if}>
 <{if !empty($showallbyuser)}>
 	<h3><{$smarty.const._SR_SEARCHRESULTS}></h3>
-	<{if isset($nomatch) && $nomatch != true}>
-		<{if isset($showall)}>
+	<{if empty($nomatch)}>
+		<{if !empty($showall)}>
 			<{$smarty.const._SR_KEYWORDS}>: <strong><{$keywords}></strong>
 			<br>
 		<{/if}>
@@ -46,22 +46,17 @@
 		<{foreach item=data from=$results_arr|default:null}>
 			<img src="<{$data.image_link}>" title="<{$data.image_title}>" alt="<{$data.image_title}>"/> <a href="<{$data.link}>"><{$data.link_title}></a>
 			<br>
-			<{if $data.uname}>
+			<{if !empty($data.uname)}>
 				<span class='x-small'>
 					<a href="<{$data.uname_link}>"><{$data.uname}></a>
-					<{if $data.time}>
+					<{if !empty($data.time)}>
 						(<{$data.time}>)
 					<{/if}>
 				</span>
 				<br>
 			<{/if}>
 		<{/foreach}>
-		<{if isset($nomatch)}>
-			<p>
-				<{$smarty.const._SR_NOMATCH}>
-			</p>
-		<{/if}>
-		<{if $previous || $next}>
+		<{if !empty($previous) || !empty($next)}>
 			<br>
 			<table>
 				<tr>
@@ -78,6 +73,10 @@
 				</tr>
 			</table>
 		<{/if}>
+	<{else}>
+		<p>
+			<{$smarty.const._SR_NOMATCH}>
+		</p>
 	<{/if}>
 <{/if}>
 <{if isset($form)}>

--- a/tests/unit/htdocs/modules/system/templates/SystemSearchTemplateTest.php
+++ b/tests/unit/htdocs/modules/system/templates/SystemSearchTemplateTest.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Unit tests for modules/system/templates/system_search.tpl
+ *
+ * Guards the show-all control flow. The block was unreachable in both
+ * directions between 97d9d6a3 (2023) and this suite: it opened on
+ * `isset($nomatch) && $nomatch != true`, which is false when results exist
+ * ($nomatch is never assigned) and false when they do not ($nomatch is true),
+ * so neither the result list nor the no-match message could render.
+ *
+ * @copyright    2000-2026 XOOPS Project (https://xoops.org)
+ * @license      GNU GPL 2.0 or later (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @package      Tests\Unit\System\Templates
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Unit\System\Templates;
+
+require_once dirname(__DIR__) . '/SourceFileTestTrait.php';
+
+use PHPUnit\Framework\TestCase;
+use Tests\Unit\System\SourceFileTestTrait;
+
+/**
+ * Tests for system_search.tpl.
+ *
+ * These tests verify the template's control flow, the guards on optional
+ * values assigned by search.php, and XOOPS Smarty delimiter usage.
+ *
+ * @category  Test
+ * @package   Tests\Unit\System\Templates
+ * @author    XOOPS Development Team
+ * @copyright 2000-2026 XOOPS Project (https://xoops.org)
+ * @license   GNU GPL 2.0 or later (https://www.gnu.org/licenses/gpl-2.0.html)
+ * @link      https://xoops.org
+ */
+class SystemSearchTemplateTest extends TestCase
+{
+    use SourceFileTestTrait;
+
+    /**
+     * @var string Alias for sourceContent (kept for readability)
+     */
+    private string $templateContent;
+
+    protected function setUp(): void
+    {
+        $this->loadSourceFile('htdocs/modules/system/templates/system_search.tpl');
+        $this->templateContent = $this->sourceContent;
+    }
+
+    /**
+     * Return the show-all block, i.e. everything from its opening guard on.
+     *
+     * search.php assigns showallbyuser for BOTH action=showall and
+     * action=showallbyuser, so this one block serves both.
+     */
+    private function showAllBlock(): string
+    {
+        $start = strpos($this->templateContent, '<{if !empty($showallbyuser)}>');
+        $this->assertNotFalse($start, 'Template should contain the show-all block');
+
+        return substr($this->templateContent, $start);
+    }
+
+    // =========================================================================
+    // Show-all control flow (issue #161)
+    // =========================================================================
+
+    /**
+     * Verify that the show-all block opens on an empty-state test.
+     *
+     * search.php leaves $nomatch unassigned when rows were found and assigns
+     * boolean true when none were, so empty() is the test that distinguishes
+     * them. It also covers the results branch, where $nomatch is a string.
+     */
+    public function testShowAllBlockOpensOnEmptyNomatch(): void
+    {
+        $this->assertStringContainsString(
+            '<{if empty($nomatch)}>',
+            $this->showAllBlock(),
+            'Show-all results should render when $nomatch is empty'
+        );
+    }
+
+    /**
+     * Verify that the unsatisfiable guard has not come back.
+     *
+     * This is the regression sentinel: no request can satisfy
+     * isset($nomatch) && $nomatch != true.
+     */
+    public function testDoesNotUseTheUnsatisfiableNomatchGuard(): void
+    {
+        $this->assertStringNotContainsString(
+            'isset($nomatch) &&',
+            $this->templateContent,
+            'The show-all guard must not require $nomatch to be both set and not true'
+        );
+
+        $this->assertStringNotContainsString(
+            '$nomatch != true',
+            $this->templateContent,
+            'Comparing $nomatch against true is the shape of the unsatisfiable guard'
+        );
+    }
+
+    /**
+     * Verify that the no-match message is a sibling of the results, not a child.
+     *
+     * Nested inside the results branch it could never render, because that
+     * branch requires $nomatch to be absent.
+     */
+    public function testNoMatchMessageIsSiblingOfTheResults(): void
+    {
+        $block = $this->showAllBlock();
+
+        $guard   = strpos($block, '<{if empty($nomatch)}>');
+        $else    = strpos($block, '<{else}>');
+        $nomatch = strpos($block, '_SR_NOMATCH');
+
+        $this->assertNotFalse($guard, 'Show-all block should open on empty($nomatch)');
+        $this->assertNotFalse($else, 'Show-all block should have an else branch');
+        $this->assertNotFalse($nomatch, 'Show-all block should render _SR_NOMATCH');
+
+        $this->assertGreaterThan($guard, $else, 'The else branch belongs after the guard');
+        $this->assertGreaterThan(
+            $else,
+            $nomatch,
+            '_SR_NOMATCH belongs in the else branch, not inside the results branch'
+        );
+    }
+
+    // =========================================================================
+    // Guards on values search.php assigns conditionally
+    // =========================================================================
+
+    /**
+     * Verify that optional row fields are guarded.
+     *
+     * search.php assigns uname only when the module's row carried a uid, and
+     * time only when it carried a timestamp.
+     */
+    public function testOptionalRowFieldsAreGuarded(): void
+    {
+        $block = $this->showAllBlock();
+
+        $this->assertStringContainsString(
+            '<{if !empty($data.uname)}>',
+            $block,
+            'uname is optional and may be an empty string'
+        );
+
+        $this->assertStringContainsString(
+            '<{if !empty($data.time)}>',
+            $block,
+            'time is optional'
+        );
+    }
+
+    /**
+     * Verify that the pagination guard tolerates unassigned links.
+     *
+     * Neither previous nor next is assigned on a single page of results, and
+     * a bare truth test on an unassigned variable warns under Smarty's
+     * compiled tpl_vars access.
+     */
+    public function testPaginationGuardToleratesUnassignedLinks(): void
+    {
+        $this->assertStringContainsString(
+            '<{if !empty($previous) || !empty($next)}>',
+            $this->showAllBlock(),
+            'Pagination should be guarded with empty() checks on both links'
+        );
+    }
+
+    /**
+     * Verify that the keyword echo is guarded.
+     *
+     * showall assigns $showall; showallbyuser does not.
+     */
+    public function testKeywordEchoIsGuarded(): void
+    {
+        $this->assertStringContainsString(
+            '<{if !empty($showall)}>',
+            $this->showAllBlock(),
+            'The keyword line is only for action=showall'
+        );
+    }
+
+    // =========================================================================
+    // Results block (action=results) — must stay as it was
+    // =========================================================================
+
+    /**
+     * Verify that the results block still switches on its own $nomatch.
+     *
+     * That branch receives _SR_NOMATCH as a string, not boolean true.
+     */
+    public function testResultsBlockStillGuardsItsOwnNomatch(): void
+    {
+        $this->assertStringContainsString(
+            '<{if !empty($nomatch)}>',
+            $this->templateContent,
+            'The results block should still render the no-match string it is given'
+        );
+    }
+
+    // =========================================================================
+    // Template conventions
+    // =========================================================================
+
+    /**
+     * Verify that the template uses the XOOPS Smarty delimiters.
+     */
+    public function testUsesXoopsSmartyDelimiters(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/<\{[^}]+\}>/',
+            $this->templateContent,
+            'Template should use Smarty delimiters <{ }>'
+        );
+
+        $this->assertSame(
+            0,
+            preg_match('/(?<![<$])\{(?:if|else|foreach|\/if|\/foreach)\b/', $this->templateContent),
+            'Template must not use bare Smarty delimiters'
+        );
+    }
+}


### PR DESCRIPTION
The show-all / show-all-by-user block tested "isset($nomatch) && $nomatch != true", which no request can satisfy: search.php leaves $nomatch unassigned when the module returned rows, and sets it to true when it did not, so neither the result list nor the no-match message ever rendered. Both actions have produced an empty page since 97d9d6a3 replaced the working "$nomatch|default:false != true" guard.

Opens the block on empty($nomatch), which covers the boolean this branch receives and the string the results branch receives. Moves _SR_NOMATCH into an else branch, so it is a sibling of the results rather than nested inside a branch that requires $nomatch to be absent. Guards the optional values that become reachable again: $showall, $data.uname, $data.time, and the previous/next pagination links.

The xswatch5 override already carries the correct guard and is unchanged; themes without an override (default, xbootstrap5, xtailwind, xtailwind2) are the affected ones.

Adds SystemSearchTemplateTest, which fails six ways against the previous template.

Closes #161

## Summary by Sourcery

Restore proper control flow for the system search template’s show-all block so search results and no-match messages render correctly again.

Bug Fixes:
- Fix unreachable show-all search results and no-match message caused by an unsatisfiable $nomatch guard in system_search.tpl.

Tests:
- Add SystemSearchTemplateTest to verify show-all control flow, guards on optional search fields, pagination handling, and template delimiter conventions.