### PR TITLE
fix(browse): send a valid max-age cache directive

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -7,7 +7,7 @@ body:
   attributes:
     label: XOOPS Version
     description: Provide the XOOPS version that you are using.
-    options: ['2.5.11', '2.7.0', '4.0.0']
+    options: ['2.5.11', '2.7.0', '2.7.1', '2.7.2', '2.7.3', '4.0.0']
   validations:
     required: true
 - type: dropdown

--- a/htdocs/browse.php
+++ b/htdocs/browse.php
@@ -88,8 +88,12 @@ if (!isset($types[$ext])) {
 //Output now
 // seconds, minutes, hours, days
 $expires = 60 * 60 * 24 * 15;
-header('Pragma: public');
-header('Cache-Control: maxage=' . $expires);
+// "max-age" carries a hyphen (RFC 9111 5.2.2.1). This line sent "maxage=", which
+// is not a directive at all, and unrecognised directives are ignored -- so caches
+// reading Cache-Control saw no lifetime, and only the Expires header below kept
+// these assets cacheable. "public" replaces the former Pragma: public, which
+// never had any defined meaning as a response header.
+header('Cache-Control: public, max-age=' . $expires);
 header('Expires: ' . gmdate('D, d M Y H:i:s', time() + $expires) . ' GMT');
 header('Content-type: ' . $types[$ext]);
 

--- a/tests/unit/htdocs/BrowseCacheHeaderTest.php
+++ b/tests/unit/htdocs/BrowseCacheHeaderTest.php
@@ -11,6 +11,12 @@ use PHPUnit\Framework\TestCase;
  * 5.2.2.1), and an unrecognised directive is ignored, so the field carried no
  * lifetime for any cache reading it -- every asset served through browse.php,
  * including the bundled jQuery most themes load in <head>.
+ *
+ * These are source contracts rather than response assertions. browse.php is a
+ * front controller: it boots through mainfile.php, streams the file body, and
+ * ends in exit(), so including it would end the test run, and inspecting real
+ * response headers would need an installed site rather than a unit suite.
+ * BrowsePathContainmentTest guards its other contract the same way.
  */
 final class BrowseCacheHeaderTest extends TestCase
 {
@@ -69,14 +75,32 @@ final class BrowseCacheHeaderTest extends TestCase
     }
 
     #[Test]
-    public function theComposedHeaderIsTheIntendedFifteenDayPolicy(): void
+    public function bothFreshnessHeadersDeriveFromTheFifteenDayLifetime(): void
     {
-        // The exact field browse.php builds from its $expires expression.
-        $expires = 60 * 60 * 24 * 15;
-        self::assertSame(1296000, $expires);
+        $src = $this->browseSource();
+
+        // Read the lifetime out of browse.php rather than restating it here.
+        // The factors are multiplied as written, so refactoring the expression
+        // is free; changing the policy fails this test, which is the point.
         self::assertSame(
-            'Cache-Control: public, max-age=1296000',
-            'Cache-Control: public, max-age=' . $expires
+            1,
+            preg_match('/\$expires\s*=\s*([\d\s*]+?);/', $src, $m),
+            'browse.php should declare its cache lifetime as an $expires expression'
+        );
+        $lifetime = array_product(array_map('intval', preg_split('/\s*\*\s*/', trim($m[1]))));
+        self::assertSame(1296000, $lifetime, 'The cache lifetime should stay at 15 days');
+
+        // Both freshness headers have to be built from that one value, or they
+        // can drift apart and describe two different policies.
+        self::assertStringContainsString(
+            "header('Cache-Control: public, max-age=' . \$expires);",
+            $src,
+            'max-age should come from $expires, not a literal'
+        );
+        self::assertStringContainsString(
+            "time() + \$expires",
+            $src,
+            'Expires should be computed from the same $expires'
         );
     }
 }

