### PR TITLE
fix(xswatch5): guard the optional search values in the theme override

### DIFF
--- a/htdocs/themes/xswatch5/modules/system/system_search.tpl
+++ b/htdocs/themes/xswatch5/modules/system/system_search.tpl
@@ -73,7 +73,7 @@
 					</div>
 					<{if !empty($previous) || !empty($next)}>
 						<div>
-						<{if isset($previous)}>
+						<{if !empty($previous)}>
 							<span class="d-none d-sm-inline"><a class="btn btn-secondary" href="<{$previous}>" role="button"><{$smarty.const._SR_PREVIOUS|replace:"<<":"<span class='fa-solid fa-circle-chevron-left fa-lg'></span>"}></a></span>
 							<span class="d-inline d-sm-none"><a class="btn btn-secondary" href="<{$previous}>" role="button"><span class="fa-solid fa-circle-chevron-left"></span></a></span>
 						<{else}>
@@ -81,7 +81,7 @@
 							<span class="d-inline d-sm-none"><a class="btn btn-secondary disabled" role="button" tabindex="-1" aria-disabled="true"><span class="text-muted"><span class="fa-solid fa-circle-chevron-left"></span></span></a></span>
 						<{/if}>
 						<span class="mx-1"></span>
-						<{if isset($next)}>
+						<{if !empty($next)}>
 							<span class="d-none d-sm-inline"><a class="btn btn-secondary" href="<{$next}>" role="button"><{$smarty.const._SR_NEXT|replace:">>":"<span class='fa-solid fa-circle-chevron-right fa-lg'></span>"}></a></span>
 							<span class="d-inline d-sm-none"><a class="btn btn-secondary" href="<{$next}>" role="button"><span class="fa-solid fa-circle-chevron-right"></span></a></span>
 						<{else}>

--- a/htdocs/themes/xswatch5/modules/system/system_search.tpl
+++ b/htdocs/themes/xswatch5/modules/system/system_search.tpl
@@ -42,7 +42,7 @@
 										<br />
 										<small><span class="fa-solid fa-user fa-sm ms-2 text-muted"></span> <a href="<{$data.uname_link}>"><{$data.uname}></a></small>
 
-										<{if $data.time}>
+										<{if !empty($data.time)}>
 											<small><span class="text-muted"><span class="fa-solid fa-calendar fa-sm ms-2"></span> <{$data.time}></span></small>
 										<{/if}>
 									</div>
@@ -71,7 +71,7 @@
 						<h5><{$module_name}></h5>
 						<{$showing|replace:"-":"- "}>
 					</div>
-					<{if $previous || $next}>
+					<{if !empty($previous) || !empty($next)}>
 						<div>
 						<{if isset($previous)}>
 							<span class="d-none d-sm-inline"><a class="btn btn-secondary" href="<{$previous}>" role="button"><{$smarty.const._SR_PREVIOUS|replace:"<<":"<span class='fa-solid fa-circle-chevron-left fa-lg'></span>"}></a></span>
@@ -106,13 +106,13 @@
 								<div class="d-inline"><img src="<{$data.image_link}>" title="<{$data.image_title}>" alt="<{$data.image_title}>"/> <a href="<{$data.link}>"><{$data.link_title}></a></div>
 							<{/if}>
 
-							<{if $data.uname}>
+							<{if !empty($data.uname)}>
 
 								<div class="d-none d-md-inline text-muted">
 									<br />
 									<small><span class="fa-solid fa-user fa-sm ms-2"></span> <a href="<{$data.uname_link}>"><{$data.uname}></a></small>
 
-									<{if $data.time}>
+									<{if !empty($data.time)}>
 										<small><span class="fa-solid fa-calendar fa-sm ms-2"></span> <{$data.time}></small>
 									<{/if}>
 								</div>


### PR DESCRIPTION
Follow-up to #165, which fixed the same class of unguarded reads in the base `system_search.tpl`. This is the theme override's share of that work.

The show-all block reads `$data.uname`, `$data.time` and the previous/next pagination links without checking that they were assigned. `search.php` assigns `uname` and `time` only when the module's row supplied them, and the pagination links only when another page exists, so an ordinary single-page result list reaches Smarty's compiled `tpl_vars` access with nothing there and warns on every render.

Uses `!empty()` for all four. The results block above them and the card footer further down the same file already do exactly this, so the file was inconsistent with itself.

The `nomatch` guard on line 60 is **not** touched. It is the correct guard this override kept while the base template lost it in 97d9d6a3, and it is why sites running xswatch5 never saw the empty show-all page that #161 reports.

No behaviour change on a page that already had all four values; four fewer warnings on the ones that do not.

## Summary by Sourcery

Bug Fixes:
- Prevent warnings on xswatch5 search result pages when uname, time, or previous/next pagination links are not provided.