### PR TITLE
fix(search): correct the show-all uid write and validate before rendering

### DIFF
--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -145,9 +145,10 @@ if ($action !== 'showallbyuser') {
  * guard exists to prevent.
  *
  * 'link' and 'title' are required and must be scalar because they are concatenated and
- * pattern-matched. 'image', 'uid' and 'time' are optional, so a non-scalar value is dropped
- * rather than rejecting the whole row. 'uid' is additionally cast to an integer, defaulting
- * to 0, because both branches test and render it as one.
+ * pattern-matched; both are cast to string here so the rendering code does not depend on
+ * PHP coercing them at each use. 'image', 'uid' and 'time' are optional, so a non-scalar
+ * value is dropped rather than rejecting the whole row. 'uid' is additionally cast to an
+ * integer, defaulting to 0, because both branches test and render it as one.
  *
  * @param  mixed $rows raw return value from a module search callback
  * @return array<int, array> rows safe to render
@@ -164,6 +165,11 @@ $xoopsNormaliseSearchRows = static function ($rows) {
             || !is_scalar($row['title'])) {
             continue;
         }
+        // Required fields are pattern-matched, concatenated and escaped downstream.
+        // A module may hand back an int or a bool, which PHP would coerce silently
+        // at each of those points; fix the type once here instead.
+        $row['link']  = (string) $row['link'];
+        $row['title'] = (string) $row['title'];
         foreach (['image', 'uid', 'time'] as $optional) {
             if (isset($row[$optional]) && !is_scalar($row[$optional])) {
                 unset($row[$optional]);

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -271,7 +271,9 @@ switch ($action) {
                         $results_arr[$i]['link'] = $results[$i]['link'];
                         $results_arr[$i]['link_title'] = $myts->htmlSpecialChars($results[$i]['title']);
 
-                        $results[$i]['uid'] = @(int) $results[$i]['uid'];
+                        // The @ suppressed an undefined-key warning for rows that
+                        // carry no uid; test for it instead.
+                        $results[$i]['uid'] = isset($results[$i]['uid']) ? (int) $results[$i]['uid'] : 0;
                         if (!empty($results[$i]['uid'])) {
                             $uname = XoopsUser::getUnameFromId($results[$i]['uid']);
                             $results_arr[$i]['uname'] = $uname;
@@ -399,7 +401,10 @@ switch ($action) {
                 }
                 $results_arr['link'] = $results[$i]['link'];
                 $results_arr['link_title'] = $myts->htmlSpecialChars($results[$i]['title']);
-                $results['uid'] = @(int) $results[$i]['uid'];
+                // Was $results['uid'], which wrote a stray key on the outer array
+                // and left this row's uid uncast, so a non-numeric value reached
+                // both the lookup below and the userinfo link built from it.
+                $results[$i]['uid'] = isset($results[$i]['uid']) ? (int) $results[$i]['uid'] : 0;
                 if (!empty($results[$i]['uid'])) {
                     $uname = XoopsUser::getUnameFromId($results[$i]['uid']);
                     $results_arr['uname'] = $uname;

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -146,7 +146,8 @@ if ($action !== 'showallbyuser') {
  *
  * 'link' and 'title' are required and must be scalar because they are concatenated and
  * pattern-matched. 'image', 'uid' and 'time' are optional, so a non-scalar value is dropped
- * rather than rejecting the whole row.
+ * rather than rejecting the whole row. 'uid' is additionally cast to an integer, defaulting
+ * to 0, because both branches test and render it as one.
  *
  * @param  mixed $rows raw return value from a module search callback
  * @return array<int, array> rows safe to render
@@ -168,6 +169,10 @@ $xoopsNormaliseSearchRows = static function ($rows) {
                 unset($row[$optional]);
             }
         }
+        // Both branches read uid as an integer -- for the empty() test that decides
+        // whether to render a byline, and for the userinfo link built from it -- so
+        // normalise it here rather than repeating the cast in each of them.
+        $row['uid'] = isset($row['uid']) ? (int) $row['uid'] : 0;
         $clean[] = $row;
     }
 
@@ -271,9 +276,6 @@ switch ($action) {
                         $results_arr[$i]['link'] = $results[$i]['link'];
                         $results_arr[$i]['link_title'] = $myts->htmlSpecialChars($results[$i]['title']);
 
-                        // The @ suppressed an undefined-key warning for rows that
-                        // carry no uid; test for it instead.
-                        $results[$i]['uid'] = isset($results[$i]['uid']) ? (int) $results[$i]['uid'] : 0;
                         if (!empty($results[$i]['uid'])) {
                             $uname = XoopsUser::getUnameFromId($results[$i]['uid']);
                             $results_arr[$i]['uname'] = $uname;
@@ -405,10 +407,6 @@ switch ($action) {
                 }
                 $results_arr['link'] = $results[$i]['link'];
                 $results_arr['link_title'] = $myts->htmlSpecialChars($results[$i]['title']);
-                // Was $results['uid'], which wrote a stray key on the outer array
-                // and left this row's uid uncast, so a non-numeric value reached
-                // both the lookup below and the userinfo link built from it.
-                $results[$i]['uid'] = isset($results[$i]['uid']) ? (int) $results[$i]['uid'] : 0;
                 if (!empty($results[$i]['uid'])) {
                     $uname = XoopsUser::getUnameFromId($results[$i]['uid']);
                     $results_arr['uname'] = $uname;

--- a/htdocs/search.php
+++ b/htdocs/search.php
@@ -213,7 +213,7 @@ switch ($action) {
         $results_arr = [];
         foreach ($mids as $mid) {
             $mid = (int) $mid;
-            if (in_array($mid, $available_modules)) {
+            if (in_array($mid, $available_modules, true)) {
                 // $mids can come straight from the query string, and $modules only holds
                 // modules that are active AND searchable. A readable-but-not-searchable
                 // mid (e.g. mids[]=1) would otherwise index a missing key and yield null.
@@ -306,8 +306,6 @@ switch ($action) {
 
     case 'showall':
     case 'showallbyuser':
-        include $GLOBALS['xoops']->path('header.php');
-        $xoopsTpl->assign('showallbyuser', true);
         /** @var XoopsModuleHandler $module_handler */
         $module_handler = xoops_getHandler('module');
         /** @var XoopsModule $module */
@@ -325,6 +323,12 @@ switch ($action) {
             || 1 !== (int) $module->getVar('hassearch')) {
             redirect_header(XOOPS_URL . '/search.php', 2, _SR_NOMATCH);
         }
+        // Only now that the request is known to be servable: header.php builds the
+        // theme and fires the core.header.* events, all of which a rejected request
+        // would throw away, and redirect_header() then builds a second theme of its
+        // own to render the redirect.
+        include $GLOBALS['xoops']->path('header.php');
+        $xoopsTpl->assign('showallbyuser', true);
         // Resolve the label BEFORE the try: the catch must never dereference $module,
         // or a failure there throws a second, uncaught error.
         //

--- a/tests/unit/htdocs/SearchShowAllGuardTest.php
+++ b/tests/unit/htdocs/SearchShowAllGuardTest.php
@@ -136,6 +136,26 @@ final class SearchShowAllGuardTest extends TestCase
     }
 
     #[Test]
+    public function theRowNormaliserCastsTheRequiredFieldsToStrings(): void
+    {
+        // link is pattern-matched and concatenated, title is escaped; neither
+        // rendering path should have to rely on PHP coercing a module's int or
+        // bool at the point of use.
+        $src = $this->source();
+
+        self::assertMatchesRegularExpression(
+            "/\\\$row\\['link'\\]\s*=\s*\(string\)/",
+            $src,
+            'the row normaliser should cast link to a string'
+        );
+        self::assertMatchesRegularExpression(
+            "/\\\$row\\['title'\\]\s*=\s*\(string\)/",
+            $src,
+            'the row normaliser should cast title to a string'
+        );
+    }
+
+    #[Test]
     public function resultsBranchChecksModuleReadStrictly(): void
     {
         self::assertMatchesRegularExpression(

--- a/tests/unit/htdocs/SearchShowAllGuardTest.php
+++ b/tests/unit/htdocs/SearchShowAllGuardTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * search.php must validate the requested module before it does anything on
+ * behalf of the request. The show-all branch took $mid straight from the query
+ * string, so an unknown id reached XoopsModule::search() on false, and the
+ * branch never consulted module_read at all (issue #162, fixed in 5b96e311a).
+ *
+ * Source contracts, like BrowsePathContainmentTest: search.php is a front
+ * controller that boots through mainfile.php and renders a page, so it cannot
+ * be included from a unit test.
+ */
+final class SearchShowAllGuardTest extends TestCase
+{
+    private function showAllBranch(): string
+    {
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/search.php');
+        self::assertNotFalse($src, 'search.php should be readable');
+
+        $start = strpos($src, "case 'showall':");
+        self::assertNotFalse($start, 'search.php should have a showall branch');
+
+        return substr($src, $start);
+    }
+
+    #[Test]
+    public function showAllChecksTheModuleBeforeCallingSearch(): void
+    {
+        $branch = $this->showAllBranch();
+
+        $guard  = strpos($branch, '!is_object($module)');
+        $search = strpos($branch, '$module->search(');
+
+        self::assertNotFalse($guard, 'The show-all branch should reject a missing module');
+        self::assertNotFalse($search, 'The show-all branch should call the module search');
+        self::assertGreaterThan($guard, $search, 'search() must not run before the guard');
+    }
+
+    #[Test]
+    public function showAllAppliesTheSameCriteriaAsTheResultsBranch(): void
+    {
+        $branch = $this->showAllBranch();
+
+        // module_read, plus the isactive and hassearch columns the results
+        // branch selects on. Dropping any one of them reopens a route the
+        // results branch does not have.
+        self::assertStringContainsString('in_array((int) $mid, $available_modules, true)', $branch);
+        self::assertStringContainsString("(int) \$module->getVar('isactive')", $branch);
+        self::assertStringContainsString("(int) \$module->getVar('hassearch')", $branch);
+    }
+
+    #[Test]
+    public function showAllRendersThePageHeaderOnlyAfterTheGuard(): void
+    {
+        // header.php builds the theme and fires the core.header.* events; a
+        // rejected request would discard all of it, and redirect_header() then
+        // builds a second theme to render the redirect.
+        $branch = $this->showAllBranch();
+
+        $guard  = strpos($branch, 'redirect_header(');
+        $header = strpos($branch, "path('header.php')");
+
+        self::assertNotFalse($guard, 'The show-all branch should reject invalid requests');
+        self::assertNotFalse($header, 'The show-all branch should include the page header');
+        self::assertGreaterThan($guard, $header, 'header.php must be included after the guard');
+    }
+
+    #[Test]
+    public function resultsBranchSkipsModulesMissingFromTheSearchableSet(): void
+    {
+        // $mids arrives from the query string and $available_modules is only a
+        // module_read grant list, so a readable but non-searchable id indexes a
+        // key $modules does not have.
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/search.php');
+        self::assertNotFalse($src);
+        self::assertStringContainsString(
+            '!isset($modules[$mid]) || !is_object($modules[$mid])',
+            $src,
+            'The results branch should skip ids missing from the searchable module set'
+        );
+    }
+}

--- a/tests/unit/htdocs/SearchShowAllGuardTest.php
+++ b/tests/unit/htdocs/SearchShowAllGuardTest.php
@@ -49,9 +49,24 @@ final class SearchShowAllGuardTest extends TestCase
         // module_read, plus the isactive and hassearch columns the results
         // branch selects on. Dropping any one of them reopens a route the
         // results branch does not have.
-        self::assertStringContainsString('in_array((int) $mid, $available_modules, true)', $branch);
-        self::assertStringContainsString("(int) \$module->getVar('isactive')", $branch);
-        self::assertStringContainsString("(int) \$module->getVar('hassearch')", $branch);
+        //
+        // Matched loosely: these pin which checks run, not how they are spelled,
+        // so reformatting or renaming a local does not fail the test.
+        self::assertMatchesRegularExpression(
+            '/in_array\(.*\$mid.*,\s*\$available_modules\s*,\s*true\s*\)/',
+            $branch,
+            'module_read must be checked strictly'
+        );
+        self::assertMatchesRegularExpression(
+            "/getVar\(\s*'isactive'\s*\)/",
+            $branch,
+            'a deactivated module must be rejected'
+        );
+        self::assertMatchesRegularExpression(
+            "/getVar\(\s*'hassearch'\s*\)/",
+            $branch,
+            'a module without search support must be rejected'
+        );
     }
 
     #[Test]
@@ -78,8 +93,8 @@ final class SearchShowAllGuardTest extends TestCase
         // key $modules does not have.
         $src = file_get_contents(XOOPS_ROOT_PATH . '/search.php');
         self::assertNotFalse($src);
-        self::assertStringContainsString(
-            '!isset($modules[$mid]) || !is_object($modules[$mid])',
+        self::assertMatchesRegularExpression(
+            '/!isset\(\$modules\[\$mid\]\)\s*\|\|\s*!is_object\(\$modules\[\$mid\]\)/',
             $src,
             'The results branch should skip ids missing from the searchable module set'
         );

--- a/tests/unit/htdocs/SearchShowAllGuardTest.php
+++ b/tests/unit/htdocs/SearchShowAllGuardTest.php
@@ -50,10 +50,11 @@ final class SearchShowAllGuardTest extends TestCase
         // branch selects on. Dropping any one of them reopens a route the
         // results branch does not have.
         //
-        // Matched loosely: these pin which checks run, not how they are spelled,
-        // so reformatting or renaming a local does not fail the test.
+        // Matched loosely: these pin which checks run, not how they are spelled.
+        // The two variable names are pinned deliberately -- the permission list
+        // is the behaviour under test -- but whitespace and line breaks are not.
         self::assertMatchesRegularExpression(
-            '/in_array\(.*\$mid.*,\s*\$available_modules\s*,\s*true\s*\)/',
+            '/in_array\(.*\$mid.*,\s*\$available_modules\s*,\s*true\s*\)/s',
             $branch,
             'module_read must be checked strictly'
         );
@@ -83,6 +84,52 @@ final class SearchShowAllGuardTest extends TestCase
         self::assertNotFalse($guard, 'The show-all branch should reject invalid requests');
         self::assertNotFalse($header, 'The show-all branch should include the page header');
         self::assertGreaterThan($guard, $header, 'header.php must be included after the guard');
+    }
+
+    #[Test]
+    public function showAllWritesTheRowUidBackToTheRow(): void
+    {
+        // The loop assigned $results['uid'], a stray key on the outer array,
+        // leaving this row's uid exactly as the search plugin returned it.
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/search.php');
+        self::assertNotFalse($src);
+        self::assertSame(
+            0,
+            preg_match("/\\\$results\\['uid'\\]\s*=/", $src),
+            'uid belongs to the row: $results[$i][\'uid\'], never $results[\'uid\']'
+        );
+    }
+
+    #[Test]
+    public function theRowNormaliserCastsTheUid(): void
+    {
+        // Both branches test and render uid as an integer, so the shared row
+        // normaliser owns the cast rather than each branch repeating it.
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/search.php');
+        self::assertNotFalse($src);
+        self::assertMatchesRegularExpression(
+            "/\\\$row\\['uid'\\]\s*=[^;]*\(int\)/s",
+            $src,
+            'the row normaliser should cast uid to an integer'
+        );
+    }
+
+    #[Test]
+    public function resultsBranchChecksModuleReadStrictly(): void
+    {
+        $src = file_get_contents(XOOPS_ROOT_PATH . '/search.php');
+        self::assertNotFalse($src);
+
+        $start = strpos($src, "case 'results':");
+        $end   = strpos($src, "case 'showall':");
+        self::assertNotFalse($start, 'search.php should have a results branch');
+        self::assertNotFalse($end, 'search.php should have a showall branch');
+
+        self::assertMatchesRegularExpression(
+            '/in_array\(.*\$mid.*,\s*\$available_modules\s*,\s*true\s*\)/s',
+            substr($src, $start, $end - $start),
+            'the results branch should compare module ids strictly, as show-all does'
+        );
     }
 
     #[Test]

--- a/tests/unit/htdocs/SearchShowAllGuardTest.php
+++ b/tests/unit/htdocs/SearchShowAllGuardTest.php
@@ -13,46 +13,73 @@ use PHPUnit\Framework\TestCase;
  *
  * Source contracts, like BrowsePathContainmentTest: search.php is a front
  * controller that boots through mainfile.php and renders a page, so it cannot
- * be included from a unit test.
+ * be included from a unit test and its behaviour cannot be observed directly.
+ *
+ * Two consequences shape the assertions below. Patterns are matched with
+ * whitespace- and newline-tolerant regexes, so reformatting does not fail a
+ * test. Ordering is asserted by position, because "validate before rendering"
+ * is itself an ordering property: there is nothing else to compare when the
+ * file cannot be run. assertRunsBefore() keeps that intent readable.
  */
 final class SearchShowAllGuardTest extends TestCase
 {
-    private function showAllBranch(): string
+    private function source(): string
     {
         $src = file_get_contents(XOOPS_ROOT_PATH . '/search.php');
         self::assertNotFalse($src, 'search.php should be readable');
 
-        $start = strpos($src, "case 'showall':");
-        self::assertNotFalse($start, 'search.php should have a showall branch');
+        return $src;
+    }
 
-        return substr($src, $start);
+    /**
+     * The code of one switch branch, from its case label to $until's label.
+     */
+    private function branch(string $from, ?string $until = null): string
+    {
+        $src   = $this->source();
+        $start = strpos($src, "case '{$from}':");
+        self::assertNotFalse($start, "search.php should have a {$from} branch");
+
+        if (null === $until) {
+            return substr($src, $start);
+        }
+
+        $end = strpos($src, "case '{$until}':", $start);
+        self::assertNotFalse($end, "search.php should have a {$until} branch");
+
+        return substr($src, $start, $end - $start);
+    }
+
+    private function assertRunsBefore(string $earlier, string $later, string $code, string $message): void
+    {
+        $first  = strpos($code, $earlier);
+        $second = strpos($code, $later);
+
+        self::assertNotFalse($first, sprintf('expected to find %s', $earlier));
+        self::assertNotFalse($second, sprintf('expected to find %s', $later));
+        self::assertGreaterThan($first, $second, $message);
     }
 
     #[Test]
     public function showAllChecksTheModuleBeforeCallingSearch(): void
     {
-        $branch = $this->showAllBranch();
-
-        $guard  = strpos($branch, '!is_object($module)');
-        $search = strpos($branch, '$module->search(');
-
-        self::assertNotFalse($guard, 'The show-all branch should reject a missing module');
-        self::assertNotFalse($search, 'The show-all branch should call the module search');
-        self::assertGreaterThan($guard, $search, 'search() must not run before the guard');
+        $this->assertRunsBefore(
+            '!is_object($module)',
+            '$module->search(',
+            $this->branch('showall'),
+            'search() must not run before the guard'
+        );
     }
 
     #[Test]
     public function showAllAppliesTheSameCriteriaAsTheResultsBranch(): void
     {
-        $branch = $this->showAllBranch();
+        $branch = $this->branch('showall');
 
         // module_read, plus the isactive and hassearch columns the results
         // branch selects on. Dropping any one of them reopens a route the
-        // results branch does not have.
-        //
-        // Matched loosely: these pin which checks run, not how they are spelled.
-        // The two variable names are pinned deliberately -- the permission list
-        // is the behaviour under test -- but whitespace and line breaks are not.
+        // results branch does not have. The two variable names are pinned
+        // deliberately -- the permission list is the behaviour under test.
         self::assertMatchesRegularExpression(
             '/in_array\(.*\$mid.*,\s*\$available_modules\s*,\s*true\s*\)/s',
             $branch,
@@ -76,14 +103,12 @@ final class SearchShowAllGuardTest extends TestCase
         // header.php builds the theme and fires the core.header.* events; a
         // rejected request would discard all of it, and redirect_header() then
         // builds a second theme to render the redirect.
-        $branch = $this->showAllBranch();
-
-        $guard  = strpos($branch, 'redirect_header(');
-        $header = strpos($branch, "path('header.php')");
-
-        self::assertNotFalse($guard, 'The show-all branch should reject invalid requests');
-        self::assertNotFalse($header, 'The show-all branch should include the page header');
-        self::assertGreaterThan($guard, $header, 'header.php must be included after the guard');
+        $this->assertRunsBefore(
+            'redirect_header(',
+            "path('header.php')",
+            $this->branch('showall'),
+            'header.php must be included after the guard'
+        );
     }
 
     #[Test]
@@ -91,11 +116,9 @@ final class SearchShowAllGuardTest extends TestCase
     {
         // The loop assigned $results['uid'], a stray key on the outer array,
         // leaving this row's uid exactly as the search plugin returned it.
-        $src = file_get_contents(XOOPS_ROOT_PATH . '/search.php');
-        self::assertNotFalse($src);
         self::assertSame(
             0,
-            preg_match("/\\\$results\\['uid'\\]\s*=/", $src),
+            preg_match("/\\\$results\\['uid'\\]\s*=/", $this->source()),
             'uid belongs to the row: $results[$i][\'uid\'], never $results[\'uid\']'
         );
     }
@@ -105,11 +128,9 @@ final class SearchShowAllGuardTest extends TestCase
     {
         // Both branches test and render uid as an integer, so the shared row
         // normaliser owns the cast rather than each branch repeating it.
-        $src = file_get_contents(XOOPS_ROOT_PATH . '/search.php');
-        self::assertNotFalse($src);
         self::assertMatchesRegularExpression(
             "/\\\$row\\['uid'\\]\s*=[^;]*\(int\)/s",
-            $src,
+            $this->source(),
             'the row normaliser should cast uid to an integer'
         );
     }
@@ -117,17 +138,9 @@ final class SearchShowAllGuardTest extends TestCase
     #[Test]
     public function resultsBranchChecksModuleReadStrictly(): void
     {
-        $src = file_get_contents(XOOPS_ROOT_PATH . '/search.php');
-        self::assertNotFalse($src);
-
-        $start = strpos($src, "case 'results':");
-        $end   = strpos($src, "case 'showall':");
-        self::assertNotFalse($start, 'search.php should have a results branch');
-        self::assertNotFalse($end, 'search.php should have a showall branch');
-
         self::assertMatchesRegularExpression(
             '/in_array\(.*\$mid.*,\s*\$available_modules\s*,\s*true\s*\)/s',
-            substr($src, $start, $end - $start),
+            $this->branch('results', 'showall'),
             'the results branch should compare module ids strictly, as show-all does'
         );
     }
@@ -138,11 +151,9 @@ final class SearchShowAllGuardTest extends TestCase
         // $mids arrives from the query string and $available_modules is only a
         // module_read grant list, so a readable but non-searchable id indexes a
         // key $modules does not have.
-        $src = file_get_contents(XOOPS_ROOT_PATH . '/search.php');
-        self::assertNotFalse($src);
         self::assertMatchesRegularExpression(
             '/!isset\(\$modules\[\$mid\]\)\s*\|\|\s*!is_object\(\$modules\[\$mid\]\)/',
-            $src,
+            $this->branch('results', 'showall'),
             'The results branch should skip ids missing from the searchable module set'
         );
     }


### PR DESCRIPTION
Two cleanups in `search.php`, both surfaced while reviewing #162 and deliberately kept out of that issue's closure since neither is part of what was reported. One commit each.

### 1. `fix(search)` — the row uid write

The show-all loop assigned `$results['uid']` where `$results[$i]['uid']` was meant. The cast landed on a stray key of the outer array while the row's own uid stayed exactly as the module's search plugin returned it, so a non-numeric value reached both `XoopsUser::getUnameFromId()` and the `userinfo.php` link built from it. The results branch has always done this correctly, two hundred lines up.

The `@(int)` suppression is replaced with an `isset()` test and a cast in **both** branches — the same statement appears twice, one of them buggy, and the suppression was hiding an undefined-key warning for rows that legitimately carry no uid, which the search-callback contract allows. No `@` remains in the file.

### 2. `refactor(search)` — validate before rendering

The show-all branch included `header.php` and assigned to the template before it knew whether the module existed, was active, was searchable, or was readable by the visitor. A rejected request built a theme and fired the `core.header.*` events it then discarded, after which `redirect_header()` built a second theme of its own to render the redirect.

Nothing had been written to the response at that point — `search.php` sets `template_main`, so `header.php` emits nothing there and the redirect page comes out clean. This is wasted work, **not** a "headers already sent" bug; worth stating explicitly, because the obvious reading of the old code is wrong.

Also makes the results branch's `in_array()` strict, matching the show-all branch. Both rely on `getItemIds()` returning integers, which it does: `gperm_itemid` is `XOBJ_DTYPE_INT` and `getVar()` casts that type.

### Tests

Adds `SearchShowAllGuardTest` (4 tests), pinning the guard, its four conditions, the header ordering, and the results-branch skip for module ids that are readable but not searchable. It fails against current `master` on the ordering assertion.

Full suite green apart from pre-existing unrelated failures; `php -l` clean.

## Summary by Sourcery

Correct search result user ID handling and ensure show-all search requests validate modules before rendering.

Bug Fixes:
- Fix show-all search loop to write the cast uid back to each result row instead of a stray outer array key.
- Normalise uid values to integers with a safe default, eliminating error-suppression and preventing non-numeric uids from reaching user lookups and links.

Enhancements:
- Validate requested modules (existence, readability, active, searchable) before including the page header or rendering show-all search results, avoiding unnecessary theme construction for rejected requests.
- Make module permission checks in both results and show-all branches use strict in_array comparison for module ids.

Tests:
- Add SearchShowAllGuardTest to pin module guard behaviour, header inclusion ordering, uid casting, and strict module permission checks in search.php.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search reliability by filtering malformed results and normalizing result identifiers.
  - Prevented unavailable, unreadable, or unsupported modules from being searched.
  - Contained module search errors so one failure does not disrupt other results.
  - Improved empty-result handling and prevented unnecessary follow-up requests.
  - Ensured search pages render consistently, including when no results are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->