--- a/tests/unit/htdocs/BrowseCacheHeaderTest.php
+++ b/tests/unit/htdocs/BrowseCacheHeaderTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * browse.php must describe its caching policy with directives that exist.
+ * It sent "Cache-Control: maxage=<seconds>"; HTTP defines "max-age" (RFC 9111
+ * 5.2.2.1), and an unrecognised directive is ignored, so the field carried no
+ * lifetime for any cache reading it -- every asset served through browse.php,
+ * including the bundled jQuery most themes load in <head>.
+ */
+final class BrowseCacheHeaderTest extends TestCase
+{
+    private function browseSource(): string
+    {
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/browse.php');
+        self::assertNotFalse($src, 'browse.php should be readable');
+
+        return $src;
+    }
+
+    #[Test]
+    public function browseSendsAHyphenatedMaxAgeDirective(): void
+    {
+        // Matched against the header() call, not the file text, so a comment
+        // naming the old spelling cannot pass or fail the test.
+        $src = $this->browseSource();
+        self::assertSame(
+            0,
+            preg_match('/header\(\s*[\'"]Cache-Control:\s*maxage/i', $src),
+            'browse.php must not emit "maxage"; HTTP has no such directive.'
+        );
+        self::assertStringContainsString("header('Cache-Control: public, max-age='", $src);
+    }
+
+    #[Test]
+    public function browseDoesNotSendPragmaPublic(): void
+    {
+        // Pragma is a request header whose only defined directive is no-cache.
+        // "public" belongs to Cache-Control, where it now is.
+        self::assertSame(
+            0,
+            preg_match('/header\(\s*[\'"]Pragma:/i', $this->browseSource()),
+            'Pragma: public has no defined meaning as a response header.'
+        );
+    }
+
+    #[Test]
+    public function browseKeepsTheExpiresFallback(): void
+    {
+        // Expires is what kept these assets cacheable while the directive was
+        // misspelled; it stays for caches that do not read Cache-Control.
+        self::assertStringContainsString("header('Expires: '", $this->browseSource());
+    }
+
+    #[Test]
+    public function browseDoesNotMarkAssetsImmutable(): void
+    {
+        // browse.php URLs are plain paths, not content-fingerprinted, so an
+        // immutable response would pin a stale asset for the full lifetime.
+        self::assertSame(
+            0,
+            preg_match('/immutable/i', $this->browseSource()),
+            'Assets served by path must not be declared immutable.'
+        );
+    }
+
+    #[Test]
+    public function theComposedHeaderIsTheIntendedFifteenDayPolicy(): void
+    {
+        // The exact field browse.php builds from its $expires expression.
+        $expires = 60 * 60 * 24 * 15;
+        self::assertSame(1296000, $expires);
+        self::assertSame(
+            'Cache-Control: public, max-age=1296000',
+            'Cache-Control: public, max-age=' . $expires
+        );
+    }
+}


### PR DESCRIPTION
browse.php emitted "Cache-Control: maxage=<seconds>". HTTP defines no maxage directive (RFC 9111 5.2.2.1), and unrecognised directives must be ignored, so the field carried no freshness information for any cache that read it and the intended policy survived only through the Expires header alongside it. Every asset served through browse.php is affected, including the bundled jQuery that most themes load in <head>.

Sends "public, max-age=<seconds>" instead, and drops "Pragma: public": Pragma is a request header whose only defined directive is no-cache, so "public" there never meant anything, and it is expressed by the public directive now. The Expires header and the 15-day lifetime are unchanged.

No immutable directive: browse.php URLs are plain paths rather than content-fingerprinted, so an immutable response would pin a stale asset for the full lifetime after a bundled asset is updated.

Adds BrowseCacheHeaderTest, which fails against the previous header pair.

Closes #163

## Summary by Sourcery

Correct browse.php caching headers to use a valid Cache-Control policy while retaining the existing 15-day lifetime and Expires fallback.

Bug Fixes:
- Replace the invalid Cache-Control maxage directive with a standards-compliant public, max-age directive for assets served via browse.php.

Tests:
- Add BrowseCacheHeaderTest to verify the Cache-Control header format, absence of Pragma: public and immutable directives, and preservation of the Expires fallback and 15-day policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected browser caching headers for browse pages.
  * Enabled a valid 15-day public cache policy using the standard `max-age` directive.
  * Preserved the `Expires` fallback while removing unsupported caching directives.

* **Tests**
  * Added coverage to verify the updated cache behavior and header values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->